### PR TITLE
feat: add support for displaying inactive annotation contexts

### DIFF
--- a/packages/osdlabel/src/components/Annotator.tsx
+++ b/packages/osdlabel/src/components/Annotator.tsx
@@ -1,3 +1,4 @@
+import { createEffect } from 'solid-js';
 import type { Component, JSX } from 'solid-js';
 import { AnnotatorProvider } from '../state/annotator-context.js';
 import type { AnnotatorProviderProps } from '../state/annotator-context.js';
@@ -16,6 +17,8 @@ export interface AnnotatorProps extends Omit<AnnotatorProviderProps, 'children'>
   readonly images: readonly ImageSource[];
   /** Annotation contexts defining tool constraints */
   readonly contexts: readonly AnnotationContext[];
+  /** List of annotation context IDs that should be displayed alongside the active context */
+  readonly displayedContextIds?: readonly string[] | undefined;
   /** Whether to show the filmstrip sidebar (default: true) */
   readonly showFilmstrip?: boolean | undefined;
   /** Whether to show the grid controls (default: false) */
@@ -121,10 +124,11 @@ const Annotator: Component<AnnotatorProps> = (props) => {
       keyboardShortcuts={props.keyboardShortcuts}
       shouldSkipKeyboardShortcutPredicate={props.shouldSkipKeyboardShortcutPredicate}
     >
-      <AnnotatorSetup contexts={props.contexts} />
+      <AnnotatorSetup contexts={props.contexts} displayedContextIds={props.displayedContextIds} />
       <AnnotatorInner
         images={props.images}
         contexts={props.contexts}
+        displayedContextIds={props.displayedContextIds}
         showFilmstrip={props.showFilmstrip}
         showGridControls={props.showGridControls}
         showContextSwitcher={props.showContextSwitcher}
@@ -138,13 +142,24 @@ const Annotator: Component<AnnotatorProps> = (props) => {
   );
 };
 
-/** Initializes contexts inside the provider (runs once) */
-const AnnotatorSetup: Component<{ readonly contexts: readonly AnnotationContext[] }> = (props) => {
-  const { actions } = useAnnotator();
-  actions.setContexts([...props.contexts]);
-  if (props.contexts.length > 0) {
-    actions.setActiveContext(props.contexts[0]!.id);
-  }
+/** Initializes contexts inside the provider */
+const AnnotatorSetup: Component<{
+  readonly contexts: readonly AnnotationContext[];
+  readonly displayedContextIds?: readonly string[] | undefined;
+}> = (props) => {
+  const { actions, contextState } = useAnnotator();
+  
+  createEffect(() => {
+    actions.setContexts([...props.contexts]);
+    if (props.contexts.length > 0 && !contextState.activeContextId) {
+      actions.setActiveContext(props.contexts[0]!.id);
+    }
+  });
+
+  createEffect(() => {
+    actions.setDisplayedContexts((props.displayedContextIds ?? []) as any);
+  });
+
   return null;
 };
 

--- a/packages/osdlabel/src/components/ViewerCell.tsx
+++ b/packages/osdlabel/src/components/ViewerCell.tsx
@@ -102,16 +102,18 @@ const ViewerCell: Component<ViewerCellProps> = (props) => {
     const ov = overlay();
     const imageId = props.imageSource?.id;
     const contextId = contextState.activeContextId;
+    const displayedIds = contextState.displayedContextIds;
     // Track this as reactive dependencies so the effect re-runs
     void props.isActive;
 
     if (!ov || !imageId) return;
 
-    // Filter annotations by imageId + contextId
+    // Filter annotations by imageId + contextId + displayedContextIds
     const imageAnns = annotationState.byImage[imageId] || {};
-    const matching = contextId
-      ? Object.values(imageAnns).filter((a) => a.contextId === contextId)
-      : Object.values(imageAnns);
+    const isContextDisplayed = (ctxId: string) =>
+      ctxId === contextId || displayedIds.includes(ctxId as any);
+
+    const matching = Object.values(imageAnns).filter((a) => isContextDisplayed(a.contextId));
 
     // Clear all existing annotation objects from canvas
     const toRemove = ov.canvas.getObjects().filter((obj) => obj.id);
@@ -122,7 +124,10 @@ const ViewerCell: Component<ViewerCellProps> = (props) => {
     void (async () => {
       if (props.imageSource?.id !== capturedImageId) return; // stale check
 
-      const promises = matching.map((ann) => createFabricObjectFromRawData(ann));
+      const promises = matching.map((ann) => {
+        const isActiveContext = ann.contextId === contextId;
+        return createFabricObjectFromRawData(ann, isActiveContext);
+      });
       const objects = await Promise.all(promises);
       const validObjects = objects.filter((obj) => obj !== null);
       if (validObjects.length > 0) {

--- a/packages/osdlabel/src/core/fabric-utils.ts
+++ b/packages/osdlabel/src/core/fabric-utils.ts
@@ -76,13 +76,14 @@ export async function deserializeFabricObject(
  */
 export async function createFabricObjectFromRawData(
   annotation: Annotation,
+  isActiveContext: boolean = true,
 ): Promise<FabricObject | null> {
   const obj = await deserializeFabricObject(annotation.rawAnnotationData);
   if (!obj) return null;
 
   obj.set({
-    selectable: true,
-    evented: true,
+    selectable: isActiveContext,
+    evented: isActiveContext,
   });
 
   return obj;

--- a/packages/osdlabel/src/core/types.ts
+++ b/packages/osdlabel/src/core/types.ts
@@ -195,6 +195,7 @@ export interface UIState {
 export interface ContextState {
   contexts: AnnotationContext[];
   activeContextId: AnnotationContextId | null;
+  displayedContextIds: AnnotationContextId[];
 }
 
 // ── Constraint Status ────────────────────────────────────────────────────

--- a/packages/osdlabel/src/state/actions.ts
+++ b/packages/osdlabel/src/state/actions.ts
@@ -124,6 +124,10 @@ export function createActions(
     setContextState('activeContextId', contextId);
   }
 
+  function setDisplayedContexts(contextIds: AnnotationContextId[]): void {
+    setContextState('displayedContextIds', contextIds);
+  }
+
   function loadAnnotations(
     byImage: Record<ImageId, Record<AnnotationId, Annotation>>,
     viewTransforms: Record<ImageId, ViewTransform> = {},
@@ -248,6 +252,7 @@ export function createActions(
     setGridDimensions,
     setContexts,
     setActiveContext,
+    setDisplayedContexts,
     loadAnnotations,
     rotateActiveImageCW,
     rotateActiveImageCCW,

--- a/packages/osdlabel/src/state/context-store.ts
+++ b/packages/osdlabel/src/state/context-store.ts
@@ -14,6 +14,7 @@ export function createContextStore() {
   const [state, setState] = createStore<ContextState>({
     contexts: [],
     activeContextId: null,
+    displayedContextIds: [],
   });
   return { state, setState };
 }


### PR DESCRIPTION
- Add `displayedContextIds` to `ContextState` and `AnnotatorProps`
- Add `setDisplayedContexts` action
- Update `ViewerCell` to render annotations from both active and displayed contexts
- Set `selectable: false` and `evented: false` on Fabric objects for inactive contexts so they are visible but not interactive