### PR TITLE
docs: add interactive demo app page

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -86,6 +86,7 @@ export default defineConfig({
             { label: 'Minimal Viewer', slug: 'examples/minimal-viewer' },
             { label: 'Multiple Annotation Contexts', slug: 'examples/multiple-contexts' },
             { label: 'Custom Toolbar', slug: 'examples/custom-toolbar' },
+            { label: 'Interactive Demo', link: '/demo/' },
           ],
         },
       ],

--- a/apps/docs/src/components/demos/full-demo/AnnotateView.tsx
+++ b/apps/docs/src/components/demos/full-demo/AnnotateView.tsx
@@ -1,0 +1,337 @@
+import { createSignal, createEffect, For } from 'solid-js';
+import {
+  Toolbar,
+  StatusBar,
+  GridView,
+  Filmstrip,
+  GridControls,
+  ViewControls,
+  AnnotatorProvider,
+  useAnnotator,
+  serialize,
+  deserialize,
+} from '@osdlabel/solid';
+import type {
+  AnnotationContextId,
+  AnnotationContext,
+  ImageSource,
+} from '@osdlabel/solid';
+
+export interface AnnotateViewProps {
+  images: readonly ImageSource[];
+  contexts: readonly AnnotationContext[];
+  onReconfigure: () => void;
+}
+
+function AppContent(props: AnnotateViewProps) {
+  const { uiState, annotationState, actions, activeImageId } = useAnnotator();
+  const [copyLabel, setCopyLabel] = createSignal('Copy JSON');
+  const [activeCtxIdx, setActiveCtxIdx] = createSignal(0);
+  const [exportedJson, setExportedJson] = createSignal('');
+  const [showImportPanel, setShowImportPanel] = createSignal(false);
+  const [importJsonText, setImportJsonText] = createSignal('');
+  const [displayedCtxIds, setDisplayedCtxIds] = createSignal<AnnotationContextId[]>([]);
+
+  createEffect(() => {
+    actions.setDisplayedContexts(displayedCtxIds());
+  });
+
+  // Initialize contexts and active image
+  actions.setContexts([...props.contexts]);
+  if (props.contexts[0]) {
+    actions.setActiveContext(props.contexts[0].id);
+  }
+  if (props.images[0]) {
+    actions.assignImageToCell(0, props.images[0].id);
+  }
+
+  const copyAnnotationsToClipboard = () => {
+    const json = JSON.stringify(annotationState.byImage, null, 2);
+    navigator.clipboard
+      .writeText(json)
+      .then(() => {
+        setCopyLabel('Copied!');
+        setTimeout(() => setCopyLabel('Copy JSON'), 1500);
+      })
+      .catch(() => {
+        setCopyLabel('Failed');
+        setTimeout(() => setCopyLabel('Copy JSON'), 1500);
+      });
+  };
+
+  const handleExportJson = () => {
+    const doc = serialize(annotationState);
+    setExportedJson(JSON.stringify(doc, null, 2));
+  };
+
+  const openImportPanel = () => {
+    setImportJsonText('');
+    setShowImportPanel(true);
+  };
+
+  const confirmImport = () => {
+    const json = importJsonText();
+    if (!json.trim()) return;
+    try {
+      const parsed: unknown = JSON.parse(json);
+      const { byImage } = deserialize(parsed);
+      actions.loadAnnotations(byImage);
+      setShowImportPanel(false);
+      setImportJsonText('');
+    } catch (err) {
+      alert(`Import failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  };
+
+  const handleContextChange = (e: Event) => {
+    const select = e.target as HTMLSelectElement;
+    const idx = parseInt(select.value, 10);
+    setActiveCtxIdx(idx);
+    const ctx = props.contexts[idx];
+    if (ctx) actions.setActiveContext(ctx.id);
+    actions.setActiveTool(null);
+  };
+
+  const buttonStyle = {
+    padding: '4px 12px',
+    border: '1px solid #555',
+    'border-radius': '4px',
+    cursor: 'pointer',
+    background: '#2a2a3e',
+    color: '#fff',
+    'font-size': '12px',
+  };
+
+  return (
+    <div style={{ width: '100%', height: '100%', display: 'flex', 'flex-direction': 'column' }}>
+      <div
+        style={{
+          padding: '8px 12px',
+          background: '#1a1a2e',
+          color: '#fff',
+          display: 'flex',
+          gap: '12px',
+          'align-items': 'center',
+          'font-family': 'system-ui, sans-serif',
+          'font-size': '14px',
+          'flex-shrink': '0',
+          'flex-wrap': 'wrap',
+        }}
+      >
+        <select
+          value={activeCtxIdx()}
+          onChange={handleContextChange}
+          style={{
+            padding: '4px 8px',
+            'border-radius': '4px',
+            border: '1px solid #555',
+            background: '#2a2a3e',
+            color: '#fff',
+            'font-size': '13px',
+          }}
+        >
+          <For each={props.contexts}>
+            {(ctx, i) => <option value={i()}>{ctx.label}</option>}
+          </For>
+        </select>
+
+        <div style={{ display: 'flex', gap: '8px', 'align-items': 'center' }}>
+          <span style={{ 'font-size': '12px', color: '#aaa' }}>Show:</span>
+          <For each={props.contexts}>
+            {(ctx) => (
+              <label
+                style={{
+                  display: 'flex',
+                  gap: '4px',
+                  'align-items': 'center',
+                  'font-size': '12px',
+                  cursor: 'pointer',
+                }}
+              >
+                <input
+                  type="checkbox"
+                  checked={displayedCtxIds().includes(ctx.id)}
+                  onChange={(e) => {
+                    const checked = e.currentTarget.checked;
+                    setDisplayedCtxIds((prev) =>
+                      checked ? [...prev, ctx.id] : prev.filter((id) => id !== ctx.id),
+                    );
+                  }}
+                />
+                {ctx.label}
+              </label>
+            )}
+          </For>
+        </div>
+
+        <Toolbar />
+        <ViewControls />
+        <GridControls maxColumns={4} maxRows={4} />
+
+        <div style={{ 'margin-left': 'auto', display: 'flex', gap: '6px' }}>
+          <button onClick={copyAnnotationsToClipboard} style={buttonStyle}>
+            {copyLabel()}
+          </button>
+          <button onClick={handleExportJson} style={buttonStyle}>
+            Export JSON
+          </button>
+          <button onClick={openImportPanel} style={buttonStyle}>
+            Import JSON
+          </button>
+          <button
+            onClick={props.onReconfigure}
+            style={{ ...buttonStyle, background: '#3e2a1a', 'border-color': '#8a5a2a' }}
+          >
+            Reconfigure
+          </button>
+        </div>
+      </div>
+
+      <div style={{ display: 'flex', flex: '1', 'min-height': '0' }}>
+        <Filmstrip images={[...props.images]} position="left" />
+        <div style={{ flex: '1', 'min-width': '0', 'min-height': '0' }}>
+          <GridView
+            columns={uiState.gridColumns}
+            rows={uiState.gridRows}
+            maxColumns={4}
+            maxRows={4}
+            images={[...props.images]}
+          />
+        </div>
+      </div>
+
+      <StatusBar imageId={activeImageId()} showFps={true} />
+
+      {showImportPanel() && (
+        <div
+          style={{
+            position: 'fixed',
+            bottom: '40px',
+            left: '10px',
+            width: '400px',
+            'max-height': '340px',
+            background: '#1a1a2e',
+            border: '1px solid #555',
+            'border-radius': '8px',
+            padding: '8px',
+            'z-index': '1000',
+            display: 'flex',
+            'flex-direction': 'column',
+            gap: '6px',
+          }}
+        >
+          <div
+            style={{ display: 'flex', 'justify-content': 'space-between', 'align-items': 'center' }}
+          >
+            <span style={{ color: '#fff', 'font-size': '12px', 'font-weight': 'bold' }}>
+              Import JSON
+            </span>
+            <button
+              onClick={() => setShowImportPanel(false)}
+              style={{
+                background: 'none',
+                border: 'none',
+                color: '#aaa',
+                cursor: 'pointer',
+                'font-size': '14px',
+              }}
+            >
+              X
+            </button>
+          </div>
+          <textarea
+            placeholder="Paste exported JSON here..."
+            value={importJsonText()}
+            onInput={(e) => setImportJsonText(e.currentTarget.value)}
+            style={{
+              width: '100%',
+              height: '240px',
+              background: '#111',
+              color: '#0f0',
+              border: '1px solid #333',
+              'border-radius': '4px',
+              padding: '6px',
+              'font-family': 'monospace',
+              'font-size': '11px',
+              resize: 'none',
+              'box-sizing': 'border-box',
+            }}
+          />
+          <div style={{ display: 'flex', gap: '6px', 'justify-content': 'flex-end' }}>
+            <button onClick={() => setShowImportPanel(false)} style={buttonStyle}>
+              Close
+            </button>
+            <button
+              onClick={confirmImport}
+              style={{ ...buttonStyle, background: '#1a5c2a', 'border-color': '#2a8a3e' }}
+            >
+              Confirm
+            </button>
+          </div>
+        </div>
+      )}
+
+      {exportedJson() && (
+        <div
+          style={{
+            position: 'fixed',
+            bottom: '40px',
+            right: '10px',
+            width: '400px',
+            'max-height': '300px',
+            background: '#1a1a2e',
+            border: '1px solid #555',
+            'border-radius': '8px',
+            padding: '8px',
+            overflow: 'auto',
+            'z-index': '1000',
+          }}
+        >
+          <div
+            style={{ display: 'flex', 'justify-content': 'space-between', 'margin-bottom': '4px' }}
+          >
+            <span style={{ color: '#fff', 'font-size': '12px', 'font-weight': 'bold' }}>
+              Exported JSON
+            </span>
+            <button
+              onClick={() => setExportedJson('')}
+              style={{
+                background: 'none',
+                border: 'none',
+                color: '#aaa',
+                cursor: 'pointer',
+                'font-size': '14px',
+              }}
+            >
+              X
+            </button>
+          </div>
+          <textarea
+            value={exportedJson()}
+            onInput={(e) => setExportedJson(e.currentTarget.value)}
+            style={{
+              width: '100%',
+              height: '240px',
+              background: '#111',
+              color: '#0f0',
+              border: 'none',
+              'border-radius': '4px',
+              padding: '6px',
+              'font-family': 'monospace',
+              'font-size': '11px',
+              resize: 'none',
+            }}
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function AnnotateView(props: AnnotateViewProps) {
+  return (
+    <AnnotatorProvider>
+      <AppContent {...props} />
+    </AnnotatorProvider>
+  );
+}

--- a/apps/docs/src/components/demos/full-demo/ConfigPanel.tsx
+++ b/apps/docs/src/components/demos/full-demo/ConfigPanel.tsx
@@ -1,0 +1,553 @@
+import { createStore } from 'solid-js/store';
+import { For, Show, createMemo } from 'solid-js';
+import { createImageId, createAnnotationContextId } from '@osdlabel/solid';
+import type {
+  ImageSource,
+  AnnotationContext,
+  ToolConstraint,
+  ToolType,
+} from '@osdlabel/solid';
+import { TOOL_TYPES } from './defaults.js';
+
+interface DraftImage {
+  id: string;
+  tileSource: string;
+  label: string;
+  thumbnailUrl: string;
+}
+
+interface DraftTool {
+  type: ToolType;
+  maxCount: string;
+  countScope: '' | 'per-image' | 'per-context';
+}
+
+interface DraftContext {
+  id: string;
+  label: string;
+  imageIds: string[];
+  tools: DraftTool[];
+}
+
+interface ConfigDraft {
+  images: DraftImage[];
+  contexts: DraftContext[];
+}
+
+function imageToDraft(img: ImageSource): DraftImage {
+  return {
+    id: img.id as string,
+    tileSource: img.tileSource,
+    label: img.label ?? '',
+    thumbnailUrl: img.thumbnailUrl ?? '',
+  };
+}
+
+function contextToDraft(ctx: AnnotationContext): DraftContext {
+  return {
+    id: ctx.id as string,
+    label: ctx.label,
+    imageIds: ctx.imageIds ? (ctx.imageIds as readonly string[]).slice() : [],
+    tools: ctx.tools.map((t) => ({
+      type: t.type,
+      maxCount: t.maxCount !== undefined ? String(t.maxCount) : '',
+      countScope: t.countScope ?? '',
+    })),
+  };
+}
+
+export interface ConfigPanelProps {
+  initialImages: readonly ImageSource[];
+  initialContexts: readonly AnnotationContext[];
+  onLaunch: (images: ImageSource[], contexts: AnnotationContext[]) => void;
+}
+
+const inputStyle = {
+  padding: '4px 6px',
+  background: '#111',
+  color: '#fff',
+  border: '1px solid #333',
+  'border-radius': '4px',
+  'font-size': '12px',
+  'font-family': 'inherit',
+};
+
+const buttonStyle = {
+  padding: '4px 10px',
+  border: '1px solid #555',
+  'border-radius': '4px',
+  cursor: 'pointer',
+  background: '#2a2a3e',
+  color: '#fff',
+  'font-size': '12px',
+};
+
+const dangerButtonStyle = {
+  ...buttonStyle,
+  background: '#3e1a1a',
+  'border-color': '#8a2a2a',
+};
+
+const primaryButtonStyle = {
+  ...buttonStyle,
+  background: '#1a5c2a',
+  'border-color': '#2a8a3e',
+  padding: '8px 16px',
+  'font-size': '14px',
+  'font-weight': 'bold',
+};
+
+const labelStyle = {
+  display: 'flex',
+  'flex-direction': 'column' as const,
+  gap: '2px',
+  'font-size': '11px',
+  color: '#aaa',
+  flex: '1',
+  'min-width': '0',
+};
+
+const cardStyle = {
+  background: '#1a1a2e',
+  border: '1px solid #333',
+  'border-radius': '6px',
+  padding: '10px',
+  display: 'flex',
+  'flex-direction': 'column' as const,
+  gap: '8px',
+};
+
+export default function ConfigPanel(props: ConfigPanelProps) {
+  const [draft, setDraft] = createStore<ConfigDraft>({
+    images: props.initialImages.map(imageToDraft),
+    contexts: props.initialContexts.map(contextToDraft),
+  });
+
+  const errors = createMemo(() => {
+    const errs: string[] = [];
+    if (draft.images.length === 0) errs.push('Add at least one image.');
+    if (draft.contexts.length === 0) errs.push('Add at least one context.');
+
+    const imgIds = draft.images.map((i) => i.id.trim());
+    if (imgIds.some((id) => id === '')) errs.push('All image IDs must be non-empty.');
+    if (draft.images.some((i) => i.tileSource.trim() === ''))
+      errs.push('All images need a tile source URL.');
+    const nonEmptyImg = imgIds.filter(Boolean);
+    if (new Set(nonEmptyImg).size !== nonEmptyImg.length)
+      errs.push('Image IDs must be unique.');
+
+    const ctxIds = draft.contexts.map((c) => c.id.trim());
+    if (ctxIds.some((id) => id === '')) errs.push('All context IDs must be non-empty.');
+    const nonEmptyCtx = ctxIds.filter(Boolean);
+    if (new Set(nonEmptyCtx).size !== nonEmptyCtx.length)
+      errs.push('Context IDs must be unique.');
+
+    for (const ctx of draft.contexts) {
+      const name = ctx.label || ctx.id || '(unnamed)';
+      if (ctx.tools.length === 0) errs.push(`Context "${name}" needs at least one tool.`);
+      for (const imgId of ctx.imageIds) {
+        if (!imgIds.includes(imgId))
+          errs.push(`Context "${name}" references unknown image "${imgId}".`);
+      }
+    }
+    return errs;
+  });
+
+  const isValid = () => errors().length === 0;
+
+  const launch = () => {
+    if (!isValid()) return;
+    const images: ImageSource[] = draft.images.map((d) => {
+      const base = {
+        id: createImageId(d.id.trim()),
+        tileSource: d.tileSource.trim(),
+      };
+      const label = d.label.trim();
+      const thumbnailUrl = d.thumbnailUrl.trim();
+      return {
+        ...base,
+        ...(label ? { label } : {}),
+        ...(thumbnailUrl ? { thumbnailUrl } : {}),
+      };
+    });
+    const contexts: AnnotationContext[] = draft.contexts.map((d) => {
+      const tools: ToolConstraint[] = d.tools.map((t) => {
+        const constraint: { type: ToolType; maxCount?: number; countScope?: 'per-image' | 'per-context' } = {
+          type: t.type,
+        };
+        const trimmed = t.maxCount.trim();
+        if (trimmed !== '') {
+          const n = Number(trimmed);
+          if (Number.isFinite(n) && n > 0) constraint.maxCount = Math.floor(n);
+        }
+        if (t.countScope !== '') constraint.countScope = t.countScope;
+        return constraint;
+      });
+      const base = {
+        id: createAnnotationContextId(d.id.trim()),
+        label: d.label.trim() || d.id.trim(),
+        tools,
+      };
+      return d.imageIds.length > 0
+        ? { ...base, imageIds: d.imageIds.map((id) => createImageId(id)) }
+        : base;
+    });
+    props.onLaunch(images, contexts);
+  };
+
+  const addImage = () => {
+    setDraft('images', (imgs) => [
+      ...imgs,
+      { id: `image-${imgs.length + 1}`, tileSource: '', label: '', thumbnailUrl: '' },
+    ]);
+  };
+
+  const addContext = () => {
+    setDraft('contexts', (cs) => [
+      ...cs,
+      {
+        id: `ctx-${cs.length + 1}`,
+        label: '',
+        imageIds: [],
+        tools: [{ type: 'rectangle', maxCount: '', countScope: '' }],
+      },
+    ]);
+  };
+
+  return (
+    <div
+      style={{
+        width: '100%',
+        height: '100%',
+        overflow: 'auto',
+        background: '#0f0f1e',
+        color: '#fff',
+        'font-family': 'system-ui, sans-serif',
+        'box-sizing': 'border-box',
+        padding: '20px',
+      }}
+    >
+      <div style={{ 'max-width': '900px', margin: '0 auto', display: 'flex', 'flex-direction': 'column', gap: '20px' }}>
+        <header>
+          <h1 style={{ margin: '0 0 4px 0', 'font-size': '24px' }}>osdlabel demo</h1>
+          <p style={{ margin: '0', color: '#aaa', 'font-size': '13px' }}>
+            Configure your images and annotation contexts, then launch the annotator. The form
+            is pre-filled with sample data &mdash; click Launch to use the defaults.
+          </p>
+        </header>
+
+        {/* Images section */}
+        <section style={cardStyle}>
+          <div style={{ display: 'flex', 'align-items': 'center', 'justify-content': 'space-between' }}>
+            <h2 style={{ margin: '0', 'font-size': '16px' }}>Images</h2>
+            <button type="button" onClick={addImage} style={buttonStyle}>
+              + Add image
+            </button>
+          </div>
+          <For each={draft.images}>
+            {(img, i) => (
+              <div
+                style={{
+                  display: 'grid',
+                  'grid-template-columns': '1fr 2fr 1fr 1fr auto',
+                  gap: '8px',
+                  'align-items': 'end',
+                  padding: '8px',
+                  background: '#15152a',
+                  'border-radius': '4px',
+                }}
+              >
+                <label style={labelStyle}>
+                  <span>ID</span>
+                  <input
+                    type="text"
+                    value={img.id}
+                    onInput={(e) => setDraft('images', i(), 'id', e.currentTarget.value)}
+                    style={inputStyle}
+                  />
+                </label>
+                <label style={labelStyle}>
+                  <span>Tile source (DZI URL or static image URL)</span>
+                  <input
+                    type="text"
+                    value={img.tileSource}
+                    onInput={(e) => setDraft('images', i(), 'tileSource', e.currentTarget.value)}
+                    placeholder="https://example.com/image.dzi"
+                    style={inputStyle}
+                  />
+                </label>
+                <label style={labelStyle}>
+                  <span>Label</span>
+                  <input
+                    type="text"
+                    value={img.label}
+                    onInput={(e) => setDraft('images', i(), 'label', e.currentTarget.value)}
+                    style={inputStyle}
+                  />
+                </label>
+                <label style={labelStyle}>
+                  <span>Thumbnail URL (optional)</span>
+                  <input
+                    type="text"
+                    value={img.thumbnailUrl}
+                    onInput={(e) => setDraft('images', i(), 'thumbnailUrl', e.currentTarget.value)}
+                    style={inputStyle}
+                  />
+                </label>
+                <button
+                  type="button"
+                  onClick={() => setDraft('images', (imgs) => imgs.filter((_, idx) => idx !== i()))}
+                  style={dangerButtonStyle}
+                  aria-label="Remove image"
+                >
+                  Remove
+                </button>
+              </div>
+            )}
+          </For>
+        </section>
+
+        {/* Contexts section */}
+        <section style={cardStyle}>
+          <div style={{ display: 'flex', 'align-items': 'center', 'justify-content': 'space-between' }}>
+            <h2 style={{ margin: '0', 'font-size': '16px' }}>Annotation contexts</h2>
+            <button type="button" onClick={addContext} style={buttonStyle}>
+              + Add context
+            </button>
+          </div>
+          <For each={draft.contexts}>
+            {(ctx, ci) => (
+              <div
+                style={{
+                  padding: '10px',
+                  background: '#15152a',
+                  'border-radius': '4px',
+                  display: 'flex',
+                  'flex-direction': 'column',
+                  gap: '10px',
+                }}
+              >
+                <div
+                  style={{
+                    display: 'grid',
+                    'grid-template-columns': '1fr 1fr auto',
+                    gap: '8px',
+                    'align-items': 'end',
+                  }}
+                >
+                  <label style={labelStyle}>
+                    <span>ID</span>
+                    <input
+                      type="text"
+                      value={ctx.id}
+                      onInput={(e) => setDraft('contexts', ci(), 'id', e.currentTarget.value)}
+                      style={inputStyle}
+                    />
+                  </label>
+                  <label style={labelStyle}>
+                    <span>Label</span>
+                    <input
+                      type="text"
+                      value={ctx.label}
+                      onInput={(e) => setDraft('contexts', ci(), 'label', e.currentTarget.value)}
+                      style={inputStyle}
+                    />
+                  </label>
+                  <button
+                    type="button"
+                    onClick={() => setDraft('contexts', (cs) => cs.filter((_, idx) => idx !== ci()))}
+                    style={dangerButtonStyle}
+                  >
+                    Remove context
+                  </button>
+                </div>
+
+                <div>
+                  <div style={{ 'font-size': '11px', color: '#aaa', 'margin-bottom': '4px' }}>
+                    Applies to images (none selected &rarr; all images)
+                  </div>
+                  <div style={{ display: 'flex', gap: '10px', 'flex-wrap': 'wrap' }}>
+                    <Show
+                      when={draft.images.length > 0}
+                      fallback={<span style={{ color: '#777', 'font-size': '11px' }}>Add images first</span>}
+                    >
+                      <For each={draft.images}>
+                        {(img) => (
+                          <label
+                            style={{
+                              display: 'flex',
+                              gap: '4px',
+                              'align-items': 'center',
+                              'font-size': '12px',
+                              cursor: 'pointer',
+                            }}
+                          >
+                            <input
+                              type="checkbox"
+                              checked={ctx.imageIds.includes(img.id)}
+                              onChange={(e) => {
+                                const checked = e.currentTarget.checked;
+                                setDraft('contexts', ci(), 'imageIds', (ids) =>
+                                  checked ? [...ids, img.id] : ids.filter((x) => x !== img.id),
+                                );
+                              }}
+                            />
+                            {img.label || img.id || '(unnamed)'}
+                          </label>
+                        )}
+                      </For>
+                    </Show>
+                  </div>
+                </div>
+
+                <div>
+                  <div
+                    style={{
+                      display: 'flex',
+                      'align-items': 'center',
+                      'justify-content': 'space-between',
+                      'margin-bottom': '4px',
+                    }}
+                  >
+                    <span style={{ 'font-size': '11px', color: '#aaa' }}>Tools</span>
+                    <button
+                      type="button"
+                      onClick={() =>
+                        setDraft('contexts', ci(), 'tools', (ts) => [
+                          ...ts,
+                          { type: 'rectangle', maxCount: '', countScope: '' },
+                        ])
+                      }
+                      style={buttonStyle}
+                    >
+                      + Add tool
+                    </button>
+                  </div>
+                  <div style={{ display: 'flex', 'flex-direction': 'column', gap: '6px' }}>
+                    <For each={ctx.tools}>
+                      {(tool, ti) => (
+                        <div
+                          style={{
+                            display: 'grid',
+                            'grid-template-columns': '2fr 1fr 1fr auto',
+                            gap: '6px',
+                            'align-items': 'end',
+                          }}
+                        >
+                          <label style={labelStyle}>
+                            <span>Type</span>
+                            <select
+                              value={tool.type}
+                              onChange={(e) =>
+                                setDraft(
+                                  'contexts',
+                                  ci(),
+                                  'tools',
+                                  ti(),
+                                  'type',
+                                  e.currentTarget.value as ToolType,
+                                )
+                              }
+                              style={inputStyle}
+                            >
+                              <For each={TOOL_TYPES}>
+                                {(t) => <option value={t}>{t}</option>}
+                              </For>
+                            </select>
+                          </label>
+                          <label style={labelStyle}>
+                            <span>Max count (optional)</span>
+                            <input
+                              type="number"
+                              min="1"
+                              value={tool.maxCount}
+                              onInput={(e) =>
+                                setDraft('contexts', ci(), 'tools', ti(), 'maxCount', e.currentTarget.value)
+                              }
+                              style={inputStyle}
+                            />
+                          </label>
+                          <label style={labelStyle}>
+                            <span>Count scope</span>
+                            <select
+                              value={tool.countScope}
+                              onChange={(e) =>
+                                setDraft(
+                                  'contexts',
+                                  ci(),
+                                  'tools',
+                                  ti(),
+                                  'countScope',
+                                  e.currentTarget.value as DraftTool['countScope'],
+                                )
+                              }
+                              style={inputStyle}
+                            >
+                              <option value="">(default)</option>
+                              <option value="per-image">per-image</option>
+                              <option value="per-context">per-context</option>
+                            </select>
+                          </label>
+                          <button
+                            type="button"
+                            onClick={() =>
+                              setDraft('contexts', ci(), 'tools', (ts) =>
+                                ts.filter((_, idx) => idx !== ti()),
+                              )
+                            }
+                            style={dangerButtonStyle}
+                          >
+                            Remove
+                          </button>
+                        </div>
+                      )}
+                    </For>
+                  </div>
+                </div>
+              </div>
+            )}
+          </For>
+        </section>
+
+        {/* Validation + Launch */}
+        <div
+          style={{
+            display: 'flex',
+            'flex-direction': 'column',
+            gap: '8px',
+            'align-items': 'flex-start',
+          }}
+        >
+          <Show when={!isValid()}>
+            <ul
+              style={{
+                color: '#ff6b6b',
+                'font-size': '12px',
+                margin: '0',
+                padding: '8px 8px 8px 24px',
+                background: '#3e1a1a',
+                border: '1px solid #8a2a2a',
+                'border-radius': '4px',
+                'list-style': 'disc',
+              }}
+            >
+              <For each={errors()}>{(err) => <li>{err}</li>}</For>
+            </ul>
+          </Show>
+          <button
+            type="button"
+            onClick={launch}
+            disabled={!isValid()}
+            style={{
+              ...primaryButtonStyle,
+              opacity: isValid() ? '1' : '0.5',
+              cursor: isValid() ? 'pointer' : 'not-allowed',
+            }}
+          >
+            Launch annotator
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/docs/src/components/demos/full-demo/DemoApp.tsx
+++ b/apps/docs/src/components/demos/full-demo/DemoApp.tsx
@@ -1,0 +1,45 @@
+import { createSignal, Show } from 'solid-js';
+import { initFabricModule } from '@osdlabel/solid';
+import type { ImageSource, AnnotationContext } from '@osdlabel/solid';
+import { DEFAULT_IMAGES, DEFAULT_CONTEXTS } from './defaults.js';
+import ConfigPanel from './ConfigPanel.js';
+import AnnotateView from './AnnotateView.js';
+
+initFabricModule();
+
+type Mode = 'configure' | 'annotate';
+
+export default function DemoApp() {
+  const [mode, setMode] = createSignal<Mode>('configure');
+  const [images, setImages] = createSignal<ImageSource[]>([...DEFAULT_IMAGES]);
+  const [contexts, setContexts] = createSignal<AnnotationContext[]>([...DEFAULT_CONTEXTS]);
+
+  const handleLaunch = (imgs: ImageSource[], ctxs: AnnotationContext[]) => {
+    setImages(imgs);
+    setContexts(ctxs);
+    setMode('annotate');
+  };
+
+  const handleReconfigure = () => {
+    setMode('configure');
+  };
+
+  return (
+    <Show
+      when={mode() === 'annotate'}
+      fallback={
+        <ConfigPanel
+          initialImages={images()}
+          initialContexts={contexts()}
+          onLaunch={handleLaunch}
+        />
+      }
+    >
+      <AnnotateView
+        images={images()}
+        contexts={contexts()}
+        onReconfigure={handleReconfigure}
+      />
+    </Show>
+  );
+}

--- a/apps/docs/src/components/demos/full-demo/defaults.ts
+++ b/apps/docs/src/components/demos/full-demo/defaults.ts
@@ -1,0 +1,63 @@
+import { createImageId, createAnnotationContextId } from '@osdlabel/solid';
+import type { ImageSource, AnnotationContext } from '@osdlabel/solid';
+
+export const DEFAULT_IMAGES: ImageSource[] = [
+  {
+    id: createImageId('highsmith'),
+    tileSource: 'https://openseadragon.github.io/example-images/highsmith/highsmith.dzi',
+    label: 'Highsmith',
+  },
+  {
+    id: createImageId('duomo'),
+    tileSource: 'https://openseadragon.github.io/example-images/duomo/duomo.dzi',
+    label: 'Duomo',
+  },
+  {
+    id: createImageId('wide'),
+    tileSource:
+      'https://openseadragon.github.io/example-images/pnp/pan/6a32000/6a32400/6a32487.dzi',
+    label: 'Wide image',
+  },
+];
+
+export const DEFAULT_CONTEXTS: AnnotationContext[] = [
+  {
+    id: createAnnotationContextId('ctx-1'),
+    label: 'Fracture',
+    imageIds: [createImageId('highsmith'), createImageId('duomo')],
+    tools: [
+      { type: 'line', maxCount: 3, countScope: 'per-image' },
+      { type: 'rectangle', maxCount: 2 },
+    ],
+  },
+  {
+    id: createAnnotationContextId('ctx-2'),
+    label: 'Pneumothorax',
+    tools: [
+      { type: 'polyline', maxCount: 3 },
+      { type: 'freeHandPath', maxCount: 3 },
+      { type: 'circle', maxCount: 2 },
+    ],
+  },
+  {
+    id: createAnnotationContextId('ctx-3'),
+    label: 'General',
+    tools: [
+      { type: 'rectangle' },
+      { type: 'circle' },
+      { type: 'line' },
+      { type: 'point' },
+      { type: 'polyline' },
+      { type: 'freeHandPath' },
+    ],
+  },
+];
+
+export const TOOL_TYPES = [
+  'rectangle',
+  'circle',
+  'line',
+  'point',
+  'polyline',
+  'freeHandPath',
+] as const;

--- a/apps/docs/src/pages/demo.astro
+++ b/apps/docs/src/pages/demo.astro
@@ -1,0 +1,34 @@
+---
+import DemoApp from '../components/demos/full-demo/DemoApp.tsx';
+---
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/svg+xml" href={`${import.meta.env.BASE_URL}favicon.svg`} />
+    <title>osdlabel interactive demo</title>
+    <style is:global>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        background: #0f0f1e;
+      }
+      #demo-root {
+        width: 100vw;
+        height: 100vh;
+        overflow: hidden;
+      }
+      * {
+        box-sizing: border-box;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="demo-root">
+      <DemoApp client:only="solid-js" />
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
Add a standalone full-page demo route at /osdlabel/demo/ that mirrors the
SolidJS dev app but begins with a configuration step. Users can edit the
list of image sources and annotation contexts (with tool constraints and
optional image scoping) before launching the annotator; a Reconfigure
button returns to the form.

The page is linked from the Examples sidebar and is served outside
Starlight's content collection so it occupies the full viewport.