### PR TITLE
refactor: move rotation/flip state from image-level to cell-level

### DIFF
--- a/apps/dev/src/App.tsx
+++ b/apps/dev/src/App.tsx
@@ -119,8 +119,8 @@ function AppContent() {
     if (!json.trim()) return;
     try {
       const parsed: unknown = JSON.parse(json);
-      const { byImage, viewTransforms } = deserialize(parsed);
-      actions.loadAnnotations(byImage, viewTransforms);
+      const { byImage } = deserialize(parsed);
+      actions.loadAnnotations(byImage);
       setShowImportPanel(false);
       setImportJsonText('');
     } catch (err) {

--- a/apps/docs/src/content/docs/api/types.md
+++ b/apps/docs/src/content/docs/api/types.md
@@ -259,6 +259,20 @@ interface ImageSource {
 
 The `dziUrl` can point to a `.dzi` file for tiled deep zoom images, or a standard image URL (`.jpg`, `.png`) for simple images.
 
+### CellTransform
+
+Per-cell visual adjustments (rotation, flip, exposure, inversion). These are transient view state — not serialized with annotations.
+
+```ts
+interface CellTransform {
+  readonly rotation: number;  // degrees (0, 90, 180, 270)
+  readonly flippedH: boolean;
+  readonly flippedV: boolean;
+  readonly exposure: number;  // -1 to 1 (0 = default)
+  readonly inverted: boolean; // false = normal, true = CSS invert
+}
+```
+
 ---
 
 ## State types
@@ -282,6 +296,7 @@ interface UIState {
   gridRows: number;
   gridAssignments: Record<number, ImageId>;
   selectedAnnotationId: AnnotationId | null;
+  cellTransforms: Record<number, CellTransform>;
 }
 ```
 

--- a/apps/docs/src/content/docs/guides/osd-fabric-integration.md
+++ b/apps/docs/src/content/docs/guides/osd-fabric-integration.md
@@ -183,7 +183,7 @@ So the flipped matrix is `[-a, b, -c, d, W-tx, ty]` — negate `a` and `c`, and 
 OSD only has horizontal flip (`setFlip`). Vertical flip is achieved by combining horizontal flip with a 180° rotation:
 
 ```ts
-// In applyViewTransform:
+// In applyViewTransform (receives CellTransform):
 const isFlipped = transform.flippedH !== transform.flippedV; // XOR
 if (transform.flippedV) {
   rotation = (rotation + 180) % 360;
@@ -323,7 +323,7 @@ No annotation data is ever modified by rotation or flip. The view transform is p
            └── fabricCanvas.renderAll()          → synchronous
 
 3. User applies rotation/flip
-   └── applyViewTransform(transform)
+   └── applyViewTransform(cellTransform)
        ├── Compute effective rotation (add 180° for vertical flip)
        ├── viewport.setFlip(isFlipped)           → immediately
        ├── viewport.setRotation(rotation, true)  → immediately (no spring)

--- a/packages/osdlabel/src/components/ViewControls.tsx
+++ b/packages/osdlabel/src/components/ViewControls.tsx
@@ -1,15 +1,9 @@
 import { type Component, Show } from 'solid-js';
 import { useAnnotator } from '../state/annotator-context.js';
-import { DEFAULT_VIEW_TRANSFORM, DEFAULT_CELL_TRANSFORM } from '../core/types.js';
+import { DEFAULT_CELL_TRANSFORM } from '../core/types.js';
 
 export const ViewControls: Component = () => {
-  const { uiState, annotationState, actions, activeImageId } = useAnnotator();
-
-  const viewTransform = () => {
-    const id = activeImageId();
-    if (!id) return DEFAULT_VIEW_TRANSFORM;
-    return annotationState.viewTransforms[id] ?? DEFAULT_VIEW_TRANSFORM;
-  };
+  const { uiState, actions, activeImageId } = useAnnotator();
 
   const cellTransform = () => {
     return uiState.cellTransforms[uiState.activeCellIndex] ?? DEFAULT_CELL_TRANSFORM;
@@ -110,7 +104,7 @@ export const ViewControls: Component = () => {
         style={{
           width: '32px',
           height: '32px',
-          'background-color': viewTransform().flippedH ? '#2196F3' : '#333',
+          'background-color': cellTransform().flippedH ? '#2196F3' : '#333',
           border: 'none',
           'border-radius': '4px',
           color: 'white',
@@ -146,7 +140,7 @@ export const ViewControls: Component = () => {
         style={{
           width: '32px',
           height: '32px',
-          'background-color': viewTransform().flippedV ? '#2196F3' : '#333',
+          'background-color': cellTransform().flippedV ? '#2196F3' : '#333',
           border: 'none',
           'border-radius': '4px',
           color: 'white',
@@ -315,9 +309,9 @@ export const ViewControls: Component = () => {
 
       <Show
         when={
-          viewTransform().rotation !== 0 ||
-          viewTransform().flippedH ||
-          viewTransform().flippedV ||
+          cellTransform().rotation !== 0 ||
+          cellTransform().flippedH ||
+          cellTransform().flippedV ||
           cellTransform().exposure !== 0 ||
           cellTransform().inverted
         }

--- a/packages/osdlabel/src/components/ViewerCell.tsx
+++ b/packages/osdlabel/src/components/ViewerCell.tsx
@@ -4,7 +4,7 @@ import OpenSeadragon from 'openseadragon';
 import { FabricOverlay } from '../overlay/fabric-overlay.js';
 import type { OverlayMode } from '../overlay/fabric-overlay.js';
 import type { ImageSource, AnnotationContextId } from '../core/types.js';
-import { DEFAULT_VIEW_TRANSFORM, DEFAULT_CELL_TRANSFORM } from '../core/types.js';
+import { DEFAULT_CELL_TRANSFORM } from '../core/types.js';
 import { useAnnotationTool } from '../hooks/useAnnotationTool.js';
 import { useAnnotator } from '../state/annotator-context.js';
 import { createFabricObjectFromRawData } from '../core/fabric-utils.js';
@@ -79,14 +79,11 @@ const ViewerCell: Component<ViewerCellProps> = (props) => {
   // Sync view transforms from state to canvas
   createEffect(() => {
     const ov = overlay();
-    const imageId = props.imageSource?.id;
-    if (!ov || !imageId) return;
+    if (!ov || !props.imageSource?.id) return;
 
-    // Explicitly track the viewTransform state
-    const imgTransform = annotationState.viewTransforms[imageId] ?? DEFAULT_VIEW_TRANSFORM;
     const cellTransform = uiState.cellTransforms[props.cellIndex] ?? DEFAULT_CELL_TRANSFORM;
 
-    ov.applyViewTransform(imgTransform);
+    ov.applyViewTransform(cellTransform);
     ov.applyImageFilters(cellTransform.exposure, cellTransform.inverted);
   });
 

--- a/packages/osdlabel/src/core/annotations/serialization.ts
+++ b/packages/osdlabel/src/core/annotations/serialization.ts
@@ -7,9 +7,8 @@ import type {
   ImageAnnotations,
   ImageId,
   ImageSource,
-  ViewTransform,
 } from '../types.js';
-import { createImageId, DEFAULT_VIEW_TRANSFORM } from '../types.js';
+import { createImageId } from '../types.js';
 import {
   normalizeFabricType,
   isFiniteNumber,
@@ -42,18 +41,10 @@ export function serialize(
     const annMap = state.byImage[image.id];
     const annotations: Annotation[] = annMap ? Object.values(annMap) : [];
 
-    const transform = state.viewTransforms[image.id];
-    const isDefaultTransform =
-      !transform ||
-      (transform.rotation === DEFAULT_VIEW_TRANSFORM.rotation &&
-        transform.flippedH === DEFAULT_VIEW_TRANSFORM.flippedH &&
-        transform.flippedV === DEFAULT_VIEW_TRANSFORM.flippedV);
-
     return {
       imageId: image.id,
       sourceUrl: image.dziUrl,
       annotations,
-      ...(!isDefaultTransform ? { viewTransform: transform } : {}),
     };
   });
 
@@ -67,7 +58,6 @@ export function serialize(
 /** Result of deserializing an annotation document */
 export interface DeserializeResult {
   readonly byImage: Record<ImageId, Record<AnnotationId, Annotation>>;
-  readonly viewTransforms: Record<ImageId, ViewTransform>;
 }
 
 /**
@@ -96,7 +86,6 @@ export function deserialize(doc: unknown): DeserializeResult {
   }
 
   const byImage: Record<ImageId, Record<AnnotationId, Annotation>> = {};
-  const viewTransforms: Record<ImageId, ViewTransform> = {};
 
   for (const imageEntry of d.images) {
     if (!isObject(imageEntry)) {
@@ -124,30 +113,9 @@ export function deserialize(doc: unknown): DeserializeResult {
     }
 
     byImage[imageId] = annMap;
-
-    let viewTransform = { ...DEFAULT_VIEW_TRANSFORM };
-    if (entry.viewTransform !== undefined) {
-      if (!isObject(entry.viewTransform)) {
-        throw new SerializationError(`Invalid viewTransform in image ${entry.imageId}`);
-      }
-      const vt = entry.viewTransform as Record<string, unknown>;
-      if (
-        typeof vt.rotation !== 'number' ||
-        typeof vt.flippedH !== 'boolean' ||
-        typeof vt.flippedV !== 'boolean'
-      ) {
-        throw new SerializationError(`Invalid viewTransform shape in image ${entry.imageId}`);
-      }
-      viewTransform = {
-        rotation: vt.rotation,
-        flippedH: vt.flippedH,
-        flippedV: vt.flippedV,
-      };
-    }
-    viewTransforms[imageId] = viewTransform;
   }
 
-  return { byImage, viewTransforms };
+  return { byImage };
 }
 
 /**

--- a/packages/osdlabel/src/core/types.ts
+++ b/packages/osdlabel/src/core/types.ts
@@ -103,7 +103,7 @@ export interface ImageAnnotations {
   readonly imageId: ImageId;
   readonly sourceUrl: string;
   readonly annotations: readonly Annotation[];
-  readonly viewTransform?: ViewTransform | undefined;
+
 }
 
 // ── Constraint System ────────────────────────────────────────────────────
@@ -138,30 +138,21 @@ export interface ImageSource {
   readonly label?: string | undefined;
 }
 
-// ── View Transform ───────────────────────────────────────────────────────
-
-/** Per-image view transform (rotation/flip state) */
-export interface ViewTransform {
-  readonly rotation: number; // degrees (0, 90, 180, 270)
-  readonly flippedH: boolean;
-  readonly flippedV: boolean;
-}
-
-export const DEFAULT_VIEW_TRANSFORM: ViewTransform = {
-  rotation: 0,
-  flippedH: false,
-  flippedV: false,
-};
-
 // ── Cell Transform ───────────────────────────────────────────────────────
 
 /** Per-cell visual adjustments (not serialized) */
 export interface CellTransform {
+  readonly rotation: number; // degrees (0, 90, 180, 270)
+  readonly flippedH: boolean;
+  readonly flippedV: boolean;
   readonly exposure: number; // -1 to 1 (0 = default, maps to CSS brightness 0.0–2.0)
   readonly inverted: boolean; // false = normal, true = CSS invert(1)
 }
 
 export const DEFAULT_CELL_TRANSFORM: CellTransform = {
+  rotation: 0,
+  flippedH: false,
+  flippedV: false,
   exposure: 0,
   inverted: false,
 };
@@ -175,7 +166,6 @@ export const DEFAULT_CELL_TRANSFORM: CellTransform = {
 /** Root state for the annotation system */
 export interface AnnotationState {
   byImage: Record<ImageId, Record<AnnotationId, Annotation>>;
-  viewTransforms: Record<ImageId, ViewTransform>;
   /** Monotonically increasing counter; incremented on every mutation for O(1) change detection */
   changeCounter: number;
 }

--- a/packages/osdlabel/src/index.ts
+++ b/packages/osdlabel/src/index.ts
@@ -19,7 +19,7 @@ export type {
   ConstraintStatus,
   KeyboardShortcutMap,
   RawAnnotationData,
-  ViewTransform,
+  CellTransform,
 } from './core/types.js';
 
 // ID factory functions
@@ -27,7 +27,7 @@ export {
   createAnnotationId,
   createImageId,
   createAnnotationContextId,
-  DEFAULT_VIEW_TRANSFORM,
+  DEFAULT_CELL_TRANSFORM,
 } from './core/types.js';
 
 // Context scoping

--- a/packages/osdlabel/src/overlay/fabric-overlay.ts
+++ b/packages/osdlabel/src/overlay/fabric-overlay.ts
@@ -1,8 +1,8 @@
 import OpenSeadragon from 'openseadragon';
 import { Canvas as FabricCanvas } from 'fabric';
 import type { TMat2D } from 'fabric';
-import type { Point, ViewTransform } from '../core/types.js';
-import { DEFAULT_VIEW_TRANSFORM } from '../core/types.js';
+import type { Point, CellTransform } from '../core/types.js';
+import { DEFAULT_CELL_TRANSFORM } from '../core/types.js';
 
 import {
   POINTER_DOWN,
@@ -214,7 +214,7 @@ export class FabricOverlay {
   }
 
   /** Apply a view transform (rotation/flip) to the OpenSeadragon viewer */
-  applyViewTransform(transform: ViewTransform): void {
+  applyViewTransform(transform: CellTransform): void {
     let rotation = transform.rotation;
     // OSD horizontal flip doesn't natively do vertical flip.
     // Vertical flip = horizontal flip + 180 degree rotation.
@@ -252,7 +252,7 @@ export class FabricOverlay {
   }
 
   resetView(): void {
-    this.applyViewTransform(DEFAULT_VIEW_TRANSFORM);
+    this.applyViewTransform(DEFAULT_CELL_TRANSFORM);
   }
 
   /**

--- a/packages/osdlabel/src/state/actions.ts
+++ b/packages/osdlabel/src/state/actions.ts
@@ -9,11 +9,9 @@ import type {
   AnnotationContext,
   AnnotationContextId,
   ContextState,
-  ViewTransform,
 } from '../core/types.js';
 import { DEFAULT_CELL_TRANSFORM } from '../core/types.js';
 import { isContextScopedToImage } from '../core/context-scoping.js';
-import { DEFAULT_VIEW_TRANSFORM } from '../core/types.js';
 
 export function createActions(
   setAnnotationState: SetStoreFunction<AnnotationState>,
@@ -130,56 +128,53 @@ export function createActions(
 
   function loadAnnotations(
     byImage: Record<ImageId, Record<AnnotationId, Annotation>>,
-    viewTransforms: Record<ImageId, ViewTransform> = {},
   ): void {
     setAnnotationState(
       produce((state) => {
         state.byImage = byImage;
-        state.viewTransforms = viewTransforms;
-        state.changeCounter += 1;
-      }),
-    );
-  }
-
-  function getActiveImageId(): ImageId | undefined {
-    return uiState.gridAssignments[uiState.activeCellIndex];
-  }
-
-  function modifyViewTransform(
-    imageId: ImageId,
-    modifier: (vt: ViewTransform) => ViewTransform,
-  ): void {
-    setAnnotationState(
-      produce((state) => {
-        const current = state.viewTransforms[imageId] ?? { ...DEFAULT_VIEW_TRANSFORM };
-        state.viewTransforms[imageId] = modifier(current);
         state.changeCounter += 1;
       }),
     );
   }
 
   function rotateActiveImageCW(): void {
-    const imageId = getActiveImageId();
-    if (!imageId) return;
-    modifyViewTransform(imageId, (vt) => ({ ...vt, rotation: (vt.rotation + 90) % 360 }));
+    const cellIndex = uiState.activeCellIndex;
+    setUIState(
+      produce((state) => {
+        const current = state.cellTransforms[cellIndex] ?? { ...DEFAULT_CELL_TRANSFORM };
+        state.cellTransforms[cellIndex] = { ...current, rotation: (current.rotation + 90) % 360 };
+      }),
+    );
   }
 
   function rotateActiveImageCCW(): void {
-    const imageId = getActiveImageId();
-    if (!imageId) return;
-    modifyViewTransform(imageId, (vt) => ({ ...vt, rotation: (vt.rotation + 270) % 360 }));
+    const cellIndex = uiState.activeCellIndex;
+    setUIState(
+      produce((state) => {
+        const current = state.cellTransforms[cellIndex] ?? { ...DEFAULT_CELL_TRANSFORM };
+        state.cellTransforms[cellIndex] = { ...current, rotation: (current.rotation + 270) % 360 };
+      }),
+    );
   }
 
   function flipActiveImageH(): void {
-    const imageId = getActiveImageId();
-    if (!imageId) return;
-    modifyViewTransform(imageId, (vt) => ({ ...vt, flippedH: !vt.flippedH }));
+    const cellIndex = uiState.activeCellIndex;
+    setUIState(
+      produce((state) => {
+        const current = state.cellTransforms[cellIndex] ?? { ...DEFAULT_CELL_TRANSFORM };
+        state.cellTransforms[cellIndex] = { ...current, flippedH: !current.flippedH };
+      }),
+    );
   }
 
   function flipActiveImageV(): void {
-    const imageId = getActiveImageId();
-    if (!imageId) return;
-    modifyViewTransform(imageId, (vt) => ({ ...vt, flippedV: !vt.flippedV }));
+    const cellIndex = uiState.activeCellIndex;
+    setUIState(
+      produce((state) => {
+        const current = state.cellTransforms[cellIndex] ?? { ...DEFAULT_CELL_TRANSFORM };
+        state.cellTransforms[cellIndex] = { ...current, flippedV: !current.flippedV };
+      }),
+    );
   }
 
   function toggleActiveImageNegative(): void {
@@ -227,12 +222,6 @@ export function createActions(
   }
 
   function resetActiveImageView(): void {
-    const imageId = getActiveImageId();
-    if (imageId) {
-      modifyViewTransform(imageId, () => ({ ...DEFAULT_VIEW_TRANSFORM }));
-    }
-
-    // Reset only the active cell's adjustments; other cells' transforms remain untouched in state
     const cellIndex = uiState.activeCellIndex;
     setUIState(
       produce((state) => {

--- a/packages/osdlabel/src/state/annotation-store.ts
+++ b/packages/osdlabel/src/state/annotation-store.ts
@@ -4,7 +4,6 @@ import type { AnnotationState } from '../core/types.js';
 export function createAnnotationStore() {
   const [state, setState] = createStore<AnnotationState>({
     byImage: {},
-    viewTransforms: {},
     changeCounter: 0,
   });
   return { state, setState };

--- a/packages/osdlabel/tests/unit/annotations/serialization.test.ts
+++ b/packages/osdlabel/tests/unit/annotations/serialization.test.ts
@@ -16,7 +16,6 @@ import {
   ImageSource,
   AnnotationId,
   ImageId,
-  ViewTransform,
 } from '../../../src/core/types';
 import {
   MAX_COORDINATE,
@@ -70,10 +69,7 @@ describe('Serialization', () => {
     { id: imageId, dziUrl: 'https://example.com/image.dzi', label: 'Test Image' },
   ];
 
-  function createTestState(
-    annotations: Annotation[],
-    viewTransforms: Record<ImageId, ViewTransform> = {},
-  ): AnnotationState {
+  function createTestState(annotations: Annotation[]): AnnotationState {
     const byImage: Record<ImageId, Record<AnnotationId, Annotation>> = {};
     for (const ann of annotations) {
       if (!byImage[ann.imageId]) {
@@ -81,7 +77,7 @@ describe('Serialization', () => {
       }
       byImage[ann.imageId][ann.id] = ann;
     }
-    return { byImage, viewTransforms, changeCounter: 0 };
+    return { byImage, changeCounter: 0 };
   }
 
   describe('serialize', () => {
@@ -95,33 +91,10 @@ describe('Serialization', () => {
       expect(doc.images[0].imageId).toBe(imageId);
       expect(doc.images[0].sourceUrl).toBe('https://example.com/image.dzi');
       expect(doc.images[0].annotations).toHaveLength(2);
-      expect(doc.images[0].viewTransform).toBeUndefined();
-    });
-
-    it('should include viewTransform when non-default', () => {
-      const state = createTestState([annotation1], {
-        [imageId]: { rotation: 90, flippedH: true, flippedV: false },
-      });
-      const doc = serialize(state, imageSources);
-
-      expect(doc.images[0].viewTransform).toEqual({
-        rotation: 90,
-        flippedH: true,
-        flippedV: false,
-      });
-    });
-
-    it('should omit viewTransform when it matches default', () => {
-      const state = createTestState([annotation1], {
-        [imageId]: { rotation: 0, flippedH: false, flippedV: false },
-      });
-      const doc = serialize(state, imageSources);
-
-      expect(doc.images[0].viewTransform).toBeUndefined();
     });
 
     it('should handle empty state', () => {
-      const state: AnnotationState = { byImage: {}, viewTransforms: {}, changeCounter: 0 };
+      const state: AnnotationState = { byImage: {}, changeCounter: 0 };
       const doc = serialize(state, imageSources);
 
       expect(doc.version).toBe('1.0.0');
@@ -150,13 +123,11 @@ describe('Serialization', () => {
 
   describe('deserialize', () => {
     it('should round-trip serialize → deserialize preserving all data', () => {
-      const state = createTestState([annotation1, annotation2], {
-        [imageId]: { rotation: 180, flippedH: false, flippedV: true },
-      });
+      const state = createTestState([annotation1, annotation2]);
       const doc = serialize(state, imageSources);
       const json = JSON.stringify(doc);
       const parsed: unknown = JSON.parse(json);
-      const { byImage: result, viewTransforms } = deserialize(parsed);
+      const { byImage: result } = deserialize(parsed);
 
       expect(result[imageId]).toBeDefined();
       const restoredAnn1 = result[imageId][annId1];
@@ -168,11 +139,9 @@ describe('Serialization', () => {
 
       const restoredAnn2 = result[imageId][annId2];
       expect(restoredAnn2.geometry).toEqual(annotation2.geometry);
-
-      expect(viewTransforms[imageId]).toEqual({ rotation: 180, flippedH: false, flippedV: true });
     });
 
-    it('should default missing viewTransform to DEFAULT_VIEW_TRANSFORM', () => {
+    it('should silently ignore viewTransform in old documents', () => {
       const doc = {
         version: '1.0.0',
         exportedAt: '2024-01-01T00:00:00.000Z',
@@ -181,67 +150,13 @@ describe('Serialization', () => {
             imageId: 'img1',
             sourceUrl: 'https://example.com',
             annotations: [],
+            viewTransform: { rotation: 90, flippedH: true, flippedV: false },
           },
         ],
       };
 
-      const { viewTransforms } = deserialize(doc);
-      expect(viewTransforms[createImageId('img1')]).toEqual({
-        rotation: 0,
-        flippedH: false,
-        flippedV: false,
-      });
-    });
-
-    it('should reject invalid viewTransform (not an object)', () => {
-      expect(() =>
-        deserialize({
-          version: '1.0.0',
-          exportedAt: '2024-01-01T00:00:00.000Z',
-          images: [
-            {
-              imageId: 'img1',
-              sourceUrl: 'https://example.com',
-              annotations: [],
-              viewTransform: 'not an object',
-            },
-          ],
-        }),
-      ).toThrow(/Invalid viewTransform/);
-    });
-
-    it('should reject viewTransform with wrong field types', () => {
-      expect(() =>
-        deserialize({
-          version: '1.0.0',
-          exportedAt: '2024-01-01T00:00:00.000Z',
-          images: [
-            {
-              imageId: 'img1',
-              sourceUrl: 'https://example.com',
-              annotations: [],
-              viewTransform: { rotation: '90', flippedH: false, flippedV: false },
-            },
-          ],
-        }),
-      ).toThrow(/Invalid viewTransform shape/);
-    });
-
-    it('should reject viewTransform with missing fields', () => {
-      expect(() =>
-        deserialize({
-          version: '1.0.0',
-          exportedAt: '2024-01-01T00:00:00.000Z',
-          images: [
-            {
-              imageId: 'img1',
-              sourceUrl: 'https://example.com',
-              annotations: [],
-              viewTransform: { rotation: 90 },
-            },
-          ],
-        }),
-      ).toThrow(/Invalid viewTransform shape/);
+      const { byImage } = deserialize(doc);
+      expect(byImage[createImageId('img1')]).toEqual({});
     });
 
     it('should reject non-object input', () => {
@@ -547,7 +462,7 @@ describe('Serialization', () => {
     });
 
     it('should return empty array for empty state', () => {
-      const state: AnnotationState = { byImage: {}, viewTransforms: {}, changeCounter: 0 };
+      const state: AnnotationState = { byImage: {}, changeCounter: 0 };
       expect(getAllAnnotationsFlat(state)).toEqual([]);
     });
   });

--- a/packages/osdlabel/tests/unit/state/view-transform-actions.test.ts
+++ b/packages/osdlabel/tests/unit/state/view-transform-actions.test.ts
@@ -5,7 +5,7 @@ import { createUIStore } from '../../../src/state/ui-store';
 import { createContextStore } from '../../../src/state/context-store';
 import { createActions } from '../../../src/state/actions';
 import { createImageId } from '../../../src/core/types';
-import { DEFAULT_VIEW_TRANSFORM } from '../../../src/core/types';
+import { DEFAULT_CELL_TRANSFORM } from '../../../src/core/types';
 
 describe('View Transform Actions', () => {
   function createTestStore() {
@@ -29,30 +29,30 @@ describe('View Transform Actions', () => {
   const dummyImageId = createImageId('img1');
 
   it('rotateActiveImageCW rotates by 90 degrees', () => {
-    const { annotationState, setUIState, actions, dispose } = createTestStore();
+    const { uiState, setUIState, actions, dispose } = createTestStore();
     setUIState('gridAssignments', 0, dummyImageId);
 
     actions.rotateActiveImageCW();
-    expect(annotationState.viewTransforms[dummyImageId]).toEqual({
-      ...DEFAULT_VIEW_TRANSFORM,
+    expect(uiState.cellTransforms[0]).toEqual({
+      ...DEFAULT_CELL_TRANSFORM,
       rotation: 90,
     });
 
     actions.rotateActiveImageCW();
-    expect(annotationState.viewTransforms[dummyImageId]).toEqual({
-      ...DEFAULT_VIEW_TRANSFORM,
+    expect(uiState.cellTransforms[0]).toEqual({
+      ...DEFAULT_CELL_TRANSFORM,
       rotation: 180,
     });
 
     actions.rotateActiveImageCW();
-    expect(annotationState.viewTransforms[dummyImageId]).toEqual({
-      ...DEFAULT_VIEW_TRANSFORM,
+    expect(uiState.cellTransforms[0]).toEqual({
+      ...DEFAULT_CELL_TRANSFORM,
       rotation: 270,
     });
 
     actions.rotateActiveImageCW();
-    expect(annotationState.viewTransforms[dummyImageId]).toEqual({
-      ...DEFAULT_VIEW_TRANSFORM,
+    expect(uiState.cellTransforms[0]).toEqual({
+      ...DEFAULT_CELL_TRANSFORM,
       rotation: 0,
     });
 
@@ -60,30 +60,30 @@ describe('View Transform Actions', () => {
   });
 
   it('rotateActiveImageCCW rotates by -90 degrees (270)', () => {
-    const { annotationState, setUIState, actions, dispose } = createTestStore();
+    const { uiState, setUIState, actions, dispose } = createTestStore();
     setUIState('gridAssignments', 0, dummyImageId);
 
     actions.rotateActiveImageCCW();
-    expect(annotationState.viewTransforms[dummyImageId]).toEqual({
-      ...DEFAULT_VIEW_TRANSFORM,
+    expect(uiState.cellTransforms[0]).toEqual({
+      ...DEFAULT_CELL_TRANSFORM,
       rotation: 270,
     });
 
     actions.rotateActiveImageCCW();
-    expect(annotationState.viewTransforms[dummyImageId]).toEqual({
-      ...DEFAULT_VIEW_TRANSFORM,
+    expect(uiState.cellTransforms[0]).toEqual({
+      ...DEFAULT_CELL_TRANSFORM,
       rotation: 180,
     });
 
     actions.rotateActiveImageCCW();
-    expect(annotationState.viewTransforms[dummyImageId]).toEqual({
-      ...DEFAULT_VIEW_TRANSFORM,
+    expect(uiState.cellTransforms[0]).toEqual({
+      ...DEFAULT_CELL_TRANSFORM,
       rotation: 90,
     });
 
     actions.rotateActiveImageCCW();
-    expect(annotationState.viewTransforms[dummyImageId]).toEqual({
-      ...DEFAULT_VIEW_TRANSFORM,
+    expect(uiState.cellTransforms[0]).toEqual({
+      ...DEFAULT_CELL_TRANSFORM,
       rotation: 0,
     });
 
@@ -91,18 +91,18 @@ describe('View Transform Actions', () => {
   });
 
   it('flipActiveImageH toggles horizontal flip', () => {
-    const { annotationState, setUIState, actions, dispose } = createTestStore();
+    const { uiState, setUIState, actions, dispose } = createTestStore();
     setUIState('gridAssignments', 0, dummyImageId);
 
     actions.flipActiveImageH();
-    expect(annotationState.viewTransforms[dummyImageId]).toEqual({
-      ...DEFAULT_VIEW_TRANSFORM,
+    expect(uiState.cellTransforms[0]).toEqual({
+      ...DEFAULT_CELL_TRANSFORM,
       flippedH: true,
     });
 
     actions.flipActiveImageH();
-    expect(annotationState.viewTransforms[dummyImageId]).toEqual({
-      ...DEFAULT_VIEW_TRANSFORM,
+    expect(uiState.cellTransforms[0]).toEqual({
+      ...DEFAULT_CELL_TRANSFORM,
       flippedH: false,
     });
 
@@ -110,18 +110,18 @@ describe('View Transform Actions', () => {
   });
 
   it('flipActiveImageV toggles vertical flip', () => {
-    const { annotationState, setUIState, actions, dispose } = createTestStore();
+    const { uiState, setUIState, actions, dispose } = createTestStore();
     setUIState('gridAssignments', 0, dummyImageId);
 
     actions.flipActiveImageV();
-    expect(annotationState.viewTransforms[dummyImageId]).toEqual({
-      ...DEFAULT_VIEW_TRANSFORM,
+    expect(uiState.cellTransforms[0]).toEqual({
+      ...DEFAULT_CELL_TRANSFORM,
       flippedV: true,
     });
 
     actions.flipActiveImageV();
-    expect(annotationState.viewTransforms[dummyImageId]).toEqual({
-      ...DEFAULT_VIEW_TRANSFORM,
+    expect(uiState.cellTransforms[0]).toEqual({
+      ...DEFAULT_CELL_TRANSFORM,
       flippedV: false,
     });
 
@@ -129,45 +129,36 @@ describe('View Transform Actions', () => {
   });
 
   it('resetActiveImageView resets to default transform', () => {
-    const { annotationState, setUIState, actions, dispose } = createTestStore();
+    const { uiState, setUIState, actions, dispose } = createTestStore();
     setUIState('gridAssignments', 0, dummyImageId);
 
     actions.rotateActiveImageCW();
     actions.flipActiveImageH();
 
     actions.resetActiveImageView();
-    expect(annotationState.viewTransforms[dummyImageId]).toEqual(DEFAULT_VIEW_TRANSFORM);
+    expect(uiState.cellTransforms[0]).toEqual(DEFAULT_CELL_TRANSFORM);
 
     dispose();
   });
 
-  it('actions are no-op when no active image', () => {
-    const { annotationState, actions, dispose } = createTestStore();
-
-    actions.rotateActiveImageCW();
-    actions.flipActiveImageH();
-
-    expect(annotationState.viewTransforms).toEqual({});
-
-    dispose();
-  });
-
-  it('only affects the active image', () => {
-    const { annotationState, setUIState, actions, dispose } = createTestStore();
-    const otherImageId = createImageId('img2');
-
+  it('only affects the active cell', () => {
+    const { uiState, setUIState, actions, dispose } = createTestStore();
     setUIState('gridAssignments', 0, dummyImageId);
+    setUIState('gridAssignments', 1, dummyImageId);
+
+    // Flip on cell 0
     actions.flipActiveImageH();
 
-    setUIState('gridAssignments', 0, otherImageId);
+    // Switch to cell 1 and rotate
+    setUIState('activeCellIndex', 1);
     actions.rotateActiveImageCW();
 
-    expect(annotationState.viewTransforms[dummyImageId]).toEqual({
-      ...DEFAULT_VIEW_TRANSFORM,
+    expect(uiState.cellTransforms[0]).toEqual({
+      ...DEFAULT_CELL_TRANSFORM,
       flippedH: true,
     });
-    expect(annotationState.viewTransforms[otherImageId]).toEqual({
-      ...DEFAULT_VIEW_TRANSFORM,
+    expect(uiState.cellTransforms[1]).toEqual({
+      ...DEFAULT_CELL_TRANSFORM,
       rotation: 90,
     });
 


### PR DESCRIPTION
Merge ViewTransform into CellTransform so rotation and flip are per-cell (like exposure/negative), allowing the same image to display with different orientations in different grid cells. Drop viewTransform serialization.