### PR TITLE
feat: make hit detection configurable and precise

### DIFF
--- a/packages/fabric-annotations/src/fabric-utils.ts
+++ b/packages/fabric-annotations/src/fabric-utils.ts
@@ -12,7 +12,16 @@ import {
 import type { Annotation, AnnotationStyle, Geometry, GeometryType } from '@osdlabel/annotation';
 import type { FabricFields, FabricRawAnnotationData } from './types.js';
 
-export function getFabricOptions(style: AnnotationStyle, id: string) {
+export interface FabricHitDetectionOptions {
+  perPixelTargetFind?: boolean;
+  targetFindTolerance?: number;
+}
+
+export function getFabricOptions(
+  style: AnnotationStyle,
+  id: string,
+  hitOptions: FabricHitDetectionOptions = {}
+) {
   const fill = new Color(style.fillColor);
   if (style.fillOpacity !== undefined) {
     fill.setAlpha(style.fillOpacity);
@@ -26,6 +35,8 @@ export function getFabricOptions(style: AnnotationStyle, id: string) {
     opacity: style.opacity,
     id,
     strokeUniform: true,
+    perPixelTargetFind: hitOptions.perPixelTargetFind ?? true,
+    targetFindTolerance: hitOptions.targetFindTolerance ?? 5,
   };
 }
 

--- a/packages/validation/src/schemas/fabric-data.ts
+++ b/packages/validation/src/schemas/fabric-data.ts
@@ -99,6 +99,12 @@ function validatePolylineRequirements(data: LooseData): boolean {
   return true;
 }
 
+function validateHitDetectionProps(data: LooseData): boolean {
+  if (data.perPixelTargetFind !== undefined && typeof data.perPixelTargetFind !== 'boolean') return false;
+  if (data.targetFindTolerance !== undefined && !isFiniteNum(data.targetFindTolerance)) return false;
+  return true;
+}
+
 // ── Fabric data object schema ───────────────────────────────────────────
 
 const FabricDataObjectSchema = v.pipe(
@@ -108,6 +114,7 @@ const FabricDataObjectSchema = v.pipe(
   v.check(validateNumericProps),
   v.check(validateDimensionProps),
   v.check(validateStringProps),
+  v.check(validateHitDetectionProps),
   v.check(validateRectRequirements),
   v.check(validateCircleRequirements),
   v.check(validateLineRequirements),


### PR DESCRIPTION
Add optional hitOptions parameter to getFabricOptions with perPixelTargetFind and targetFindTolerance to narrow detection to actual shape geometry. Also adds validation to FabricRawAnnotationDataSchema.