### PR TITLE
feat: add exposure and negative image view controls

### DIFF
--- a/apps/dev/tests/e2e/view-controls.spec.ts
+++ b/apps/dev/tests/e2e/view-controls.spec.ts
@@ -14,6 +14,9 @@ test.describe('View Controls', () => {
     await expect(page.locator('[data-testid="view-rotate-ccw"]')).toBeVisible();
     await expect(page.locator('[data-testid="view-flip-h"]')).toBeVisible();
     await expect(page.locator('[data-testid="view-flip-v"]')).toBeVisible();
+    await expect(page.locator('[data-testid="view-negative"]')).toBeVisible();
+    await expect(page.locator('[data-testid="view-exposure-increase"]')).toBeVisible();
+    await expect(page.locator('[data-testid="view-exposure-decrease"]')).toBeVisible();
     // Reset button should not be visible initially as view is not transformed
     await expect(page.locator('[data-testid="view-reset"]')).not.toBeVisible();
   });
@@ -53,6 +56,40 @@ test.describe('View Controls', () => {
     
     await flipHBtn.click();
     await expect(flipHBtn).toHaveCSS('background-color', 'rgb(51, 51, 51)');
+    await expect(resetBtn).not.toBeVisible();
+  });
+
+  test('Negative button toggles and shows active state', async ({ page }) => {
+    const negativeBtn = page.locator('[data-testid="view-negative"]');
+    const resetBtn = page.locator('[data-testid="view-reset"]');
+
+    await expect(negativeBtn).toHaveCSS('background-color', 'rgb(51, 51, 51)');
+    
+    await negativeBtn.click();
+    await expect(negativeBtn).toHaveCSS('background-color', 'rgb(33, 150, 243)');
+    await expect(resetBtn).toBeVisible();
+    
+    await negativeBtn.click();
+    await expect(negativeBtn).toHaveCSS('background-color', 'rgb(51, 51, 51)');
+    await expect(resetBtn).not.toBeVisible();
+  });
+
+  test('Exposure buttons adjust exposure and show reset', async ({ page }) => {
+    const increaseBtn = page.locator('[data-testid="view-exposure-increase"]');
+    const decreaseBtn = page.locator('[data-testid="view-exposure-decrease"]');
+    const resetBtn = page.locator('[data-testid="view-reset"]');
+
+    await increaseBtn.click();
+    await expect(resetBtn).toBeVisible();
+    
+    await decreaseBtn.click();
+    // Exposure should be back to 0, so reset disappears
+    await expect(resetBtn).not.toBeVisible();
+
+    await decreaseBtn.click();
+    await expect(resetBtn).toBeVisible();
+    
+    await resetBtn.click();
     await expect(resetBtn).not.toBeVisible();
   });
 
@@ -144,13 +181,28 @@ test.describe('View Controls', () => {
 
     // Press Shift+R
     await page.keyboard.press('Shift+R');
-    
     // Press Shift+0 (Reset)
     await page.keyboard.press('Shift+0');
-    
+
     await expect(flipHBtn).toHaveCSS('background-color', 'rgb(51, 51, 51)');
     await expect(resetBtn).not.toBeVisible();
-    
+
+    const negativeBtn = page.locator('[data-testid="view-negative"]');
+    // Press Shift+N
+    await page.keyboard.press('Shift+N');
+    await expect(negativeBtn).toHaveCSS('background-color', 'rgb(33, 150, 243)');
+    await expect(resetBtn).toBeVisible();
+
+    // Press Shift+E
+    await page.keyboard.press('Shift+E');
+    // Press Shift+D
+    await page.keyboard.press('Shift+D');
+
+    // Press Shift+0 (Reset)
+    await page.keyboard.press('Shift+0');
+    await expect(negativeBtn).toHaveCSS('background-color', 'rgb(51, 51, 51)');
+    await expect(resetBtn).not.toBeVisible();
+
     // Plain 'r' triggers rectangle tool, not rotation
     await page.keyboard.press('r');
     await expect(page.locator('[data-testid="tool-rectangle"]')).toHaveCSS('background-color', 'rgb(33, 150, 243)');

--- a/apps/docs/src/content/docs/api/types.md
+++ b/apps/docs/src/content/docs/api/types.md
@@ -259,6 +259,20 @@ interface ImageSource {
 
 The `dziUrl` can point to a `.dzi` file for tiled deep zoom images, or a standard image URL (`.jpg`, `.png`) for simple images.
 
+### ViewTransform
+
+Per-image view transform applied during rendering without modifying annotation data.
+
+```ts
+interface ViewTransform {
+  readonly rotation: number;      // degrees (0, 90, 180, 270)
+  readonly flippedH: boolean;
+  readonly flippedV: boolean;
+  readonly exposure: number;      // -1 to 1 (0 = default)
+  readonly inverted: boolean;     // false = normal, true = CSS invert(1)
+}
+```
+
 ---
 
 ## State types
@@ -329,6 +343,9 @@ interface KeyboardShortcutMap {
   readonly pathFinish: string;
   readonly pathClose: string;
   readonly pathCancel: string;
+  readonly toggleNegative: string;
+  readonly increaseExposure: string;
+  readonly decreaseExposure: string;
 }
 ```
 

--- a/apps/docs/src/content/docs/guides/keyboard-shortcuts.mdx
+++ b/apps/docs/src/content/docs/guides/keyboard-shortcuts.mdx
@@ -27,6 +27,19 @@ osdlabel is designed for high-throughput annotation tasks with a comprehensive s
 | `]`                    | Add a grid row                            |
 | `[`                    | Remove a grid row                         |
 
+### View transform shortcuts
+
+| Key         | Action                      |
+| ----------- | --------------------------- |
+| `Shift+R`   | Rotate image 90° CW         |
+| `Shift+L`   | Rotate image 90° CCW        |
+| `Shift+H`   | Flip image horizontally     |
+| `Shift+V`   | Flip image vertically       |
+| `Shift+N`   | Toggle negative (invert)    |
+| `Shift+E`   | Increase exposure           |
+| `Shift+D`   | Decrease exposure           |
+| `Shift+0` / `)` | Reset view transform  |
+
 ### Path tool shortcuts
 
 | Key      | Action                      |

--- a/packages/osdlabel/src/components/ViewControls.tsx
+++ b/packages/osdlabel/src/components/ViewControls.tsx
@@ -133,7 +133,113 @@ export const ViewControls: Component = () => {
         </svg>
       </button>
 
-      <Show when={viewTransform().rotation !== 0 || viewTransform().flippedH || viewTransform().flippedV}>
+      <div style={{ width: '1px', height: '24px', 'background-color': '#555', margin: '0 4px' }} />
+
+      <button
+        type="button"
+        title="Toggle Negative (Shift+N)"
+        data-testid="view-negative"
+        disabled={!isActive()}
+        onClick={() => actions.toggleActiveImageNegative()}
+        style={{
+          width: '32px',
+          height: '32px',
+          'background-color': viewTransform().inverted ? '#2196F3' : '#333',
+          border: 'none',
+          'border-radius': '4px',
+          color: 'white',
+          cursor: isActive() ? 'pointer' : 'default',
+          opacity: isActive() ? '1' : '0.5',
+          display: 'flex',
+          'align-items': 'center',
+          'justify-content': 'center',
+        }}
+      >
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <circle cx="12" cy="12" r="10" />
+          <path d="M12 2a10 10 0 0 0 0 20z" fill="currentColor" />
+        </svg>
+      </button>
+
+      <button
+        type="button"
+        title="Decrease Exposure (Shift+D)"
+        data-testid="view-exposure-decrease"
+        disabled={!isActive()}
+        onClick={() => actions.decreaseActiveImageExposure()}
+        style={{
+          width: '32px',
+          height: '32px',
+          'background-color': '#333',
+          border: 'none',
+          'border-radius': '4px',
+          color: 'white',
+          cursor: isActive() ? 'pointer' : 'default',
+          opacity: isActive() ? '1' : '0.5',
+          display: 'flex',
+          'align-items': 'center',
+          'justify-content': 'center',
+        }}
+      >
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <circle cx="12" cy="12" r="4" />
+          <path d="M12 2v2" />
+          <path d="M12 20v2" />
+          <path d="m4.93 4.93 1.41 1.41" />
+          <path d="m17.66 17.66 1.41 1.41" />
+          <path d="M2 12h2" />
+          <path d="M20 12h2" />
+          <path d="m6.34 17.66-1.41 1.41" />
+          <path d="m19.07 4.93-1.41 1.41" />
+        </svg>
+        <span style={{ position: 'absolute', 'margin-top': '18px', 'font-size': '10px', 'font-weight': 'bold' }}>-</span>
+      </button>
+
+      <div style={{ 
+        width: '24px', 
+        'text-align': 'center', 
+        color: 'white', 
+        'font-size': '12px',
+        opacity: isActive() ? '1' : '0.5' 
+      }}>
+        {viewTransform().exposure > 0 ? `+${Math.round(viewTransform().exposure * 10)}` : Math.round(viewTransform().exposure * 10)}
+      </div>
+
+      <button
+        type="button"
+        title="Increase Exposure (Shift+E)"
+        data-testid="view-exposure-increase"
+        disabled={!isActive()}
+        onClick={() => actions.increaseActiveImageExposure()}
+        style={{
+          width: '32px',
+          height: '32px',
+          'background-color': '#333',
+          border: 'none',
+          'border-radius': '4px',
+          color: 'white',
+          cursor: isActive() ? 'pointer' : 'default',
+          opacity: isActive() ? '1' : '0.5',
+          display: 'flex',
+          'align-items': 'center',
+          'justify-content': 'center',
+        }}
+      >
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <circle cx="12" cy="12" r="4" />
+          <path d="M12 2v2" />
+          <path d="M12 20v2" />
+          <path d="m4.93 4.93 1.41 1.41" />
+          <path d="m17.66 17.66 1.41 1.41" />
+          <path d="M2 12h2" />
+          <path d="M20 12h2" />
+          <path d="m6.34 17.66-1.41 1.41" />
+          <path d="m19.07 4.93-1.41 1.41" />
+        </svg>
+        <span style={{ position: 'absolute', 'margin-top': '18px', 'font-size': '10px', 'font-weight': 'bold' }}>+</span>
+      </button>
+
+      <Show when={viewTransform().rotation !== 0 || viewTransform().flippedH || viewTransform().flippedV || viewTransform().exposure !== 0 || viewTransform().inverted}>
         <div style={{ width: '1px', height: '24px', 'background-color': '#555', margin: '0 4px' }} />
         <button
           type="button"

--- a/packages/osdlabel/src/components/ViewerCell.tsx
+++ b/packages/osdlabel/src/components/ViewerCell.tsx
@@ -84,6 +84,7 @@ const ViewerCell: Component<ViewerCellProps> = (props) => {
     // Explicitly track the viewTransform state
     const transform = annotationState.viewTransforms[imageId] ?? DEFAULT_VIEW_TRANSFORM;
     ov.applyViewTransform(transform);
+    ov.applyImageFilters(transform.exposure, transform.inverted);
   });
 
   // Use annotation tool hook

--- a/packages/osdlabel/src/core/annotations/serialization.ts
+++ b/packages/osdlabel/src/core/annotations/serialization.ts
@@ -138,6 +138,8 @@ export function deserialize(doc: unknown): DeserializeResult {
         rotation: vt.rotation,
         flippedH: vt.flippedH,
         flippedV: vt.flippedV,
+        exposure: typeof vt.exposure === 'number' ? vt.exposure : 0,
+        inverted: typeof vt.inverted === 'boolean' ? vt.inverted : false,
       };
     }
     viewTransforms[imageId] = viewTransform;

--- a/packages/osdlabel/src/core/types.ts
+++ b/packages/osdlabel/src/core/types.ts
@@ -145,9 +145,11 @@ export interface ViewTransform {
   readonly rotation: number;      // degrees (0, 90, 180, 270)
   readonly flippedH: boolean;
   readonly flippedV: boolean;
+  readonly exposure: number;      // -1 to 1 (0 = default)
+  readonly inverted: boolean;     // false = normal, true = CSS invert(1)
 }
 
-export const DEFAULT_VIEW_TRANSFORM: ViewTransform = { rotation: 0, flippedH: false, flippedV: false };
+export const DEFAULT_VIEW_TRANSFORM: ViewTransform = { rotation: 0, flippedH: false, flippedV: false, exposure: 0, inverted: false };
 
 // ── State Types ──────────────────────────────────────────────────────────
 // Note: State container types intentionally omit `readonly` — SolidJS store
@@ -225,4 +227,7 @@ export interface KeyboardShortcutMap {
   readonly flipHorizontal: string;
   readonly flipVertical: string;
   readonly resetView: string;
+  readonly toggleNegative: string;
+  readonly increaseExposure: string;
+  readonly decreaseExposure: string;
 }

--- a/packages/osdlabel/src/hooks/useKeyboard.ts
+++ b/packages/osdlabel/src/hooks/useKeyboard.ts
@@ -35,6 +35,9 @@ export const DEFAULT_KEYBOARD_SHORTCUTS: KeyboardShortcutMap = {
   flipHorizontal: 'H',
   flipVertical: 'V',
   resetView: ')',
+  toggleNegative: 'N',
+  increaseExposure: 'E',
+  decreaseExposure: 'D',
 } as const;
 
 export function useKeyboard(
@@ -74,6 +77,12 @@ export function useKeyboard(
       actions.flipActiveImageH();
     } else if (e.shiftKey && keyLower === shortcuts.flipVertical.toLowerCase()) {
       actions.flipActiveImageV();
+    } else if (e.shiftKey && keyLower === shortcuts.toggleNegative.toLowerCase()) {
+      actions.toggleActiveImageNegative();
+    } else if (e.shiftKey && keyLower === shortcuts.increaseExposure.toLowerCase()) {
+      actions.increaseActiveImageExposure();
+    } else if (e.shiftKey && keyLower === shortcuts.decreaseExposure.toLowerCase()) {
+      actions.decreaseActiveImageExposure();
     } else if (key === shortcuts.resetView || (e.shiftKey && keyLower === '0')) {
       actions.resetActiveImageView();
     }

--- a/packages/osdlabel/src/overlay/fabric-overlay.ts
+++ b/packages/osdlabel/src/overlay/fabric-overlay.ts
@@ -231,6 +231,15 @@ export class FabricOverlay {
     this.sync();
   }
 
+  /** Apply image adjustment filters (exposure/invert) to the OSD drawer canvas */
+  applyImageFilters(exposure: number, inverted: boolean): void {
+    const drawerCanvas = this._viewer.drawer.canvas as HTMLElement;
+    const parts: string[] = [];
+    if (exposure !== 0) parts.push(`brightness(${1 + exposure})`);
+    if (inverted) parts.push('invert(1)');
+    drawerCanvas.style.filter = parts.length > 0 ? parts.join(' ') : '';
+  }
+
   getRotation(): number {
     return this._viewer.viewport.getRotation();
   }

--- a/packages/osdlabel/src/state/actions.ts
+++ b/packages/osdlabel/src/state/actions.ts
@@ -159,6 +159,30 @@ export function createActions(
     modifyViewTransform(imageId, (vt) => ({ ...vt, flippedV: !vt.flippedV }));
   }
 
+  function toggleActiveImageNegative(): void {
+    const imageId = getActiveImageId();
+    if (!imageId) return;
+    modifyViewTransform(imageId, (vt) => ({ ...vt, inverted: !vt.inverted }));
+  }
+
+  function increaseActiveImageExposure(): void {
+    const imageId = getActiveImageId();
+    if (!imageId) return;
+    modifyViewTransform(imageId, (vt) => ({ ...vt, exposure: Math.min(1, vt.exposure + 0.1) }));
+  }
+
+  function decreaseActiveImageExposure(): void {
+    const imageId = getActiveImageId();
+    if (!imageId) return;
+    modifyViewTransform(imageId, (vt) => ({ ...vt, exposure: Math.max(-1, vt.exposure - 0.1) }));
+  }
+
+  function setActiveImageExposure(value: number): void {
+    const imageId = getActiveImageId();
+    if (!imageId) return;
+    modifyViewTransform(imageId, (vt) => ({ ...vt, exposure: Math.max(-1, Math.min(1, value)) }));
+  }
+
   function resetActiveImageView(): void {
     const imageId = getActiveImageId();
     if (!imageId) return;
@@ -181,6 +205,10 @@ export function createActions(
     rotateActiveImageCCW,
     flipActiveImageH,
     flipActiveImageV,
+    toggleActiveImageNegative,
+    increaseActiveImageExposure,
+    decreaseActiveImageExposure,
+    setActiveImageExposure,
     resetActiveImageView,
   };
 }

--- a/packages/osdlabel/tests/unit/annotations/serialization.test.ts
+++ b/packages/osdlabel/tests/unit/annotations/serialization.test.ts
@@ -162,7 +162,7 @@ describe('Serialization', () => {
       const restoredAnn2 = result[imageId][annId2];
       expect(restoredAnn2.geometry).toEqual(annotation2.geometry);
       
-      expect(viewTransforms[imageId]).toEqual({ rotation: 180, flippedH: false, flippedV: true });
+      expect(viewTransforms[imageId]).toEqual({ rotation: 180, flippedH: false, flippedV: true, exposure: 0, inverted: false });
     });
 
     it('should default missing viewTransform to DEFAULT_VIEW_TRANSFORM', () => {
@@ -179,7 +179,7 @@ describe('Serialization', () => {
       };
       
       const { viewTransforms } = deserialize(doc);
-      expect(viewTransforms[createImageId('img1')]).toEqual({ rotation: 0, flippedH: false, flippedV: false });
+      expect(viewTransforms[createImageId('img1')]).toEqual({ rotation: 0, flippedH: false, flippedV: false, exposure: 0, inverted: false });
     });
 
     it('should reject invalid viewTransform (not an object)', () => {


### PR DESCRIPTION
- Add `exposure` and `inverted` to per-image `ViewTransform` state

- Apply non-destructive CSS `brightness()` and `invert()` filters to the OSD drawer canvas

- Add new negative toggle and exposure adjustment buttons to `ViewControls`

- Add `Shift+N`, `Shift+E`, and `Shift+D` keyboard shortcuts

- Update unit tests, E2E tests, and documentation to cover new controls