### PR TITLE
refactor: remove metadata field from annotations

### DIFF
--- a/packages/annotation/src/annotation.ts
+++ b/packages/annotation/src/annotation.ts
@@ -9,7 +9,6 @@ export interface BaseAnnotation {
   readonly geometry: Geometry;
   readonly toolType: ToolType;
   readonly label?: string | undefined;
-  readonly metadata?: Readonly<Record<string, unknown>> | undefined;
   readonly createdAt: string;
   readonly updatedAt: string;
 }

--- a/packages/fabric-annotations/src/tools/base-tool.ts
+++ b/packages/fabric-annotations/src/tools/base-tool.ts
@@ -11,7 +11,6 @@ export interface AddAnnotationParams {
   readonly contextId: AnnotationContextId;
   readonly type: ToolType;
   readonly label?: string;
-  readonly metadata?: Readonly<Record<string, unknown>>;
 }
 
 /** Framework-agnostic callbacks that tools use to interact with application state */

--- a/packages/osdlabel/src/hooks/useAnnotationTool.ts
+++ b/packages/osdlabel/src/hooks/useAnnotationTool.ts
@@ -147,14 +147,7 @@ export function useAnnotationTool(
         return status[toolType].enabled;
       },
       addAnnotation: (params: AddAnnotationParams) => {
-        const {
-          fabricObject,
-          imageId: imgIdParam,
-          contextId,
-          type: annType,
-          label,
-          metadata,
-        } = params;
+        const { fabricObject, imageId: imgIdParam, contextId, type: annType, label } = params;
 
         // Read the annotation ID set by the tool via module augmentation
         const id = fabricObject.id as AnnotationId;
@@ -177,7 +170,6 @@ export function useAnnotationTool(
           toolType: annType,
           rawAnnotationData,
           label,
-          metadata,
         });
       },
       updateAnnotation: (id: AnnotationId, imageIdArg: ImageId, fabricObject: FabricObject) => {


### PR DESCRIPTION
Removes the optional metadata property from BaseAnnotation interface, AddAnnotationParams, and associated hook implementations.