### PR TITLE
Add keyboard shortcuts for grid rows

### DIFF
--- a/apps/dev/tests/e2e/keyboard.spec.ts
+++ b/apps/dev/tests/e2e/keyboard.spec.ts
@@ -87,6 +87,38 @@ test.describe('Keyboard Shortcuts', () => {
     await expect(gridSize).toContainText('4x1');
     await page.keyboard.press('='); // Should stay 4
     await expect(gridSize).toContainText('4x1');
+
+    // Return to 1x1
+    await page.keyboard.press('-');
+    await page.keyboard.press('-');
+    await page.keyboard.press('-');
+    await expect(gridSize).toContainText('1x1');
+
+    // Increase rows with ']'
+    await page.keyboard.press(']');
+    await expect(gridSize).toContainText('1x2');
+
+    // Increase rows again
+    await page.keyboard.press(']');
+    await expect(gridSize).toContainText('1x3');
+
+    // Decrease rows with '['
+    await page.keyboard.press('[');
+    await expect(gridSize).toContainText('1x2');
+
+    // Check clamping at 1 row
+    await page.keyboard.press('[');
+    await expect(gridSize).toContainText('1x1');
+    await page.keyboard.press('[');
+    await expect(gridSize).toContainText('1x1');
+
+    // Check clamping at Max (4) for rows
+    await page.keyboard.press(']'); // 2
+    await page.keyboard.press(']'); // 3
+    await page.keyboard.press(']'); // 4
+    await expect(gridSize).toContainText('1x4');
+    await page.keyboard.press(']'); // Should stay 4
+    await expect(gridSize).toContainText('1x4');
   });
 
   test('Grid cell selection shortcuts (1-9)', async ({ page }) => {

--- a/apps/docs/src/components/demos/SerializationDemo.tsx
+++ b/apps/docs/src/components/demos/SerializationDemo.tsx
@@ -124,7 +124,7 @@ function SerializationDemoContent() {
                             <div style={{ width: '100%', height: '100%', position: 'relative' }}>
                               {/* I will use the actual components */}
                               <div style={{ height: '100%' }}>
-                                {/* This is getting complex to re-implement. 
+                                {/* This is getting complex to re-implement.
                                                         I'll just use the provided Annotator and a separate state if I can.
                                                         Actually, let's just show the serialize/deserialize in action. */}
                               </div>

--- a/apps/docs/src/content/docs/guides/keyboard-shortcuts.mdx
+++ b/apps/docs/src/content/docs/guides/keyboard-shortcuts.mdx
@@ -24,6 +24,8 @@ osdlabel is designed for high-throughput annotation tasks with a comprehensive s
 | `1`–`9`                | Activate grid cell by position            |
 | `=` / `+`              | Add a grid column                         |
 | `-`                    | Remove a grid column                      |
+| `]`                    | Add a grid row                            |
+| `[`                    | Remove a grid row                         |
 
 ### Path tool shortcuts
 

--- a/packages/osdlabel/src/core/types.ts
+++ b/packages/osdlabel/src/core/types.ts
@@ -202,6 +202,8 @@ export interface KeyboardShortcutMap {
   readonly gridCell9: string;
   readonly increaseGridColumns: string;
   readonly decreaseGridColumns: string;
+  readonly increaseGridRows: string;
+  readonly decreaseGridRows: string;
   readonly pathFinish: string;
   readonly pathClose: string;
   readonly pathCancel: string;

--- a/packages/osdlabel/src/hooks/useKeyboard.ts
+++ b/packages/osdlabel/src/hooks/useKeyboard.ts
@@ -25,6 +25,8 @@ export const DEFAULT_KEYBOARD_SHORTCUTS: KeyboardShortcutMap = {
   gridCell9: '9',
   increaseGridColumns: '=',
   decreaseGridColumns: '-',
+  increaseGridRows: ']',
+  decreaseGridRows: '[',
   pathFinish: 'Enter',
   pathClose: 'c',
   pathCancel: 'Escape',
@@ -113,6 +115,17 @@ export function useKeyboard(
     } else if (key === shortcuts.decreaseGridColumns) {
       if (uiState.gridColumns > 1) {
         actions.setGridDimensions(uiState.gridColumns - 1, uiState.gridRows);
+      }
+    }
+    // Grid Rows
+    else if (key === shortcuts.increaseGridRows) {
+      const maxRows = MAX_GRID_SIZE.rows;
+      if (uiState.gridRows < maxRows) {
+        actions.setGridDimensions(uiState.gridColumns, uiState.gridRows + 1);
+      }
+    } else if (key === shortcuts.decreaseGridRows) {
+      if (uiState.gridRows > 1) {
+        actions.setGridDimensions(uiState.gridColumns, uiState.gridRows - 1);
       }
     }
   };


### PR DESCRIPTION
This PR introduces two new keyboard shortcuts, `]` and `[`, to respectively add and remove a grid row in the UI.

This complements the existing shortcuts (`=` and `-`) that add and remove grid columns.

- Clamps the grid row value between 1 and the configured `MAX_GRID_SIZE.rows` (4).
- Covered by unit types and Playwright E2E tests.
- Documentation has been updated to reflect the new default bindings.

---
*PR created automatically by Jules for task [8798346480179080435](https://jules.google.com/task/8798346480179080435) started by @guyo13*