### PR TITLE
🧪 [testing improvement] Add useKeyboard Hook Unit Tests

### DIFF
--- a/packages/osdlabel/tests/unit/hooks/useKeyboard.test.ts
+++ b/packages/osdlabel/tests/unit/hooks/useKeyboard.test.ts
@@ -1,0 +1,279 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createRoot } from 'solid-js';
+import { useKeyboard, DEFAULT_KEYBOARD_SHORTCUTS } from '../../../src/hooks/useKeyboard.js';
+
+// Mock annotator actions
+const mockActions = {
+  setActiveTool: vi.fn(),
+  setSelectedAnnotation: vi.fn(),
+  deleteAnnotation: vi.fn(),
+  setActiveCell: vi.fn(),
+  setGridDimensions: vi.fn(),
+};
+
+// Mock UI state
+const mockUiState = {
+  selectedAnnotationId: null as string | null,
+  gridAssignments: ['img-1', 'img-2', 'img-3', 'img-4', 'img-5', 'img-6', 'img-7', 'img-8', 'img-9'],
+  activeCellIndex: 0,
+  gridColumns: 1,
+  gridRows: 1,
+};
+
+// Mock context state
+const mockState = {
+  uiState: mockUiState,
+  actions: mockActions,
+};
+
+// Mock constraints
+const mockConstraints = {
+  isToolEnabled: vi.fn().mockReturnValue(true),
+};
+
+vi.mock('../../../src/state/annotator-context.js', () => ({
+  useAnnotator: () => mockState,
+}));
+
+vi.mock('../../../src/hooks/useConstraints.js', () => ({
+  useConstraints: () => mockConstraints,
+}));
+
+// Helper to simulate a keyboard event
+function dispatchKeyDown(key: string, target?: Partial<HTMLElement>) {
+  const event = new KeyboardEvent('keydown', { key });
+  if (target) {
+    Object.defineProperty(event, 'target', { value: target, enumerable: true });
+  } else {
+    Object.defineProperty(event, 'target', {
+      value: document.createElement('div'),
+      enumerable: true,
+    });
+  }
+  window.dispatchEvent(event);
+}
+
+describe('useKeyboard', () => {
+  let activeToolKeyHandlerRef: { handler: ((event: KeyboardEvent) => boolean) | null };
+  let disposeRoot: () => void;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUiState.selectedAnnotationId = null;
+    mockUiState.activeCellIndex = 0;
+    mockUiState.gridColumns = 1;
+    mockUiState.gridRows = 1;
+    mockConstraints.isToolEnabled.mockReturnValue(true);
+
+    activeToolKeyHandlerRef = { handler: null };
+
+    // Setup hook within a reactive root
+    createRoot((dispose) => {
+      disposeRoot = dispose;
+      useKeyboard(DEFAULT_KEYBOARD_SHORTCUTS, activeToolKeyHandlerRef);
+    });
+  });
+
+  afterEach(() => {
+    if (disposeRoot) {
+      disposeRoot();
+    }
+  });
+
+  it('should ignore events when target is INPUT, TEXTAREA, or contentEditable', () => {
+    dispatchKeyDown('v', { tagName: 'INPUT' });
+    dispatchKeyDown('v', { tagName: 'TEXTAREA' });
+    dispatchKeyDown('v', { isContentEditable: true } as any);
+
+    expect(mockActions.setActiveTool).not.toHaveBeenCalled();
+  });
+
+  it('should ignore events when shouldSkipTargetPredicate returns true', () => {
+    // Re-initialize with a predicate
+    disposeRoot();
+
+    const predicate = vi.fn((target: HTMLElement) => target.className === 'ignore-me');
+
+    createRoot((dispose) => {
+      disposeRoot = dispose;
+      useKeyboard(DEFAULT_KEYBOARD_SHORTCUTS, activeToolKeyHandlerRef, predicate);
+    });
+
+    dispatchKeyDown('v', { className: 'ignore-me', tagName: 'DIV' });
+    expect(predicate).toHaveBeenCalled();
+    expect(mockActions.setActiveTool).not.toHaveBeenCalled();
+
+    dispatchKeyDown('v', { className: 'process-me', tagName: 'DIV' });
+    expect(mockActions.setActiveTool).toHaveBeenCalledWith('select');
+  });
+
+  it('should pass event to activeToolKeyHandlerRef and stop if consumed', () => {
+    const handler = vi.fn().mockReturnValue(true); // consumed
+    activeToolKeyHandlerRef.handler = handler;
+
+    dispatchKeyDown('v');
+
+    expect(handler).toHaveBeenCalled();
+    expect(mockActions.setActiveTool).not.toHaveBeenCalled();
+  });
+
+  it('should process event if activeToolKeyHandlerRef returns false', () => {
+    const handler = vi.fn().mockReturnValue(false); // not consumed
+    activeToolKeyHandlerRef.handler = handler;
+
+    dispatchKeyDown('v');
+
+    expect(handler).toHaveBeenCalled();
+    expect(mockActions.setActiveTool).toHaveBeenCalledWith('select');
+  });
+
+  describe('Tool Selection Shortcuts', () => {
+    it('should set tool on matching key press if enabled', () => {
+      dispatchKeyDown(DEFAULT_KEYBOARD_SHORTCUTS.selectTool);
+      expect(mockActions.setActiveTool).toHaveBeenCalledWith('select');
+
+      dispatchKeyDown(DEFAULT_KEYBOARD_SHORTCUTS.rectangleTool);
+      expect(mockActions.setActiveTool).toHaveBeenCalledWith('rectangle');
+
+      dispatchKeyDown(DEFAULT_KEYBOARD_SHORTCUTS.circleTool);
+      expect(mockActions.setActiveTool).toHaveBeenCalledWith('circle');
+
+      dispatchKeyDown(DEFAULT_KEYBOARD_SHORTCUTS.lineTool);
+      expect(mockActions.setActiveTool).toHaveBeenCalledWith('line');
+
+      dispatchKeyDown(DEFAULT_KEYBOARD_SHORTCUTS.pointTool);
+      expect(mockActions.setActiveTool).toHaveBeenCalledWith('point');
+
+      dispatchKeyDown(DEFAULT_KEYBOARD_SHORTCUTS.pathTool);
+      expect(mockActions.setActiveTool).toHaveBeenCalledWith('path');
+    });
+
+    it('should handle uppercase tool shortcuts', () => {
+      dispatchKeyDown('V'); // Uppercase of 'v'
+      expect(mockActions.setActiveTool).toHaveBeenCalledWith('select');
+    });
+
+    it('should NOT set tool if isToolEnabled returns false', () => {
+      mockConstraints.isToolEnabled.mockImplementation((tool) => tool !== 'rectangle');
+
+      dispatchKeyDown(DEFAULT_KEYBOARD_SHORTCUTS.rectangleTool);
+      expect(mockActions.setActiveTool).not.toHaveBeenCalledWith('rectangle');
+
+      // But should allow others
+      dispatchKeyDown(DEFAULT_KEYBOARD_SHORTCUTS.circleTool);
+      expect(mockActions.setActiveTool).toHaveBeenCalledWith('circle');
+    });
+  });
+
+  describe('Cancel / Escape Shortcut', () => {
+    it('should deselect annotation if one is selected', () => {
+      mockUiState.selectedAnnotationId = 'ann-1';
+      dispatchKeyDown(DEFAULT_KEYBOARD_SHORTCUTS.cancel);
+
+      expect(mockActions.setSelectedAnnotation).toHaveBeenCalledWith(null);
+      expect(mockActions.setActiveTool).not.toHaveBeenCalled();
+    });
+
+    it('should set active tool to null if no annotation is selected', () => {
+      mockUiState.selectedAnnotationId = null;
+      dispatchKeyDown(DEFAULT_KEYBOARD_SHORTCUTS.cancel);
+
+      expect(mockActions.setActiveTool).toHaveBeenCalledWith(null);
+      expect(mockActions.setSelectedAnnotation).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Delete Shortcut', () => {
+    it('should delete selected annotation on active cell image', () => {
+      mockUiState.selectedAnnotationId = 'ann-1';
+      mockUiState.activeCellIndex = 0; // points to 'img-1'
+
+      dispatchKeyDown(DEFAULT_KEYBOARD_SHORTCUTS.delete);
+
+      expect(mockActions.deleteAnnotation).toHaveBeenCalledWith('ann-1', 'img-1');
+      expect(mockActions.setSelectedAnnotation).toHaveBeenCalledWith(null);
+    });
+
+    it('should also work with deleteAlt shortcut', () => {
+      mockUiState.selectedAnnotationId = 'ann-2';
+      mockUiState.activeCellIndex = 1; // points to 'img-2'
+
+      dispatchKeyDown(DEFAULT_KEYBOARD_SHORTCUTS.deleteAlt);
+
+      expect(mockActions.deleteAnnotation).toHaveBeenCalledWith('ann-2', 'img-2');
+      expect(mockActions.setSelectedAnnotation).toHaveBeenCalledWith(null);
+    });
+
+    it('should do nothing if no annotation is selected', () => {
+      mockUiState.selectedAnnotationId = null;
+      dispatchKeyDown(DEFAULT_KEYBOARD_SHORTCUTS.delete);
+
+      expect(mockActions.deleteAnnotation).not.toHaveBeenCalled();
+    });
+
+    it('should do nothing if active image id is missing', () => {
+      mockUiState.selectedAnnotationId = 'ann-1';
+      mockUiState.activeCellIndex = 10; // Out of bounds, undefined image
+      dispatchKeyDown(DEFAULT_KEYBOARD_SHORTCUTS.delete);
+
+      expect(mockActions.deleteAnnotation).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Grid Shortcuts', () => {
+    it('should set active cell 0-8 for keys 1-9', () => {
+      dispatchKeyDown(DEFAULT_KEYBOARD_SHORTCUTS.gridCell1);
+      expect(mockActions.setActiveCell).toHaveBeenCalledWith(0);
+
+      dispatchKeyDown(DEFAULT_KEYBOARD_SHORTCUTS.gridCell9);
+      expect(mockActions.setActiveCell).toHaveBeenCalledWith(8);
+    });
+
+    it('should increase grid columns up to maximum', () => {
+      mockUiState.gridColumns = 2;
+      mockUiState.gridRows = 2;
+
+      dispatchKeyDown(DEFAULT_KEYBOARD_SHORTCUTS.increaseGridColumns);
+
+      expect(mockActions.setGridDimensions).toHaveBeenCalledWith(3, 2);
+    });
+
+    it('should handle "=" as "+" for increasing columns', () => {
+      mockUiState.gridColumns = 2;
+      mockUiState.gridRows = 2;
+
+      // If DEFAULT_KEYBOARD_SHORTCUTS.increaseGridColumns is '=', pressing '+' also works
+      if (DEFAULT_KEYBOARD_SHORTCUTS.increaseGridColumns === '=') {
+        dispatchKeyDown('+');
+        expect(mockActions.setGridDimensions).toHaveBeenCalledWith(3, 2);
+      }
+    });
+
+    it('should decrease grid columns down to 1', () => {
+      mockUiState.gridColumns = 3;
+      mockUiState.gridRows = 2;
+
+      dispatchKeyDown(DEFAULT_KEYBOARD_SHORTCUTS.decreaseGridColumns);
+
+      expect(mockActions.setGridDimensions).toHaveBeenCalledWith(2, 2);
+    });
+
+    it('should NOT decrease grid columns below 1', () => {
+      mockUiState.gridColumns = 1;
+      mockUiState.gridRows = 2;
+
+      dispatchKeyDown(DEFAULT_KEYBOARD_SHORTCUTS.decreaseGridColumns);
+
+      expect(mockActions.setGridDimensions).not.toHaveBeenCalled();
+    });
+  });
+
+  it('should remove event listener on cleanup', () => {
+    disposeRoot();
+    vi.clearAllMocks();
+
+    // After cleanup, shortcuts should not trigger actions
+    dispatchKeyDown(DEFAULT_KEYBOARD_SHORTCUTS.selectTool);
+    expect(mockActions.setActiveTool).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
This PR addresses the testing gap for the `useKeyboard` hook by providing a dedicated Vitest unit test suite.

📊 **Coverage:** What scenarios are now tested
- Validates the addition and removal of global keydown event listeners on mount and cleanup.
- Verifies that input from elements like `INPUT`, `TEXTAREA`, or `contentEditable` skips the hook logic.
- Verifies custom target predicates correctly bypass event execution.
- Checks whether events are properly captured (or bubbled) by the active tool key handler reference.
- Ensures all tool selection shortcuts (rectangle, circle, line, point, path, select) function and respect constraint checks (`isToolEnabled`).
- Asserts that Cancel ('Escape') and Delete ('Delete' / 'Backspace') shortcuts perform state mutation logic exactly as expected for active annotations.
- Covers Grid cell selections and column dimension limits shortcuts.

✨ **Result:** The improvement in test coverage
We now have full unit test coverage of the keyboard listener lifecycle, ensuring deterministic and safe shortcut behavior. No changes to the actual hook logic were needed, verifying it operates smoothly within a Solid.js reactive container.

---
*PR created automatically by Jules for task [9685031198899601664](https://jules.google.com/task/9685031198899601664) started by @guyo13*