### PR TITLE
feat: add image scoping and per-image/global count scope to annotation contexts

### DIFF
--- a/apps/dev/src/App.tsx
+++ b/apps/dev/src/App.tsx
@@ -41,8 +41,9 @@ const CONTEXTS: AnnotationContext[] = [
   {
     id: 'ctx-1' as AnnotationContextId,
     label: 'Fracture',
+    imageIds: [createImageId('highsmith'), createImageId('duomo')],
     tools: [
-      { type: 'line', maxCount: 3 },
+      { type: 'line', maxCount: 3, countScope: 'per-image' },
       { type: 'rectangle', maxCount: 2 },
     ],
   },

--- a/apps/dev/tests/e2e/context-scoping.spec.ts
+++ b/apps/dev/tests/e2e/context-scoping.spec.ts
@@ -1,0 +1,123 @@
+import { test, expect } from '@playwright/test';
+
+// The dev app's "Fracture" context is scoped to [highsmith, duomo].
+// - Line tool: maxCount 3, countScope 'per-image'
+// - Rectangle tool: maxCount 2, countScope 'global' (default)
+
+test.describe('Context Scoping', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector('[data-testid="tool-navigate"]', { timeout: 10000 });
+  });
+
+  test('out-of-scope image disables all tools while keeping context active', async ({ page }) => {
+    // Fracture context is active by default; highsmith is the current image (in scope).
+    const lineButton = page.getByTestId('tool-line');
+    const rectButton = page.getByTestId('tool-rectangle');
+
+    await expect(lineButton).toBeEnabled();
+    await expect(rectButton).toBeEnabled();
+
+    // Navigate to 'wide', which is NOT in Fracture's imageIds.
+    await page.getByTestId('filmstrip-item-wide').click();
+    await page.waitForTimeout(300);
+
+    // Both drawing tools should be disabled — context is active but image is out of scope.
+    await expect(lineButton).toBeDisabled();
+    await expect(rectButton).toBeDisabled();
+
+    // The toolbar buttons should still be visible (context hasn't changed).
+    await expect(lineButton).toBeVisible();
+    await expect(rectButton).toBeVisible();
+
+    // Navigate back to highsmith (in scope) — tools re-enabled.
+    await page.getByTestId('filmstrip-item-highsmith').click();
+    await page.waitForTimeout(300);
+
+    await expect(lineButton).toBeEnabled();
+    await expect(rectButton).toBeEnabled();
+  });
+
+  test('out-of-scope disables tools for jpg image as well', async ({ page }) => {
+    const lineButton = page.getByTestId('tool-line');
+
+    await expect(lineButton).toBeEnabled();
+
+    // 'jpg' is also not in Fracture's imageIds.
+    await page.getByTestId('filmstrip-item-jpg').click();
+    await page.waitForTimeout(300);
+
+    await expect(lineButton).toBeDisabled();
+  });
+
+  test('per-image counting: line limit resets when switching to another scoped image', async ({
+    page,
+  }) => {
+    const canvas = page.locator('canvas.upper-canvas');
+    await canvas.waitFor({ state: 'attached', timeout: 15000 });
+    await page.waitForTimeout(1000);
+
+    const lineButton = page.getByTestId('tool-line');
+    await expect(lineButton).toContainText('Line 0/3');
+    await expect(lineButton).toBeEnabled();
+
+    await lineButton.click();
+
+    const box = await canvas.boundingBox();
+    if (!box) throw new Error('Canvas not found');
+
+    // Draw 3 lines on highsmith to hit the per-image limit.
+    for (let i = 0; i < 3; i++) {
+      const yStart = box.y + 100 + i * 60;
+      await page.mouse.move(box.x + 100, yStart);
+      await page.mouse.down();
+      await page.mouse.move(box.x + 300, yStart, { steps: 5 });
+      await page.mouse.up();
+      await page.waitForTimeout(300);
+    }
+
+    await expect(lineButton).toContainText('Line 3/3');
+    await expect(lineButton).toBeDisabled();
+
+    // Switch to duomo — also in Fracture's imageIds, but has its own per-image count.
+    await page.getByTestId('filmstrip-item-duomo').click();
+    await page.waitForTimeout(500);
+
+    // Line count should be 0/3 for duomo — separate per-image counter.
+    await expect(lineButton).toContainText('Line 0/3');
+    await expect(lineButton).toBeEnabled();
+  });
+
+  test('global counting: rectangle count persists when switching between scoped images', async ({
+    page,
+  }) => {
+    const canvas = page.locator('canvas.upper-canvas');
+    await canvas.waitFor({ state: 'attached', timeout: 15000 });
+    await page.waitForTimeout(1000);
+
+    const rectButton = page.getByTestId('tool-rectangle');
+    await expect(rectButton).toContainText('Rect 0/2');
+    await expect(rectButton).toBeEnabled();
+
+    await rectButton.click();
+
+    const box = await canvas.boundingBox();
+    if (!box) throw new Error('Canvas not found');
+
+    // Draw 1 rectangle on highsmith.
+    await page.mouse.move(box.x + 100, box.y + 100);
+    await page.mouse.down();
+    await page.mouse.move(box.x + 250, box.y + 200, { steps: 5 });
+    await page.mouse.up();
+    await page.waitForTimeout(300);
+
+    await expect(rectButton).toContainText('Rect 1/2');
+
+    // Switch to duomo — global count should carry over (not reset).
+    await page.getByTestId('filmstrip-item-duomo').click();
+    await page.waitForTimeout(500);
+
+    await expect(rectButton).toContainText('Rect 1/2');
+    await expect(rectButton).toBeEnabled();
+  });
+});

--- a/packages/osdlabel/src/core/context-scoping.ts
+++ b/packages/osdlabel/src/core/context-scoping.ts
@@ -1,0 +1,27 @@
+import type { AnnotationContext, ImageId } from './types.js';
+
+/**
+ * Returns `true` if the context applies to the given image.
+ * - `imageIds` undefined → applies to all images
+ * - `imageIds` empty `[]` → applies to no images (context effectively disabled)
+ * - `imageIds` contains `imageId` → applies
+ */
+export function isContextScopedToImage(context: AnnotationContext, imageId: ImageId): boolean {
+  if (context.imageIds === undefined) return true;
+  return context.imageIds.includes(imageId);
+}
+
+/**
+ * Returns which image IDs should be counted for constraint checking.
+ * - `'per-image'` → only count annotations on the current image
+ * - `'global'` → count across all scoped images (undefined = all images)
+ */
+export function getCountableImageIds(
+  context: AnnotationContext,
+  currentImageId: ImageId,
+  countScope: 'per-image' | 'global',
+): readonly ImageId[] | undefined {
+  if (countScope === 'per-image') return [currentImageId];
+  // 'global': if context has imageIds, count only those; otherwise undefined = all
+  return context.imageIds;
+}

--- a/packages/osdlabel/src/core/types.ts
+++ b/packages/osdlabel/src/core/types.ts
@@ -107,10 +107,14 @@ export interface ImageAnnotations {
 
 // ── Constraint System ────────────────────────────────────────────────────
 
+/** Count scope for tool constraints */
+export type CountScope = 'per-image' | 'global';
+
 /** Tool constraint within an annotation context */
 export interface ToolConstraint {
   readonly type: AnnotationType;
   readonly maxCount?: number | undefined;
+  readonly countScope?: CountScope | undefined;
   readonly defaultStyle?: Partial<AnnotationStyle> | undefined;
 }
 
@@ -119,6 +123,7 @@ export interface AnnotationContext {
   readonly id: AnnotationContextId;
   readonly label: string;
   readonly tools: readonly ToolConstraint[];
+  readonly imageIds?: readonly ImageId[] | undefined;
   readonly metadata?: Readonly<Record<string, unknown>> | undefined;
 }
 

--- a/packages/osdlabel/src/index.ts
+++ b/packages/osdlabel/src/index.ts
@@ -24,6 +24,10 @@ export type {
 // ID factory functions
 export { createAnnotationId, createImageId, createAnnotationContextId } from './core/types.js';
 
+// Context scoping
+export { isContextScopedToImage } from './core/context-scoping.js';
+export type { CountScope } from './core/types.js';
+
 // Constants
 export { DEFAULT_ANNOTATION_STYLE, DEFAULT_GRID_CONFIG, MAX_GRID_SIZE } from './core/constants.js';
 

--- a/packages/osdlabel/src/state/actions.ts
+++ b/packages/osdlabel/src/state/actions.ts
@@ -10,13 +10,21 @@ import {
   AnnotationContextId,
   ContextState,
 } from '../core/types.js';
+import { isContextScopedToImage } from '../core/context-scoping.js';
 
 export function createActions(
   setAnnotationState: SetStoreFunction<AnnotationState>,
   setUIState: SetStoreFunction<UIState>,
   setContextState: SetStoreFunction<ContextState>,
+  contextState: ContextState,
 ) {
   function addAnnotation(annotation: Omit<Annotation, 'createdAt' | 'updatedAt'>): void {
+    const ctx = contextState.contexts.find((c) => c.id === annotation.contextId);
+    if (ctx && !isContextScopedToImage(ctx, annotation.imageId)) {
+      console.warn(`Context "${ctx.label}" not scoped to image "${annotation.imageId}"`);
+      return;
+    }
+
     setAnnotationState(
       produce((state) => {
         const imageAnns = state.byImage[annotation.imageId] ?? {};

--- a/packages/osdlabel/src/state/annotator-context.tsx
+++ b/packages/osdlabel/src/state/annotator-context.tsx
@@ -60,8 +60,9 @@ export function AnnotatorProvider(props: AnnotatorProviderProps) {
   const { state: uiState, setState: setUIState } = createUIStore();
   const { state: contextState, setState: setContextState } = createContextStore();
 
-  const actions = createActions(setAnnotationState, setUIState, setContextState);
-  const constraintStatus = createConstraintStatus(contextState, annotationState);
+  const actions = createActions(setAnnotationState, setUIState, setContextState, contextState);
+  const currentImageId = () => uiState.gridAssignments[uiState.activeCellIndex];
+  const constraintStatus = createConstraintStatus(contextState, annotationState, currentImageId);
 
   const activeToolKeyHandlerRef: ActiveToolKeyHandlerRef = { handler: null };
   const mergedShortcuts = { ...DEFAULT_KEYBOARD_SHORTCUTS, ...props.keyboardShortcuts };

--- a/packages/osdlabel/src/state/context-store.ts
+++ b/packages/osdlabel/src/state/context-store.ts
@@ -6,7 +6,9 @@ import {
   AnnotationState,
   ConstraintStatus,
   AnnotationType,
+  ImageId,
 } from '../core/types.js';
+import { isContextScopedToImage, getCountableImageIds } from '../core/context-scoping.js';
 
 export function createContextStore() {
   const [state, setState] = createStore<ContextState>({
@@ -19,14 +21,16 @@ export function createContextStore() {
 export function createConstraintStatus(
   contextState: ContextState,
   annotationState: AnnotationState,
+  currentImageId: () => ImageId | undefined,
 ) {
   return createMemo<ConstraintStatus>(() => {
     const activeContext = contextState.contexts.find((c) => c.id === contextState.activeContextId);
+    const imgId = currentImageId();
 
     const allTypes: AnnotationType[] = ['rectangle', 'circle', 'line', 'point', 'path'];
     const result: Partial<ConstraintStatus> = {};
 
-    if (!activeContext) {
+    if (!activeContext || !imgId || !isContextScopedToImage(activeContext, imgId)) {
       for (const type of allTypes) {
         result[type] = { enabled: false, currentCount: 0, maxCount: null };
       }
@@ -38,10 +42,12 @@ export function createConstraintStatus(
       if (!toolConstraint) {
         result[type] = { enabled: false, currentCount: 0, maxCount: null };
       } else {
+        const countScope = toolConstraint.countScope ?? 'global';
         const currentCount = countAnnotationsForContextAndType(
           annotationState,
           activeContext.id,
           type,
+          getCountableImageIds(activeContext, imgId, countScope),
         );
         const maxCount = toolConstraint.maxCount ?? null;
         const enabled = maxCount === null || currentCount < maxCount;
@@ -61,9 +67,14 @@ function countAnnotationsForContextAndType(
   annotationState: AnnotationState,
   contextId: AnnotationContextId,
   type: AnnotationType,
+  scopedImageIds?: readonly ImageId[] | undefined,
 ): number {
   let count = 0;
-  for (const imageAnns of Object.values(annotationState.byImage)) {
+  const imageBuckets = scopedImageIds
+    ? scopedImageIds.map((id) => annotationState.byImage[id])
+    : Object.values(annotationState.byImage);
+
+  for (const imageAnns of imageBuckets) {
     if (!imageAnns) continue;
     for (const ann of Object.values(imageAnns)) {
       if (ann.contextId === contextId && ann.geometry.type === type) {
@@ -71,5 +82,6 @@ function countAnnotationsForContextAndType(
       }
     }
   }
+
   return count;
 }

--- a/packages/osdlabel/tests/unit/benchmark.test.ts
+++ b/packages/osdlabel/tests/unit/benchmark.test.ts
@@ -20,8 +20,8 @@ describe('version counter', () => {
     return createRoot((dispose) => {
       const { state: annotationState, setState: setAnnotationState } = createAnnotationStore();
       const { setState: setUIState } = createUIStore();
-      const { setState: setContextState } = createContextStore();
-      const actions = createActions(setAnnotationState, setUIState, setContextState);
+      const { state: contextState, setState: setContextState } = createContextStore();
+      const actions = createActions(setAnnotationState, setUIState, setContextState, contextState);
       return { annotationState, actions, dispose };
     });
   }

--- a/packages/osdlabel/tests/unit/constraints/enforcement.test.ts
+++ b/packages/osdlabel/tests/unit/constraints/enforcement.test.ts
@@ -10,17 +10,21 @@ import {
   createImageId,
   createAnnotationContextId,
   AnnotationContext,
+  ImageId,
 } from '../../../src/core/types';
 
 describe('Constraint Enforcement', () => {
-  function createTestStore() {
+  function createTestStore(initialImageId: ImageId = imageId) {
     return createRoot((dispose) => {
       const { state: annotationState, setState: setAnnotationState } = createAnnotationStore();
       const { state: uiState, setState: setUIState } = createUIStore();
       const { state: contextState, setState: setContextState } = createContextStore();
 
-      const actions = createActions(setAnnotationState, setUIState, setContextState);
-      const constraintStatus = createConstraintStatus(contextState, annotationState);
+      const actions = createActions(setAnnotationState, setUIState, setContextState, contextState);
+      // Assign image to cell 0 so constraint status has a currentImageId
+      setUIState('gridAssignments', 0, initialImageId);
+      const currentImageId = () => uiState.gridAssignments[uiState.activeCellIndex];
+      const constraintStatus = createConstraintStatus(contextState, annotationState, currentImageId);
 
       return { annotationState, uiState, contextState, actions, constraintStatus, dispose };
     });
@@ -261,6 +265,206 @@ describe('Constraint Enforcement', () => {
     });
 
     expect(canAddLine()).toBe(false);
+
+    dispose();
+  });
+
+  // ── Context Scoping Tests ──────────────────────────────────────────────
+
+  const imageId2 = createImageId('img2');
+  const imageId3 = createImageId('img3');
+
+  it('should disable all tools when context is not scoped to current image', () => {
+    const { actions, constraintStatus, dispose } = createTestStore();
+
+    const scopedContext: AnnotationContext = {
+      id: contextId1,
+      label: 'Scoped Context',
+      imageIds: [imageId2], // only img2, not img1
+      tools: [{ type: 'rectangle' }, { type: 'circle' }],
+    };
+
+    actions.setContexts([scopedContext]);
+    actions.setActiveContext(contextId1);
+
+    const status = constraintStatus();
+    expect(status.rectangle.enabled).toBe(false);
+    expect(status.circle.enabled).toBe(false);
+
+    dispose();
+  });
+
+  it('should enable tools when context is scoped to current image', () => {
+    const { actions, constraintStatus, dispose } = createTestStore();
+
+    const scopedContext: AnnotationContext = {
+      id: contextId1,
+      label: 'Scoped Context',
+      imageIds: [imageId, imageId2],
+      tools: [{ type: 'rectangle' }, { type: 'circle' }],
+    };
+
+    actions.setContexts([scopedContext]);
+    actions.setActiveContext(contextId1);
+
+    const status = constraintStatus();
+    expect(status.rectangle.enabled).toBe(true);
+    expect(status.circle.enabled).toBe(true);
+
+    dispose();
+  });
+
+  it('should disable all tools when imageIds is empty array', () => {
+    const { actions, constraintStatus, dispose } = createTestStore();
+
+    const emptyContext: AnnotationContext = {
+      id: contextId1,
+      label: 'Empty Scope',
+      imageIds: [],
+      tools: [{ type: 'rectangle' }],
+    };
+
+    actions.setContexts([emptyContext]);
+    actions.setActiveContext(contextId1);
+
+    const status = constraintStatus();
+    expect(status.rectangle.enabled).toBe(false);
+
+    dispose();
+  });
+
+  it('should behave as before when imageIds is undefined (all images)', () => {
+    const { actions, constraintStatus, dispose } = createTestStore();
+
+    // context1 has no imageIds — backward compatible
+    actions.setContexts([context1]);
+    actions.setActiveContext(contextId1);
+
+    const status = constraintStatus();
+    expect(status.rectangle.enabled).toBe(true);
+    expect(status.circle.enabled).toBe(true);
+
+    dispose();
+  });
+
+  it('should count per-image when countScope is per-image', () => {
+    const { actions, constraintStatus, dispose } = createTestStore();
+
+    const perImageContext: AnnotationContext = {
+      id: contextId1,
+      label: 'Per-Image',
+      tools: [{ type: 'rectangle', maxCount: 1, countScope: 'per-image' }],
+    };
+
+    actions.setContexts([perImageContext]);
+    actions.setActiveContext(contextId1);
+
+    // Add rectangle on img1 (current image)
+    actions.addAnnotation({
+      id: createAnnotationId('r1'),
+      imageId,
+      contextId: contextId1,
+      geometry: { type: 'rectangle', origin: { x: 0, y: 0 }, width: 10, height: 10, rotation: 0 },
+      rawAnnotationData: baseRawData,
+    });
+
+    let status = constraintStatus();
+    expect(status.rectangle.currentCount).toBe(1);
+    expect(status.rectangle.enabled).toBe(false); // maxCount 1 reached on current image
+
+    // Add rectangle on img2 (different image) — should not affect img1's count
+    actions.addAnnotation({
+      id: createAnnotationId('r2'),
+      imageId: imageId2,
+      contextId: contextId1,
+      geometry: { type: 'rectangle', origin: { x: 0, y: 0 }, width: 10, height: 10, rotation: 0 },
+      rawAnnotationData: baseRawData,
+    });
+
+    // Still on img1 — count should still be 1 (per-image)
+    status = constraintStatus();
+    expect(status.rectangle.currentCount).toBe(1);
+    expect(status.rectangle.enabled).toBe(false);
+
+    dispose();
+  });
+
+  it('should count globally across scoped images when countScope is global with imageIds', () => {
+    const { actions, constraintStatus, dispose } = createTestStore();
+
+    const globalScopedContext: AnnotationContext = {
+      id: contextId1,
+      label: 'Global Scoped',
+      imageIds: [imageId, imageId2],
+      tools: [{ type: 'rectangle', maxCount: 2, countScope: 'global' }],
+    };
+
+    actions.setContexts([globalScopedContext]);
+    actions.setActiveContext(contextId1);
+
+    // Add rectangle on img1
+    actions.addAnnotation({
+      id: createAnnotationId('r1'),
+      imageId,
+      contextId: contextId1,
+      geometry: { type: 'rectangle', origin: { x: 0, y: 0 }, width: 10, height: 10, rotation: 0 },
+      rawAnnotationData: baseRawData,
+    });
+
+    // Add rectangle on img2
+    actions.addAnnotation({
+      id: createAnnotationId('r2'),
+      imageId: imageId2,
+      contextId: contextId1,
+      geometry: { type: 'rectangle', origin: { x: 0, y: 0 }, width: 10, height: 10, rotation: 0 },
+      rawAnnotationData: baseRawData,
+    });
+
+    // Global count should be 2 (across scoped images)
+    const status = constraintStatus();
+    expect(status.rectangle.currentCount).toBe(2);
+    expect(status.rectangle.enabled).toBe(false);
+
+    // Add rectangle on img3 (out of scope) — should not be counted
+    actions.addAnnotation({
+      id: createAnnotationId('r3'),
+      imageId: imageId3,
+      contextId: contextId1,
+      geometry: { type: 'rectangle', origin: { x: 0, y: 0 }, width: 10, height: 10, rotation: 0 },
+      rawAnnotationData: baseRawData,
+    });
+
+    // Count should still be 2 (img3 not in scoped images)
+    const status2 = constraintStatus();
+    expect(status2.rectangle.currentCount).toBe(2);
+
+    dispose();
+  });
+
+  it('should block addAnnotation on out-of-scope image', () => {
+    const { actions, annotationState, dispose } = createTestStore();
+
+    const scopedContext: AnnotationContext = {
+      id: contextId1,
+      label: 'Scoped',
+      imageIds: [imageId], // only img1
+      tools: [{ type: 'rectangle' }],
+    };
+
+    actions.setContexts([scopedContext]);
+    actions.setActiveContext(contextId1);
+
+    // Try to add annotation on img2 (out of scope)
+    actions.addAnnotation({
+      id: createAnnotationId('r1'),
+      imageId: imageId2,
+      contextId: contextId1,
+      geometry: { type: 'rectangle', origin: { x: 0, y: 0 }, width: 10, height: 10, rotation: 0 },
+      rawAnnotationData: baseRawData,
+    });
+
+    // Annotation should not have been added
+    expect(annotationState.byImage[imageId2]).toBeUndefined();
 
     dispose();
   });

--- a/packages/osdlabel/tests/unit/core/context-scoping.test.ts
+++ b/packages/osdlabel/tests/unit/core/context-scoping.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { isContextScopedToImage, getCountableImageIds } from '../../../src/core/context-scoping';
+import {
+  createAnnotationContextId,
+  createImageId,
+  AnnotationContext,
+} from '../../../src/core/types';
+
+describe('isContextScopedToImage', () => {
+  const imgA = createImageId('imgA');
+  const imgB = createImageId('imgB');
+  const imgC = createImageId('imgC');
+  const ctxId = createAnnotationContextId('ctx1');
+
+  const baseContext: AnnotationContext = {
+    id: ctxId,
+    label: 'Test',
+    tools: [{ type: 'rectangle' }],
+  };
+
+  it('returns true when imageIds is undefined (applies to all images)', () => {
+    expect(isContextScopedToImage(baseContext, imgA)).toBe(true);
+    expect(isContextScopedToImage(baseContext, imgB)).toBe(true);
+  });
+
+  it('returns false when imageIds is empty array (no images)', () => {
+    const ctx: AnnotationContext = { ...baseContext, imageIds: [] };
+    expect(isContextScopedToImage(ctx, imgA)).toBe(false);
+  });
+
+  it('returns true when imageIds includes the image', () => {
+    const ctx: AnnotationContext = { ...baseContext, imageIds: [imgA, imgB] };
+    expect(isContextScopedToImage(ctx, imgA)).toBe(true);
+    expect(isContextScopedToImage(ctx, imgB)).toBe(true);
+  });
+
+  it('returns false when imageIds does not include the image', () => {
+    const ctx: AnnotationContext = { ...baseContext, imageIds: [imgA, imgB] };
+    expect(isContextScopedToImage(ctx, imgC)).toBe(false);
+  });
+});
+
+describe('getCountableImageIds', () => {
+  const imgA = createImageId('imgA');
+  const imgB = createImageId('imgB');
+  const ctxId = createAnnotationContextId('ctx1');
+
+  const baseContext: AnnotationContext = {
+    id: ctxId,
+    label: 'Test',
+    tools: [{ type: 'rectangle' }],
+  };
+
+  it('returns [currentImageId] for per-image scope', () => {
+    const result = getCountableImageIds(baseContext, imgA, 'per-image');
+    expect(result).toEqual([imgA]);
+  });
+
+  it('returns undefined for global scope when no imageIds set', () => {
+    const result = getCountableImageIds(baseContext, imgA, 'global');
+    expect(result).toBeUndefined();
+  });
+
+  it('returns context imageIds for global scope when imageIds is set', () => {
+    const ctx: AnnotationContext = { ...baseContext, imageIds: [imgA, imgB] };
+    const result = getCountableImageIds(ctx, imgA, 'global');
+    expect(result).toEqual([imgA, imgB]);
+  });
+});

--- a/packages/osdlabel/tests/unit/state/actions.test.ts
+++ b/packages/osdlabel/tests/unit/state/actions.test.ts
@@ -12,6 +12,7 @@ import {
   Annotation,
   AnnotationContext,
   AnnotationContextId,
+  ImageId,
 } from '../../../src/core/types';
 
 describe('State Management', () => {
@@ -21,8 +22,11 @@ describe('State Management', () => {
       const { state: uiState, setState: setUIState } = createUIStore();
       const { state: contextState, setState: setContextState } = createContextStore();
 
-      const actions = createActions(setAnnotationState, setUIState, setContextState);
-      const constraintStatus = createConstraintStatus(contextState, annotationState);
+      const actions = createActions(setAnnotationState, setUIState, setContextState, contextState);
+      // Assign image to cell 0 so constraint status has a currentImageId
+      setUIState('gridAssignments', 0, dummyImageId);
+      const currentImageId = () => uiState.gridAssignments[uiState.activeCellIndex];
+      const constraintStatus = createConstraintStatus(contextState, annotationState, currentImageId);
 
       return { annotationState, uiState, contextState, actions, constraintStatus, dispose };
     });


### PR DESCRIPTION

- Add `imageIds` to `AnnotationContext` to restrict a context to specific images (undefined = all images, backward compatible)
- Add `countScope` to `ToolConstraint` to make `maxCount` apply per-image or globally (default: 'global')
- Add `CountScope` type and `isContextScopedToImage` helper (exported from index)
- Disable all tools when the active image is out of scope for the active context
- Add defense-in-depth guard in `addAnnotation` that blocks mutations for out-of-scope images
- Wire `currentImageId` from UI state into `createConstraintStatus` and `createActions`
- Unit tests for `context-scoping.ts` helpers and extended constraint enforcement tests
- E2E tests covering out-of-scope disabling, per-image counting, and global counting