### PR TITLE
feat: add cell-level exposure and negative visual transforms

### DIFF
--- a/apps/docs/src/content/docs/guides/multi-image-grid.mdx
+++ b/apps/docs/src/content/docs/guides/multi-image-grid.mdx
@@ -63,6 +63,23 @@ actions.setActiveCell(0);
 
 The active cell is highlighted visually and receives all drawing/selection input. Other cells display annotations in read-only mode (navigation only).
 
+## Cell Image Transforms
+
+Each cell maintains its own visual transforms, such as exposure and negative image suppression, which can be controlled via state actions.
+
+```tsx
+const { actions, uiState } = useAnnotator();
+
+// Get the transform for the active cell
+const activeCellTransform = uiState.cellTransforms[uiState.activeCellIndex];
+
+// Toggle negative image effect for the active cell
+actions.toggleActiveCellNegative();
+
+// Change exposure (brightness) for the active cell
+actions.setActiveCellExposure(1.5);
+```
+
 ## Filmstrip
 
 The `Filmstrip` component shows thumbnails of all available images and allows drag-to-assign interaction:

--- a/packages/osdlabel/src/components/GridView.tsx
+++ b/packages/osdlabel/src/components/GridView.tsx
@@ -54,6 +54,7 @@ const GridView: Component<GridViewProps> = (props) => {
                 <ViewerCell
                   imageSource={imageSource()}
                   isActive={isActive()}
+                  cellIndex={cellIndex}
                   onActivate={() => actions.setActiveCell(cellIndex)}
                 />
               ) : (

--- a/packages/osdlabel/src/components/ViewControls.tsx
+++ b/packages/osdlabel/src/components/ViewControls.tsx
@@ -1,14 +1,18 @@
 import { type Component, Show } from 'solid-js';
 import { useAnnotator } from '../state/annotator-context.js';
-import { DEFAULT_VIEW_TRANSFORM } from '../core/types.js';
+import { DEFAULT_VIEW_TRANSFORM, DEFAULT_CELL_TRANSFORM } from '../core/types.js';
 
 export const ViewControls: Component = () => {
-  const { annotationState, actions, activeImageId } = useAnnotator();
+  const { uiState, annotationState, actions, activeImageId } = useAnnotator();
 
   const viewTransform = () => {
     const id = activeImageId();
     if (!id) return DEFAULT_VIEW_TRANSFORM;
     return annotationState.viewTransforms[id] ?? DEFAULT_VIEW_TRANSFORM;
+  };
+
+  const cellTransform = () => {
+    return uiState.cellTransforms[uiState.activeCellIndex] ?? DEFAULT_CELL_TRANSFORM;
   };
 
   const isActive = () => !!activeImageId();
@@ -133,13 +137,62 @@ export const ViewControls: Component = () => {
         </svg>
       </button>
 
-      <Show when={viewTransform().rotation !== 0 || viewTransform().flippedH || viewTransform().flippedV}>
+      <div style={{ width: '1px', height: '24px', 'background-color': '#555', margin: '0 4px' }} />
+
+      <button
+        type="button"
+        title="Toggle Negative"
+        data-testid="view-negative"
+        disabled={!isActive()}
+        onClick={() => actions.toggleActiveCellNegative()}
+        style={{
+          padding: '0 8px',
+          height: '32px',
+          'background-color': cellTransform().negative ? '#2196F3' : '#333',
+          border: 'none',
+          'border-radius': '4px',
+          color: 'white',
+          cursor: isActive() ? 'pointer' : 'default',
+          opacity: isActive() ? '1' : '0.5',
+          display: 'flex',
+          'align-items': 'center',
+          'justify-content': 'center',
+          'font-size': '12px',
+          'font-weight': cellTransform().negative ? 'bold' : 'normal',
+        }}
+      >
+        Neg
+      </button>
+
+      <div style={{ display: 'flex', 'align-items': 'center', gap: '4px', opacity: isActive() ? '1' : '0.5' }}>
+        <span style={{ color: '#ccc', 'font-size': '12px' }}>Exp</span>
+        <input
+          type="range"
+          min="0"
+          max="5"
+          step="0.1"
+          data-testid="view-exposure"
+          disabled={!isActive()}
+          value={cellTransform().exposure}
+          onInput={(e) => actions.setActiveCellExposure(parseFloat(e.currentTarget.value))}
+          style={{ width: '60px', cursor: isActive() ? 'pointer' : 'default' }}
+        />
+        <span style={{ color: '#ccc', 'font-size': '12px', 'min-width': '20px', 'text-align': 'right' }}>
+          {cellTransform().exposure.toFixed(1)}
+        </span>
+      </div>
+
+      <Show when={viewTransform().rotation !== 0 || viewTransform().flippedH || viewTransform().flippedV || cellTransform().negative || cellTransform().exposure !== 1}>
         <div style={{ width: '1px', height: '24px', 'background-color': '#555', margin: '0 4px' }} />
         <button
           type="button"
-          title="Reset View (Shift+0)"
+          title="Reset View"
           data-testid="view-reset"
-          onClick={() => actions.resetActiveImageView()}
+          onClick={() => {
+            actions.resetActiveImageView();
+            if (cellTransform().negative) actions.toggleActiveCellNegative();
+            if (cellTransform().exposure !== 1) actions.setActiveCellExposure(1);
+          }}
           style={{
             padding: '0 8px',
             height: '32px',

--- a/packages/osdlabel/src/components/ViewerCell.tsx
+++ b/packages/osdlabel/src/components/ViewerCell.tsx
@@ -4,7 +4,7 @@ import OpenSeadragon from 'openseadragon';
 import { FabricOverlay } from '../overlay/fabric-overlay.js';
 import type { OverlayMode } from '../overlay/fabric-overlay.js';
 import type { ImageSource } from '../core/types.js';
-import { DEFAULT_VIEW_TRANSFORM } from '../core/types.js';
+import { DEFAULT_VIEW_TRANSFORM, DEFAULT_CELL_TRANSFORM } from '../core/types.js';
 import { useAnnotationTool } from '../hooks/useAnnotationTool.js';
 import { useAnnotator } from '../state/annotator-context.js';
 import { createFabricObjectFromRawData } from '../core/fabric-utils.js';
@@ -13,13 +13,14 @@ import '../core/fabric-module.js';
 export interface ViewerCellProps {
   readonly imageSource: ImageSource | undefined;
   readonly isActive: boolean;
+  readonly cellIndex: number;
   readonly mode?: OverlayMode;
   readonly onActivate: () => void;
   readonly onOverlayReady?: (overlay: FabricOverlay) => void;
 }
 
 const ViewerCell: Component<ViewerCellProps> = (props) => {
-  const { annotationState, contextState } = useAnnotator();
+  const { uiState, annotationState, contextState } = useAnnotator();
   let containerRef: HTMLDivElement | undefined;
   let viewer: OpenSeadragon.Viewer | undefined;
   const [overlay, setOverlay] = createSignal<FabricOverlay>();
@@ -84,6 +85,21 @@ const ViewerCell: Component<ViewerCellProps> = (props) => {
     // Explicitly track the viewTransform state
     const transform = annotationState.viewTransforms[imageId] ?? DEFAULT_VIEW_TRANSFORM;
     ov.applyViewTransform(transform);
+  });
+
+  // Apply cell transforms (exposure and negative) to OSD canvas
+  createEffect(() => {
+    const transform = uiState.cellTransforms[props.cellIndex] ?? DEFAULT_CELL_TRANSFORM;
+
+    if (viewer && (viewer as any).drawer?.canvas) {
+      const canvas = (viewer as any).drawer.canvas as HTMLCanvasElement;
+      const filters: string[] = [];
+      if (transform.negative) filters.push('invert(1)');
+      if (transform.exposure !== undefined && transform.exposure !== 1) {
+        filters.push(`brightness(${transform.exposure})`);
+      }
+      canvas.style.filter = filters.length > 0 ? filters.join(' ') : 'none';
+    }
   });
 
   // Use annotation tool hook

--- a/packages/osdlabel/src/core/types.ts
+++ b/packages/osdlabel/src/core/types.ts
@@ -149,6 +149,16 @@ export interface ViewTransform {
 
 export const DEFAULT_VIEW_TRANSFORM: ViewTransform = { rotation: 0, flippedH: false, flippedV: false };
 
+// ── Cell Transform ───────────────────────────────────────────────────────
+
+/** Per-cell transform (exposure/negative state) */
+export interface CellTransform {
+  readonly exposure: number;
+  readonly negative: boolean;
+}
+
+export const DEFAULT_CELL_TRANSFORM: CellTransform = { exposure: 1, negative: false };
+
 // ── State Types ──────────────────────────────────────────────────────────
 // Note: State container types intentionally omit `readonly` — SolidJS store
 // proxies enforce immutability at runtime, and `readonly` here would conflict
@@ -171,6 +181,7 @@ export interface UIState {
   gridRows: number;
   gridAssignments: Record<number, ImageId>;
   selectedAnnotationId: AnnotationId | null;
+  cellTransforms: Record<number, CellTransform>;
 }
 
 /** Context state */

--- a/packages/osdlabel/src/state/actions.ts
+++ b/packages/osdlabel/src/state/actions.ts
@@ -12,7 +12,7 @@ import type {
   ViewTransform,
 } from '../core/types.js';
 import { isContextScopedToImage } from '../core/context-scoping.js';
-import { DEFAULT_VIEW_TRANSFORM } from '../core/types.js';
+import { DEFAULT_VIEW_TRANSFORM, DEFAULT_CELL_TRANSFORM } from '../core/types.js';
 
 export function createActions(
   setAnnotationState: SetStoreFunction<AnnotationState>,
@@ -165,6 +165,26 @@ export function createActions(
     modifyViewTransform(imageId, () => ({ ...DEFAULT_VIEW_TRANSFORM }));
   }
 
+  function setActiveCellExposure(exposure: number): void {
+    setUIState(
+      produce((state) => {
+        const cellIndex = state.activeCellIndex;
+        const current = state.cellTransforms[cellIndex] ?? { ...DEFAULT_CELL_TRANSFORM };
+        state.cellTransforms[cellIndex] = { ...current, exposure };
+      }),
+    );
+  }
+
+  function toggleActiveCellNegative(): void {
+    setUIState(
+      produce((state) => {
+        const cellIndex = state.activeCellIndex;
+        const current = state.cellTransforms[cellIndex] ?? { ...DEFAULT_CELL_TRANSFORM };
+        state.cellTransforms[cellIndex] = { ...current, negative: !current.negative };
+      }),
+    );
+  }
+
   return {
     addAnnotation,
     updateAnnotation,
@@ -182,5 +202,7 @@ export function createActions(
     flipActiveImageH,
     flipActiveImageV,
     resetActiveImageView,
+    setActiveCellExposure,
+    toggleActiveCellNegative,
   };
 }

--- a/packages/osdlabel/src/state/ui-store.ts
+++ b/packages/osdlabel/src/state/ui-store.ts
@@ -9,6 +9,7 @@ export function createUIStore() {
     gridRows: 1,
     gridAssignments: {},
     selectedAnnotationId: null,
+    cellTransforms: {},
   });
   return { state, setState };
 }

--- a/packages/osdlabel/tests/unit/state/actions.test.ts
+++ b/packages/osdlabel/tests/unit/state/actions.test.ts
@@ -212,4 +212,27 @@ describe('State Management', () => {
     expect(status.circle.enabled).toBe(false);
     dispose();
   });
+
+  it('setActiveCellExposure updates exposure for the active cell', () => {
+    const { uiState, actions, dispose } = createTestStore();
+    actions.setActiveCell(1);
+    actions.setActiveCellExposure(1.5);
+    expect(uiState.cellTransforms[1]).toBeDefined();
+    expect(uiState.cellTransforms[1]?.exposure).toBe(1.5);
+    expect(uiState.cellTransforms[1]?.negative).toBe(false);
+    dispose();
+  });
+
+  it('toggleActiveCellNegative toggles negative for the active cell', () => {
+    const { uiState, actions, dispose } = createTestStore();
+    actions.setActiveCell(2);
+    actions.toggleActiveCellNegative();
+    expect(uiState.cellTransforms[2]).toBeDefined();
+    expect(uiState.cellTransforms[2]?.negative).toBe(true);
+    expect(uiState.cellTransforms[2]?.exposure).toBe(1);
+
+    actions.toggleActiveCellNegative();
+    expect(uiState.cellTransforms[2]?.negative).toBe(false);
+    dispose();
+  });
 });

--- a/packages/osdlabel/tests/unit/state/ui-store.test.ts
+++ b/packages/osdlabel/tests/unit/state/ui-store.test.ts
@@ -14,6 +14,7 @@ describe('UI Store', () => {
       expect(state.gridRows).toBe(1);
       expect(state.gridAssignments).toEqual({});
       expect(state.selectedAnnotationId).toBeNull();
+      expect(state.cellTransforms).toEqual({});
 
       dispose();
     });


### PR DESCRIPTION
Implement support for cell-level visual transformations, specifically adjusting exposure (brightness) and toggling negative (invert colors) modes, as requested in `tasks/25-cell-exposure.md`. These transformations are applied via CSS filters (`brightness()` and `invert()`) on the individual OpenSeadragon canvas elements, meaning they affect the viewer visually without altering the underlying image source data. The view controls correctly scope to the active cell, update seamlessly on cell switch, and reset alongside rotation/flip controls when the "Reset" button is pressed. The new transforms are documented, thoroughly tested via unit tests, and verified via Playwright E2E screenshots.

---
*PR created automatically by Jules for task [8308547275330582647](https://jules.google.com/task/8308547275330582647) started by @guyo13*