### PR TITLE
feat: add @osdlabel/decoration package and DecorationLayer renderer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,14 +51,15 @@ This is `osdlabel`, a DZI image annotation library built with SolidJS, Fabric.js
 
 ### Architecture
 
-The project is split into seven packages with clear dependency boundaries:
+The project is split into eight packages with clear dependency boundaries:
 
 - **`@osdlabel/annotation`** (`packages/annotation/`) — Pure annotation data model. Zero dependencies. Types are split into dedicated modules: `annotation.ts` (`BaseAnnotation`, `Annotation<E>`, `AnnotationStyle`, `AnnotationId`), `annotation-tool.ts` (`ToolType`), `geometry.ts` (geometry discriminated unions), `raw-annotation.ts` (generic `RawAnnotationData<TFormat, TData>`), `util.ts` (`createAnnotationId`, `toolTypeToGeometryType`), `id.ts`, `constants.ts`.
-- **`@osdlabel/viewer-api`** (`packages/viewer-api/`) — Viewer state types and utilities. Contains: `ImageId` branded type, `createImageId`, `ImageIdFields` extension interface, `ImageSource`, `AnnotationState<E>`, `getAllAnnotationsFlat`, `CellTransform`, `DEFAULT_CELL_TRANSFORM`, `UIState`, `KeyboardShortcutMap`. Depends on `@osdlabel/annotation`.
+- **`@osdlabel/viewer-api`** (`packages/viewer-api/`) — Viewer state types and utilities. Contains: `ImageId` branded type, `createImageId`, `ImageIdFields` extension interface, `ImageSource`, `PixelSpacing`, `AnnotationState<E>`, `getAllAnnotationsFlat`, `CellTransform`, `DEFAULT_CELL_TRANSFORM`, `UIState`, `KeyboardShortcutMap`. Depends on `@osdlabel/annotation`.
 - **`@osdlabel/annotation-context`** (`packages/annotation-context/`) — Annotation context, constraints, and scoping. Contains: `AnnotationContextId` branded type, `AnnotationContext`, `ToolConstraint`, `ConstraintStatus`, `ContextState`, `ContextFields` extension interface, context scoping functions (`isContextScopedToImage`, `getCountableImageIds`). Depends on `@osdlabel/annotation` and `@osdlabel/viewer-api` (for `ImageId`).
+- **`@osdlabel/decoration`** (`packages/decoration/`) — Declarative annotation decorations and geometry math. Zero framework deps. Contains: `Decoration` discriminated union (`TextDecoration`, `LineDecoration`), `DecorationProvider` contract + `composeProviders`, geometry math utilities (`area`, `perimeter`, `length`, `radius`, `distance`, `centroid`, `midpoint`, `boundingBox`), `Measurement` + unit conversion (`toPhysicalLength`, `toPhysicalArea`, `formatMeasurement`), and built-in providers (`createMeasurementProvider`, `createLabelProvider`). Depends on `@osdlabel/annotation` and `@osdlabel/viewer-api` (for `PixelSpacing`).
 - **`@osdlabel/validation`** (`packages/validation/`) — Valibot schema implementations (Standard Schema compatible). Contains: `GeometrySchema`, `PointSchema`, `ToolTypeSchema` (in `tool.ts`), `BaseAnnotationSchema`, `OsdFieldsSchema`, `OsdAnnotationSchema` (in `annotation.ts`), `FabricRawAnnotationDataSchema` (in `fabric-data.ts`). Depends on `@osdlabel/annotation` and `valibot`.
 - **`@osdlabel/fabric-annotations`** (`packages/fabric-annotations/`) — Fabric.js annotation tools and utilities, SolidJS-agnostic. Contains: all annotation tools (`BaseTool`, `ShapeTool`, `RectangleTool`, etc.), `ToolOverlay` interface, `FabricRawAnnotationData` (extends `RawAnnotationData<'fabric'>`), `FabricFields` extension interface, Fabric object serialization utilities (`serializeFabricObject`, `deserializeFabricObject`, `createFabricObjectFromRawData`, `getGeometryFromFabricObject`, `getFabricOptions`), `initFabricModule`. Depends on `@osdlabel/annotation`, `@osdlabel/annotation-context`, `@osdlabel/viewer-api` (for `KeyboardShortcutMap`), and `fabric`.
-- **`@osdlabel/fabric-osd`** (`packages/fabric-osd/`) — Fabric.js + OpenSeaDragon overlay bridge, SolidJS-agnostic. Contains: `FabricOverlay` (canvas overlay + viewport transform), `computeViewportTransform`. Depends on `@osdlabel/annotation`, `@osdlabel/viewer-api` (for `CellTransform`), `@osdlabel/fabric-annotations`, `@osdlabel/validation`, `fabric`, and `openseadragon`.
+- **`@osdlabel/fabric-osd`** (`packages/fabric-osd/`) — Fabric.js + OpenSeaDragon overlay bridge & decoration renderer, SolidJS-agnostic. Contains: `FabricOverlay` (canvas overlay + viewport transform; exposes `onSync` and `overlayElement` for companion layers), `computeViewportTransform`, and `DecorationLayer` (renders text decorations as DOM elements positioned via `imageToScreen` and connector-line decorations as non-interactive Fabric objects). Depends on `@osdlabel/annotation`, `@osdlabel/viewer-api` (for `CellTransform`), `@osdlabel/decoration`, `@osdlabel/fabric-annotations`, `@osdlabel/validation`, `fabric`, and `openseadragon`.
 - **`osdlabel`** (`packages/osdlabel/`) — Framework-agnostic shared logic. Contains: `OsdAnnotation` composed type alias (`Annotation<ImageIdFields & ContextFields & FabricFields>`), `serialize`/`deserialize`/`SerializationError`/`DeserializeResult` (serialization lives here, not in annotation), pure action types and reducer functions (`applyAnnotationAction`, `applyUIAction`, `applyContextAction`), initial state factories, constraint computation (`computeConstraintStatus`), keyboard mapping (`mapKeyEventToActions`, `DEFAULT_KEYBOARD_SHORTCUTS`), and tool factory (`createAnnotationTool`, `buildToolCallbacks`). No framework dependencies.
 - **`@osdlabel/solid`** (`packages/solid/`) — SolidJS annotator UI. Contains: reactive state stores (using `createStore` + `produce`), hooks (`useAnnotationTool`, `useKeyboard`, `useConstraints`), and components (`Annotator`, `ViewerCell`, `GridView`, `Toolbar`, etc.). Depends on `osdlabel` + `solid-js`.
 - **`@osdlabel/react`** (`packages/react/`) — React annotator UI. Contains: Immer-based reducers, React Context + `useReducer` state management, hooks (`useAnnotationTool`, `useKeyboard`, `useConstraints`), and components (`Annotator`, `ViewerCell`, `GridView`, `Toolbar`, etc.). Depends on `osdlabel` + `react` + `immer`.
@@ -81,6 +82,8 @@ Key architectural rules:
 - **State mutations go through named action functions.** Never modify the store directly from components. Pure reducers live in `packages/osdlabel/src/actions.ts`; framework-specific action dispatchers live in `@osdlabel/solid` and `@osdlabel/react`.
 - **One active cell at a time.** Only one grid cell can be in annotation mode at a time. All other cells display existing annotations in read-only mode.
 - **Constraint enforcement is reactive.** In SolidJS, use `createMemo`; in React, use `useMemo`. Both derive whether each tool is enabled/disabled from the current annotation counts and the active context's limits. The toolbar reads this derived state. Do not imperatively enable/disable tools.
+- **Decorations are derived, never serialized.** Text labels, computed measurements (area/perimeter/length/radius), and connector lines are produced by pure `DecorationProvider` functions over current annotation state + `PixelSpacing`. The result is fed to `DecorationLayer.setDecorations` in a reactive effect (SolidJS `createEffect` / React `useEffect`). Providers must produce stable `Decoration.id` values so the renderer can diff in place. Do not embed computed measurements in `serialize()` output — recompute them at render time.
+- **Hybrid decoration rendering: DOM text + Fabric lines.** Text decorations render as absolutely-positioned `<div>` elements inside a host layer that `DecorationLayer` appends to `FabricOverlay.overlayElement`; positions are recomputed on the `FabricOverlay.onSync` callback. Connector / measurement lines render as non-interactive Fabric `Line` objects on the overlay's canvas (carrying `_readOnly: true` and no `id`) — they follow pan/zoom/rotate/flip via the existing `viewportTransform` at zero per-frame cost.
 - **All packages use lockstep versioning.** Run `pnpm run check-versions` to validate. CI enforces this.
 
 ### Testing
@@ -103,11 +106,12 @@ Key architectural rules:
 This is a pnpm workspace monorepo with Turborepo for task orchestration:
 
 - `packages/annotation/` — `@osdlabel/annotation` (annotation data model)
-- `packages/viewer-api/` — `@osdlabel/viewer-api` (viewer state types)
+- `packages/viewer-api/` — `@osdlabel/viewer-api` (viewer state types; also owns `PixelSpacing`)
 - `packages/annotation-context/` — `@osdlabel/annotation-context` (context, constraints, scoping)
+- `packages/decoration/` — `@osdlabel/decoration` (declarative decorations, geometry math, built-in providers)
 - `packages/validation/` — `@osdlabel/validation` (Valibot schemas, Standard Schema compatible)
 - `packages/fabric-annotations/` — `@osdlabel/fabric-annotations` (Fabric.js annotation tools & utilities)
-- `packages/fabric-osd/` — `@osdlabel/fabric-osd` (Fabric.js + OSD overlay bridge)
+- `packages/fabric-osd/` — `@osdlabel/fabric-osd` (Fabric.js + OSD overlay bridge; also owns `DecorationLayer`)
 - `packages/osdlabel/` — `osdlabel` (framework-agnostic shared logic)
 - `packages/solid/` — `@osdlabel/solid` (SolidJS annotator UI)
 - `packages/react/` — `@osdlabel/react` (React annotator UI)
@@ -122,17 +126,18 @@ The library is split across multiple npm packages:
 1. **`@osdlabel/annotation`** — Pure data model. `import { type Annotation, type BaseAnnotation, type RawAnnotationData, createAnnotationId } from '@osdlabel/annotation'`
 2. **`@osdlabel/viewer-api`** — Viewer state types and utilities. `import { type ImageId, type ImageIdFields, type ImageSource, type AnnotationState, type UIState, type CellTransform, type KeyboardShortcutMap, createImageId, DEFAULT_CELL_TRANSFORM, getAllAnnotationsFlat } from '@osdlabel/viewer-api'`
 3. **`@osdlabel/annotation-context`** — Context & constraints. `import { type AnnotationContext, isContextScopedToImage, getCountableImageIds } from '@osdlabel/annotation-context'`
-4. **`@osdlabel/validation`** — Validation schemas. `import { BaseAnnotationSchema, OsdAnnotationSchema, OsdFieldsSchema, GeometrySchema, ToolTypeSchema, FabricRawAnnotationDataSchema } from '@osdlabel/validation'`
-5. **`@osdlabel/fabric-annotations`** — Fabric annotation tools & utilities. `import { initFabricModule, RectangleTool, type ToolOverlay, type FabricFields, type FabricRawAnnotationData } from '@osdlabel/fabric-annotations'`
-6. **`@osdlabel/fabric-osd`** — OSD overlay bridge. `import { FabricOverlay, computeViewportTransform } from '@osdlabel/fabric-osd'`
-7. **`osdlabel`** — Framework-agnostic shared logic. Types, serialization, pure reducers, constraints, keyboard mapping, tool factory.
-   - Main barrel: `import { serialize, deserialize, type OsdAnnotation, applyAnnotationAction, computeConstraintStatus } from 'osdlabel'`
-8. **`@osdlabel/solid`** — SolidJS UI. Re-exports everything from `osdlabel` plus SolidJS-specific state/hooks/components.
+4. **`@osdlabel/decoration`** — Declarative annotation decorations (text labels, computed measurements, connector lines), geometry math, and built-in providers. Zero framework deps. `import { createMeasurementProvider, createLabelProvider, type DecorationProvider, area, perimeter } from '@osdlabel/decoration'`
+5. **`@osdlabel/validation`** — Validation schemas. `import { BaseAnnotationSchema, OsdAnnotationSchema, OsdFieldsSchema, GeometrySchema, ToolTypeSchema, FabricRawAnnotationDataSchema } from '@osdlabel/validation'`
+6. **`@osdlabel/fabric-annotations`** — Fabric annotation tools & utilities. `import { initFabricModule, RectangleTool, type ToolOverlay, type FabricFields, type FabricRawAnnotationData } from '@osdlabel/fabric-annotations'`
+7. **`@osdlabel/fabric-osd`** — OSD overlay bridge & decoration renderer. `import { FabricOverlay, computeViewportTransform, DecorationLayer } from '@osdlabel/fabric-osd'`
+8. **`osdlabel`** — Framework-agnostic shared logic. Types, serialization, pure reducers, constraints, keyboard mapping, tool factory. Also re-exports the decoration API.
+   - Main barrel: `import { serialize, deserialize, type OsdAnnotation, applyAnnotationAction, computeConstraintStatus, createMeasurementProvider, type DecorationProvider } from 'osdlabel'`
+9. **`@osdlabel/solid`** — SolidJS UI. Re-exports everything from `osdlabel` plus SolidJS-specific state/hooks/components.
    - Main barrel: `import { Annotator, useAnnotator, Toolbar } from '@osdlabel/solid'`
    - Sub-path barrels: `@osdlabel/solid/components`, `@osdlabel/solid/state`, `@osdlabel/solid/hooks`
-9. **`@osdlabel/react`** — React UI. Re-exports everything from `osdlabel` plus React-specific state/hooks/components.
-   - Main barrel: `import { Annotator, useAnnotator, Toolbar } from '@osdlabel/react'`
-   - Sub-path barrels: `@osdlabel/react/components`, `@osdlabel/react/state`, `@osdlabel/react/hooks`
+10. **`@osdlabel/react`** — React UI. Re-exports everything from `osdlabel` plus React-specific state/hooks/components.
+    - Main barrel: `import { Annotator, useAnnotator, Toolbar } from '@osdlabel/react'`
+    - Sub-path barrels: `@osdlabel/react/components`, `@osdlabel/react/state`, `@osdlabel/react/hooks`
 
 The `@osdlabel/solid` package is built using **Vite in library mode** with `vite-plugin-solid`. The `osdlabel`, `@osdlabel/react`, and all other packages are built with plain `tsc`.
 
@@ -142,7 +147,7 @@ Run from the workspace root — Turbo fans out to the correct packages:
 
 ```bash
 pnpm dev            # Start Vite dev server (apps/dev) with HMR into library source
-pnpm build          # Build all packages (annotation → viewer-api → annotation-context → validation → fabric-annotations → fabric-osd → osdlabel)
+pnpm build          # Build all packages (annotation → viewer-api → annotation-context, decoration → validation → fabric-annotations → fabric-osd → osdlabel)
 pnpm typecheck      # Type-check all packages
 pnpm test           # Run Vitest unit tests across all packages
 pnpm test:e2e       # Run Playwright E2E tests in apps/dev/
@@ -167,6 +172,11 @@ pnpm typecheck    # tsc --noEmit
 pnpm test         # vitest run
 
 # packages/annotation-context/
+pnpm build        # tsc -p tsconfig.build.json
+pnpm typecheck    # tsc --noEmit
+pnpm test         # vitest run
+
+# packages/decoration/
 pnpm build        # tsc -p tsconfig.build.json
 pnpm typecheck    # tsc --noEmit
 pnpm test         # vitest run

--- a/packages/decoration/README.md
+++ b/packages/decoration/README.md
@@ -1,0 +1,5 @@
+# @osdlabel/decoration
+
+Declarative annotation decorations (text labels, computed measurements, connector lines) and calibrated geometry math for osdlabel.
+
+Decorations are a **pure derivation** of annotation state — they are never serialized, and they are recomputed whenever the underlying annotations change. This package defines the data model and provider contract; the rendering happens in `@osdlabel/fabric-osd`.

--- a/packages/decoration/package.json
+++ b/packages/decoration/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@osdlabel/fabric-osd",
+  "name": "@osdlabel/decoration",
   "version": "0.0.1",
-  "description": "Fabric.js and OpenSeaDragon integration layer for osdlabel — canvas overlay and viewport transform.",
+  "description": "Declarative annotation decorations (labels, measurements, connector lines) and calibrated geometry math for osdlabel.",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -30,18 +30,9 @@
   },
   "dependencies": {
     "@osdlabel/annotation": "workspace:*",
-    "@osdlabel/decoration": "workspace:*",
-    "@osdlabel/fabric-annotations": "workspace:*",
-    "@osdlabel/validation": "workspace:*",
     "@osdlabel/viewer-api": "workspace:*"
   },
-  "peerDependencies": {
-    "fabric": "catalog:",
-    "openseadragon": "catalog:",
-    "valibot": "catalog:"
-  },
   "devDependencies": {
-    "@types/openseadragon": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"
   }

--- a/packages/decoration/src/built-in-providers.ts
+++ b/packages/decoration/src/built-in-providers.ts
@@ -1,0 +1,177 @@
+import type { Annotation, BaseAnnotation, Geometry, Point } from '@osdlabel/annotation';
+import type { PixelSpacing } from '@osdlabel/viewer-api';
+import type {
+  Decoration,
+  TextDecoration,
+  TextDecorationStyle,
+  TextPlacement,
+} from './decoration.js';
+import type { DecorationProvider } from './provider.js';
+import * as geom from './geometry-math.js';
+import {
+  formatMeasurement,
+  toPhysicalArea,
+  toPhysicalLength,
+  type FormatMeasurementOptions,
+  type Measurement,
+} from './measurement.js';
+
+// ── createMeasurementProvider ──────────────────────────────────────────────
+
+/** Which measurements to render. All flags default to `false`. */
+export interface MeasurementProviderOptions {
+  readonly area?: boolean | undefined;
+  readonly perimeter?: boolean | undefined;
+  readonly length?: boolean | undefined;
+  readonly radius?: boolean | undefined;
+  readonly format?: FormatMeasurementOptions | undefined;
+  /** Custom formatter; receives the metric label and the value+unit. */
+  readonly formatLine?: ((label: string, measurement: Measurement) => string) | undefined;
+  /** Style applied to the rendered text labels. */
+  readonly style?: TextDecorationStyle | undefined;
+}
+
+/**
+ * A provider that renders one text label per visible annotation containing
+ * the requested geometric measurements. Anchors and placement are chosen
+ * automatically per geometry type.
+ */
+export function createMeasurementProvider<E extends object = Record<string, never>>(
+  options: MeasurementProviderOptions,
+): DecorationProvider<E> {
+  return ({ annotations, pixelSpacing }) => {
+    const decorations: Decoration[] = [];
+    for (const ann of annotations) {
+      const lines = computeMeasurementLines(ann.geometry, options, pixelSpacing);
+      if (lines.length === 0) continue;
+      const placement = anchorPlacementFor(ann.geometry);
+      const decoration: TextDecoration = {
+        id: `measurement:${ann.id}`,
+        type: 'text',
+        relatedAnnotationIds: [ann.id],
+        text: lines.join('\n'),
+        anchor: placement.anchor,
+        ...(placement.offset !== undefined ? { offset: placement.offset } : {}),
+        placement: placement.placement,
+        ...(options.style !== undefined ? { style: options.style } : {}),
+      };
+      decorations.push(decoration);
+    }
+    return decorations;
+  };
+}
+
+function computeMeasurementLines(
+  geometry: Geometry,
+  options: MeasurementProviderOptions,
+  pixelSpacing: PixelSpacing | undefined,
+): string[] {
+  const fmt = options.format;
+  const lines: string[] = [];
+
+  const writeLine = (labelText: string, measurement: Measurement): void => {
+    const line = options.formatLine
+      ? options.formatLine(labelText, measurement)
+      : `${labelText}: ${formatMeasurement(measurement, fmt)}`;
+    lines.push(line);
+  };
+
+  if (options.radius && geometry.type === 'circle') {
+    writeLine('r', toPhysicalLength(geometry.radius, pixelSpacing, 'mean'));
+  }
+  if (options.area) {
+    const a = geom.area(geometry);
+    if (a > 0) writeLine('A', toPhysicalArea(a, pixelSpacing));
+  }
+  if (options.perimeter) {
+    const p = geom.perimeter(geometry);
+    if (p > 0) writeLine('P', toPhysicalLength(p, pixelSpacing, 'mean'));
+  }
+  if (options.length) {
+    const l = geom.length(geometry);
+    if (l > 0 && (geometry.type === 'line' || geometry.type === 'polyline')) {
+      writeLine('L', toPhysicalLength(l, pixelSpacing, 'mean'));
+    }
+  }
+
+  return lines;
+}
+
+interface ResolvedAnchor {
+  readonly anchor: Point;
+  readonly offset?: { readonly x: number; readonly y: number };
+  readonly placement: TextPlacement;
+}
+
+function anchorPlacementFor(geometry: Geometry): ResolvedAnchor {
+  switch (geometry.type) {
+    case 'rectangle':
+    case 'polygon':
+      return { anchor: geom.centroid(geometry), placement: 'center' };
+    case 'circle':
+      return {
+        anchor: { x: geometry.center.x + geometry.radius, y: geometry.center.y },
+        offset: { x: 8, y: 0 },
+        placement: 'left',
+      };
+    case 'line':
+      return {
+        anchor: geom.midpoint(geometry.start, geometry.end),
+        offset: { x: 0, y: -6 },
+        placement: 'bottom',
+      };
+    case 'point':
+      return {
+        anchor: geometry.position,
+        offset: { x: 8, y: 0 },
+        placement: 'left',
+      };
+    case 'polyline':
+      return { anchor: geom.centroid(geometry), placement: 'center' };
+  }
+}
+
+// ── createLabelProvider ────────────────────────────────────────────────────
+
+export interface LabelProviderOptions {
+  /** Style applied to label text. */
+  readonly style?: TextDecorationStyle | undefined;
+  /**
+   * Custom extractor; receives the annotation and should return the text
+   * to render, or `undefined` to skip. Defaults to reading `annotation.label`.
+   */
+  readonly extract?:
+    | (<E extends object>(annotation: Annotation<E>) => string | undefined)
+    | undefined;
+}
+
+/**
+ * A provider that renders the `label` field of each visible annotation as
+ * a text decoration. Annotations without a label are skipped.
+ */
+export function createLabelProvider<E extends object = Record<string, never>>(
+  options?: LabelProviderOptions,
+): DecorationProvider<E> {
+  const extract =
+    options?.extract ?? ((annotation: BaseAnnotation): string | undefined => annotation.label);
+  return ({ annotations }) => {
+    const decorations: Decoration[] = [];
+    for (const ann of annotations) {
+      const text = extract(ann);
+      if (!text) continue;
+      const placement = anchorPlacementFor(ann.geometry);
+      const decoration: TextDecoration = {
+        id: `label:${ann.id}`,
+        type: 'text',
+        relatedAnnotationIds: [ann.id],
+        text,
+        anchor: placement.anchor,
+        ...(placement.offset !== undefined ? { offset: placement.offset } : {}),
+        placement: placement.placement,
+        ...(options?.style !== undefined ? { style: options.style } : {}),
+      };
+      decorations.push(decoration);
+    }
+    return decorations;
+  };
+}

--- a/packages/decoration/src/decoration.ts
+++ b/packages/decoration/src/decoration.ts
@@ -1,0 +1,91 @@
+import type { AnnotationId, Point } from '@osdlabel/annotation';
+
+/** Styling applied to a text decoration (DOM-rendered). */
+export interface TextDecorationStyle {
+  readonly color?: string | undefined;
+  /** Font size in screen pixels. */
+  readonly fontSize?: number | undefined;
+  readonly fontFamily?: string | undefined;
+  readonly fontWeight?: string | number | undefined;
+  /** CSS background shorthand (e.g. 'rgba(0,0,0,0.6)'). */
+  readonly background?: string | undefined;
+  /** CSS padding shorthand (e.g. '2px 4px'). */
+  readonly padding?: string | undefined;
+  /** CSS border-radius shorthand. */
+  readonly borderRadius?: string | undefined;
+  /** Additional CSS class applied to the host element. */
+  readonly className?: string | undefined;
+}
+
+/** Styling applied to a line decoration (Fabric-rendered). */
+export interface LineDecorationStyle {
+  readonly stroke?: string | undefined;
+  /** Stroke width in screen pixels (rendered with strokeUniform). */
+  readonly strokeWidth?: number | undefined;
+  readonly opacity?: number | undefined;
+}
+
+interface BaseDecoration {
+  /**
+   * Stable identifier used for diffing across recomputations. Providers must
+   * produce the same id for the same logical decoration so the renderer can
+   * update in place instead of recreating DOM/canvas objects.
+   */
+  readonly id: string;
+  /**
+   * Annotation ids this decoration is associated with. Used for lifecycle
+   * (e.g. so the renderer can remove decorations when their related
+   * annotations are deleted). May be empty for purely contextual decorations.
+   */
+  readonly relatedAnnotationIds: readonly AnnotationId[];
+}
+
+/**
+ * Where the text element is anchored relative to its own bounding box.
+ *
+ * - `'top-left'` (default): the element's top-left corner is at the anchor.
+ * - `'center'`: the element is centered on the anchor.
+ * - `'top'` / `'bottom'`: horizontally centered, top/bottom edge at anchor.
+ * - `'left'` / `'right'`: vertically centered, left/right edge at anchor.
+ */
+export type TextPlacement = 'top-left' | 'center' | 'top' | 'bottom' | 'left' | 'right';
+
+/** A text label rendered as a DOM element positioned over the image. */
+export interface TextDecoration extends BaseDecoration {
+  readonly type: 'text';
+  readonly text: string;
+  /** Anchor point in image-space coordinates. */
+  readonly anchor: Point;
+  /**
+   * Optional screen-pixel offset added to the anchor's screen position
+   * before the element is placed.
+   */
+  readonly offset?: { readonly x: number; readonly y: number } | undefined;
+  /** How the element aligns to its anchor. Default: `'top-left'`. */
+  readonly placement?: TextPlacement | undefined;
+  readonly style?: TextDecorationStyle | undefined;
+}
+
+/** A connector / measurement line rendered as a Fabric object in image-space. */
+export interface LineDecoration extends BaseDecoration {
+  readonly type: 'line';
+  /** Start point in image-space coordinates. */
+  readonly start: Point;
+  /** End point in image-space coordinates. */
+  readonly end: Point;
+  /** If true, the line is rendered with a dash pattern. */
+  readonly dashed?: boolean | undefined;
+  readonly style?: LineDecorationStyle | undefined;
+}
+
+/**
+ * Declarative description of something to render alongside annotations.
+ *
+ * Decorations are pure data: providers return them, the renderer turns them
+ * into DOM/Fabric objects. Decorations are never serialized into annotation
+ * data — they are always recomputed from current state.
+ */
+export type Decoration = TextDecoration | LineDecoration;
+
+/** Discriminator values of `Decoration`. */
+export type DecorationType = Decoration['type'];

--- a/packages/decoration/src/geometry-math.ts
+++ b/packages/decoration/src/geometry-math.ts
@@ -163,6 +163,10 @@ function polylineLength(points: readonly Point[]): number {
   return total;
 }
 
+// Vertex-average centroid: fast and accurate for regular polygons. For highly
+// irregular polygons it skews toward dense vertex clusters; the area-weighted
+// shoelace centroid (which also requires a degenerate-polygon fallback) would
+// be the upgrade if label placement becomes a real problem.
 function pointsCentroid(points: readonly Point[]): Point {
   if (points.length === 0) return { x: 0, y: 0 };
   let sx = 0;

--- a/packages/decoration/src/geometry-math.ts
+++ b/packages/decoration/src/geometry-math.ts
@@ -1,0 +1,213 @@
+import type { Geometry, Point } from '@osdlabel/annotation';
+
+const DEG_TO_RAD = Math.PI / 180;
+
+/** Euclidean distance between two points (image-pixel space). */
+export function distance(a: Point, b: Point): number {
+  const dx = b.x - a.x;
+  const dy = b.y - a.y;
+  return Math.sqrt(dx * dx + dy * dy);
+}
+
+/**
+ * Area of a geometry in image-px². Returns `0` for zero-area geometries
+ * (points, lines, single-point polylines). Polygon area is the absolute
+ * value of the signed shoelace area (so winding direction doesn't matter).
+ */
+export function area(geometry: Geometry): number {
+  switch (geometry.type) {
+    case 'rectangle':
+      return geometry.width * geometry.height;
+    case 'circle':
+      return Math.PI * geometry.radius * geometry.radius;
+    case 'polygon':
+      return polygonShoelaceArea(geometry.points);
+    case 'line':
+    case 'point':
+    case 'polyline':
+      return 0;
+  }
+}
+
+/**
+ * Closed-perimeter of a geometry in image-px. For open shapes (lines,
+ * polylines, points) returns `0` — use {@link length} for those.
+ */
+export function perimeter(geometry: Geometry): number {
+  switch (geometry.type) {
+    case 'rectangle':
+      return 2 * (geometry.width + geometry.height);
+    case 'circle':
+      return 2 * Math.PI * geometry.radius;
+    case 'polygon':
+      return polygonPerimeter(geometry.points);
+    case 'line':
+    case 'point':
+    case 'polyline':
+      return 0;
+  }
+}
+
+/**
+ * Open-curve length of a geometry in image-px. For closed shapes
+ * (rectangle, circle, polygon) this equals {@link perimeter}; for points
+ * returns `0`.
+ */
+export function length(geometry: Geometry): number {
+  switch (geometry.type) {
+    case 'line':
+      return distance(geometry.start, geometry.end);
+    case 'polyline':
+      return polylineLength(geometry.points);
+    case 'rectangle':
+    case 'circle':
+    case 'polygon':
+      return perimeter(geometry);
+    case 'point':
+      return 0;
+  }
+}
+
+/** Radius of a circle in image-px; `undefined` for non-circles. */
+export function radius(geometry: Geometry): number | undefined {
+  return geometry.type === 'circle' ? geometry.radius : undefined;
+}
+
+/**
+ * Geometric centroid in image-px. For rectangles, accounts for the
+ * `rotation` field rotating the rect about its `origin` (top-left).
+ */
+export function centroid(geometry: Geometry): Point {
+  switch (geometry.type) {
+    case 'rectangle': {
+      const localCx = geometry.width / 2;
+      const localCy = geometry.height / 2;
+      const theta = geometry.rotation * DEG_TO_RAD;
+      const cos = Math.cos(theta);
+      const sin = Math.sin(theta);
+      return {
+        x: geometry.origin.x + localCx * cos - localCy * sin,
+        y: geometry.origin.y + localCx * sin + localCy * cos,
+      };
+    }
+    case 'circle':
+      return geometry.center;
+    case 'line':
+      return midpoint(geometry.start, geometry.end);
+    case 'point':
+      return geometry.position;
+    case 'polyline':
+    case 'polygon':
+      return pointsCentroid(geometry.points);
+  }
+}
+
+/** Axis-aligned bounding box in image-px. */
+export function boundingBox(geometry: Geometry): { readonly min: Point; readonly max: Point } {
+  switch (geometry.type) {
+    case 'rectangle':
+      return rectangleBoundingBox(
+        geometry.origin,
+        geometry.width,
+        geometry.height,
+        geometry.rotation,
+      );
+    case 'circle':
+      return {
+        min: { x: geometry.center.x - geometry.radius, y: geometry.center.y - geometry.radius },
+        max: { x: geometry.center.x + geometry.radius, y: geometry.center.y + geometry.radius },
+      };
+    case 'line':
+      return pointsBoundingBox([geometry.start, geometry.end]);
+    case 'point':
+      return { min: geometry.position, max: geometry.position };
+    case 'polyline':
+    case 'polygon':
+      return pointsBoundingBox(geometry.points);
+  }
+}
+
+/** Midpoint between two points. */
+export function midpoint(a: Point, b: Point): Point {
+  return { x: (a.x + b.x) / 2, y: (a.y + b.y) / 2 };
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function polygonShoelaceArea(points: readonly Point[]): number {
+  if (points.length < 3) return 0;
+  let sum = 0;
+  for (let i = 0; i < points.length; i++) {
+    const a = points[i]!;
+    const b = points[(i + 1) % points.length]!;
+    sum += a.x * b.y - b.x * a.y;
+  }
+  return Math.abs(sum) / 2;
+}
+
+function polygonPerimeter(points: readonly Point[]): number {
+  if (points.length < 2) return 0;
+  let total = 0;
+  for (let i = 0; i < points.length; i++) {
+    total += distance(points[i]!, points[(i + 1) % points.length]!);
+  }
+  return total;
+}
+
+function polylineLength(points: readonly Point[]): number {
+  if (points.length < 2) return 0;
+  let total = 0;
+  for (let i = 0; i < points.length - 1; i++) {
+    total += distance(points[i]!, points[i + 1]!);
+  }
+  return total;
+}
+
+function pointsCentroid(points: readonly Point[]): Point {
+  if (points.length === 0) return { x: 0, y: 0 };
+  let sx = 0;
+  let sy = 0;
+  for (const p of points) {
+    sx += p.x;
+    sy += p.y;
+  }
+  return { x: sx / points.length, y: sy / points.length };
+}
+
+function pointsBoundingBox(points: readonly Point[]): { readonly min: Point; readonly max: Point } {
+  if (points.length === 0) {
+    return { min: { x: 0, y: 0 }, max: { x: 0, y: 0 } };
+  }
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  for (const p of points) {
+    if (p.x < minX) minX = p.x;
+    if (p.y < minY) minY = p.y;
+    if (p.x > maxX) maxX = p.x;
+    if (p.y > maxY) maxY = p.y;
+  }
+  return { min: { x: minX, y: minY }, max: { x: maxX, y: maxY } };
+}
+
+function rectangleBoundingBox(
+  origin: Point,
+  width: number,
+  height: number,
+  rotationDeg: number,
+): { readonly min: Point; readonly max: Point } {
+  const theta = rotationDeg * DEG_TO_RAD;
+  const cos = Math.cos(theta);
+  const sin = Math.sin(theta);
+  const corners: Point[] = [
+    { x: 0, y: 0 },
+    { x: width, y: 0 },
+    { x: width, y: height },
+    { x: 0, y: height },
+  ].map((c) => ({
+    x: origin.x + c.x * cos - c.y * sin,
+    y: origin.y + c.x * sin + c.y * cos,
+  }));
+  return pointsBoundingBox(corners);
+}

--- a/packages/decoration/src/index.ts
+++ b/packages/decoration/src/index.ts
@@ -1,0 +1,25 @@
+export type {
+  Decoration,
+  DecorationType,
+  TextDecoration,
+  TextDecorationStyle,
+  TextPlacement,
+  LineDecoration,
+  LineDecorationStyle,
+} from './decoration.js';
+export type { DecorationContext, DecorationProvider } from './provider.js';
+export { composeProviders } from './provider.js';
+export type { Measurement, SpacingAxis, FormatMeasurementOptions } from './measurement.js';
+export { toPhysicalLength, toPhysicalArea, formatMeasurement } from './measurement.js';
+export {
+  area,
+  perimeter,
+  length,
+  radius,
+  distance,
+  centroid,
+  midpoint,
+  boundingBox,
+} from './geometry-math.js';
+export { createMeasurementProvider, createLabelProvider } from './built-in-providers.js';
+export type { MeasurementProviderOptions, LabelProviderOptions } from './built-in-providers.js';

--- a/packages/decoration/src/measurement.ts
+++ b/packages/decoration/src/measurement.ts
@@ -1,0 +1,66 @@
+import type { PixelSpacing } from '@osdlabel/viewer-api';
+
+/** A scalar measurement with an explicit unit. */
+export interface Measurement {
+  readonly value: number;
+  /** Display unit, e.g. `'px'`, `'mm'`, `'mm²'`, `'µm'`. */
+  readonly unit: string;
+}
+
+/**
+ * Axis along which to apply pixel spacing. Use `'x'` or `'y'` for
+ * one-dimensional measurements (e.g. horizontal length), `'mean'` for
+ * isotropic conversion when the orientation is unknown (e.g. circle radius).
+ */
+export type SpacingAxis = 'x' | 'y' | 'mean';
+
+/**
+ * Convert a 1-D pixel measurement to physical units using `pixelSpacing`.
+ * Returns the original value with unit `'px'` if no spacing is provided.
+ */
+export function toPhysicalLength(
+  pixels: number,
+  pixelSpacing: PixelSpacing | undefined,
+  axis: SpacingAxis = 'mean',
+): Measurement {
+  if (!pixelSpacing) return { value: pixels, unit: 'px' };
+  const factor = axisFactor(pixelSpacing, axis);
+  return { value: pixels * factor, unit: pixelSpacing.unit };
+}
+
+/**
+ * Convert a 2-D pixel-area measurement to physical units. Uses the product
+ * of x and y spacing, which is the physically meaningful conversion for
+ * area regardless of anisotropy.
+ */
+export function toPhysicalArea(
+  pixelsSquared: number,
+  pixelSpacing: PixelSpacing | undefined,
+): Measurement {
+  if (!pixelSpacing) return { value: pixelsSquared, unit: 'px²' };
+  return {
+    value: pixelsSquared * pixelSpacing.x * pixelSpacing.y,
+    unit: `${pixelSpacing.unit}²`,
+  };
+}
+
+/** Default formatting options for `formatMeasurement`. */
+export interface FormatMeasurementOptions {
+  /** Number of fractional digits (default: 2). */
+  readonly precision?: number | undefined;
+  /** Separator between the numeric value and the unit (default: `' '`). */
+  readonly unitSeparator?: string | undefined;
+}
+
+/** Render a measurement to a human-readable string (e.g. `"12.34 mm"`). */
+export function formatMeasurement(m: Measurement, options?: FormatMeasurementOptions): string {
+  const precision = options?.precision ?? 2;
+  const sep = options?.unitSeparator ?? ' ';
+  return `${m.value.toFixed(precision)}${sep}${m.unit}`;
+}
+
+function axisFactor(spacing: PixelSpacing, axis: SpacingAxis): number {
+  if (axis === 'x') return spacing.x;
+  if (axis === 'y') return spacing.y;
+  return (spacing.x + spacing.y) / 2;
+}

--- a/packages/decoration/src/provider.ts
+++ b/packages/decoration/src/provider.ts
@@ -1,0 +1,36 @@
+import type { Annotation } from '@osdlabel/annotation';
+import type { PixelSpacing } from '@osdlabel/viewer-api';
+import type { Decoration } from './decoration.js';
+
+/**
+ * Inputs to a `DecorationProvider`. Generic over the annotation extension
+ * type so providers can read extension fields (e.g. `contextId`, `imageId`)
+ * from the annotations they receive.
+ */
+export interface DecorationContext<E extends object = Record<string, never>> {
+  /** All annotations currently visible in the cell the decorations are being computed for. */
+  readonly annotations: readonly Annotation<E>[];
+  /** Calibration for the cell's image; `undefined` if no calibration is set. */
+  readonly pixelSpacing?: PixelSpacing | undefined;
+}
+
+/**
+ * A pure function that derives decorations from current annotation state.
+ *
+ * Providers run on every reactive recomputation — they must be deterministic
+ * and side-effect-free. The renderer diffs the returned array by
+ * `Decoration.id`, so providers should produce stable ids.
+ */
+export type DecorationProvider<E extends object = Record<string, never>> = (
+  ctx: DecorationContext<E>,
+) => readonly Decoration[];
+
+/**
+ * Compose multiple providers into a single provider that emits the union of
+ * their outputs. Pure flat-map; ordering is preserved.
+ */
+export function composeProviders<E extends object = Record<string, never>>(
+  providers: readonly DecorationProvider<E>[],
+): DecorationProvider<E> {
+  return (ctx) => providers.flatMap((p) => p(ctx));
+}

--- a/packages/decoration/tests/unit/built-in-providers.test.ts
+++ b/packages/decoration/tests/unit/built-in-providers.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+import type { Annotation, AnnotationId, ToolType } from '@osdlabel/annotation';
+import type { PixelSpacing } from '@osdlabel/viewer-api';
+import { createLabelProvider, createMeasurementProvider } from '../../src/built-in-providers.js';
+import type { TextDecoration } from '../../src/decoration.js';
+
+function ann(
+  id: string,
+  toolType: ToolType,
+  geometry: Annotation['geometry'],
+  label?: string,
+): Annotation {
+  const base = {
+    id: id as AnnotationId,
+    geometry,
+    toolType,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  } as const;
+  return label !== undefined ? { ...base, label } : base;
+}
+
+describe('createMeasurementProvider', () => {
+  it('emits a single text decoration per annotation with requested metrics', () => {
+    const provider = createMeasurementProvider({ area: true, radius: true });
+    const a = ann('c1', 'circle', { type: 'circle', center: { x: 10, y: 10 }, radius: 5 });
+    const decorations = provider({ annotations: [a] });
+    expect(decorations).toHaveLength(1);
+    const d = decorations[0] as TextDecoration;
+    expect(d.type).toBe('text');
+    expect(d.relatedAnnotationIds).toEqual(['c1']);
+    expect(d.text).toContain('r:');
+    expect(d.text).toContain('A:');
+    // No calibration → values in px
+    expect(d.text).toContain('px');
+  });
+
+  it('uses pixel spacing to render mm values', () => {
+    const provider = createMeasurementProvider({ area: true, radius: true });
+    const spacing: PixelSpacing = { x: 0.5, y: 0.5, unit: 'mm' };
+    const a = ann('c1', 'circle', { type: 'circle', center: { x: 0, y: 0 }, radius: 4 });
+    const [d] = provider({ annotations: [a], pixelSpacing: spacing });
+    const text = (d as TextDecoration).text;
+    expect(text).toContain('mm');
+    // radius: 4 * 0.5 = 2.00 mm
+    expect(text).toContain('r: 2.00 mm');
+    // area: π·16 px² → π·16·0.25 mm² ≈ 12.57 mm²
+    expect(text).toMatch(/A: 12\.5[67] mm²/);
+  });
+
+  it('skips annotations whose geometry yields no requested metric', () => {
+    const provider = createMeasurementProvider({ area: true });
+    const point = ann('p1', 'point', { type: 'point', position: { x: 0, y: 0 } });
+    const circle = ann('c1', 'circle', { type: 'circle', center: { x: 0, y: 0 }, radius: 3 });
+    const decorations = provider({ annotations: [point, circle] });
+    expect(decorations).toHaveLength(1);
+    expect(decorations[0]!.relatedAnnotationIds).toEqual(['c1']);
+  });
+
+  it('produces stable, annotation-scoped ids for diffing', () => {
+    const provider = createMeasurementProvider({ area: true });
+    const a = ann('rect-1', 'rectangle', {
+      type: 'rectangle',
+      origin: { x: 0, y: 0 },
+      width: 4,
+      height: 4,
+      rotation: 0,
+    });
+    const [d] = provider({ annotations: [a] });
+    expect(d!.id).toBe('measurement:rect-1');
+  });
+
+  it('emits length for lines when length is requested', () => {
+    const provider = createMeasurementProvider({ length: true });
+    const a = ann('l1', 'line', {
+      type: 'line',
+      start: { x: 0, y: 0 },
+      end: { x: 3, y: 4 },
+    });
+    const [d] = provider({ annotations: [a] });
+    expect((d as TextDecoration).text).toContain('L: 5.00 px');
+  });
+});
+
+describe('createLabelProvider', () => {
+  it('renders annotation.label as a text decoration', () => {
+    const provider = createLabelProvider();
+    const a = ann('p1', 'point', { type: 'point', position: { x: 0, y: 0 } }, 'tumor');
+    const [d] = provider({ annotations: [a] });
+    expect((d as TextDecoration).text).toBe('tumor');
+    expect(d!.id).toBe('label:p1');
+  });
+
+  it('skips annotations without a label', () => {
+    const provider = createLabelProvider();
+    const a = ann('p1', 'point', { type: 'point', position: { x: 0, y: 0 } });
+    expect(provider({ annotations: [a] })).toEqual([]);
+  });
+
+  it('honors a custom extractor', () => {
+    const provider = createLabelProvider({ extract: () => 'CUSTOM' });
+    const a = ann('p1', 'point', { type: 'point', position: { x: 0, y: 0 } });
+    const [d] = provider({ annotations: [a] });
+    expect((d as TextDecoration).text).toBe('CUSTOM');
+  });
+});

--- a/packages/decoration/tests/unit/geometry-math.test.ts
+++ b/packages/decoration/tests/unit/geometry-math.test.ts
@@ -1,0 +1,259 @@
+import { describe, expect, it } from 'vitest';
+import type { Geometry } from '@osdlabel/annotation';
+import {
+  area,
+  boundingBox,
+  centroid,
+  distance,
+  length,
+  midpoint,
+  perimeter,
+  radius,
+} from '../../src/geometry-math.js';
+
+describe('distance', () => {
+  it('returns the Euclidean distance between two points', () => {
+    expect(distance({ x: 0, y: 0 }, { x: 3, y: 4 })).toBe(5);
+  });
+  it('is symmetric', () => {
+    expect(distance({ x: 2, y: 7 }, { x: -1, y: 3 })).toBeCloseTo(
+      distance({ x: -1, y: 3 }, { x: 2, y: 7 }),
+    );
+  });
+});
+
+describe('midpoint', () => {
+  it('returns the average of the two points', () => {
+    expect(midpoint({ x: 0, y: 0 }, { x: 4, y: 8 })).toEqual({ x: 2, y: 4 });
+  });
+});
+
+describe('area', () => {
+  it('rectangle: width × height', () => {
+    const g: Geometry = {
+      type: 'rectangle',
+      origin: { x: 5, y: 5 },
+      width: 10,
+      height: 4,
+      rotation: 0,
+    };
+    expect(area(g)).toBe(40);
+  });
+  it('rectangle: rotation does not change area', () => {
+    const a: Geometry = {
+      type: 'rectangle',
+      origin: { x: 0, y: 0 },
+      width: 10,
+      height: 4,
+      rotation: 0,
+    };
+    const b: Geometry = {
+      type: 'rectangle',
+      origin: { x: 0, y: 0 },
+      width: 10,
+      height: 4,
+      rotation: 37,
+    };
+    expect(area(a)).toBe(area(b));
+  });
+  it('circle: π·r²', () => {
+    const g: Geometry = { type: 'circle', center: { x: 0, y: 0 }, radius: 5 };
+    expect(area(g)).toBeCloseTo(Math.PI * 25);
+  });
+  it('polygon: shoelace area (square)', () => {
+    const g: Geometry = {
+      type: 'polygon',
+      points: [
+        { x: 0, y: 0 },
+        { x: 4, y: 0 },
+        { x: 4, y: 4 },
+        { x: 0, y: 4 },
+      ],
+    };
+    expect(area(g)).toBe(16);
+  });
+  it('polygon: shoelace area is winding-independent', () => {
+    const ccw: Geometry = {
+      type: 'polygon',
+      points: [
+        { x: 0, y: 0 },
+        { x: 4, y: 0 },
+        { x: 4, y: 4 },
+        { x: 0, y: 4 },
+      ],
+    };
+    const cw: Geometry = {
+      type: 'polygon',
+      points: [...ccw.points].reverse(),
+    };
+    expect(area(cw)).toBe(area(ccw));
+  });
+  it('line / point / polyline area is 0', () => {
+    expect(area({ type: 'line', start: { x: 0, y: 0 }, end: { x: 3, y: 4 } })).toBe(0);
+    expect(area({ type: 'point', position: { x: 1, y: 2 } })).toBe(0);
+    expect(
+      area({
+        type: 'polyline',
+        points: [
+          { x: 0, y: 0 },
+          { x: 1, y: 1 },
+        ],
+      }),
+    ).toBe(0);
+  });
+});
+
+describe('perimeter', () => {
+  it('rectangle: 2·(w + h)', () => {
+    expect(
+      perimeter({ type: 'rectangle', origin: { x: 0, y: 0 }, width: 3, height: 7, rotation: 0 }),
+    ).toBe(20);
+  });
+  it('circle: 2·π·r', () => {
+    expect(perimeter({ type: 'circle', center: { x: 0, y: 0 }, radius: 5 })).toBeCloseTo(
+      2 * Math.PI * 5,
+    );
+  });
+  it('polygon: sum of edge lengths (including closing edge)', () => {
+    expect(
+      perimeter({
+        type: 'polygon',
+        points: [
+          { x: 0, y: 0 },
+          { x: 4, y: 0 },
+          { x: 4, y: 3 },
+          { x: 0, y: 3 },
+        ],
+      }),
+    ).toBe(14);
+  });
+  it('open shapes return 0', () => {
+    expect(perimeter({ type: 'line', start: { x: 0, y: 0 }, end: { x: 1, y: 1 } })).toBe(0);
+    expect(
+      perimeter({
+        type: 'polyline',
+        points: [
+          { x: 0, y: 0 },
+          { x: 1, y: 1 },
+        ],
+      }),
+    ).toBe(0);
+    expect(perimeter({ type: 'point', position: { x: 0, y: 0 } })).toBe(0);
+  });
+});
+
+describe('length', () => {
+  it('line: distance between endpoints', () => {
+    expect(length({ type: 'line', start: { x: 0, y: 0 }, end: { x: 3, y: 4 } })).toBe(5);
+  });
+  it('polyline: sum of segments (open)', () => {
+    expect(
+      length({
+        type: 'polyline',
+        points: [
+          { x: 0, y: 0 },
+          { x: 3, y: 0 },
+          { x: 3, y: 4 },
+        ],
+      }),
+    ).toBe(7);
+  });
+  it('point: 0', () => {
+    expect(length({ type: 'point', position: { x: 1, y: 1 } })).toBe(0);
+  });
+  it('closed shapes: equals perimeter', () => {
+    const rect: Geometry = {
+      type: 'rectangle',
+      origin: { x: 0, y: 0 },
+      width: 3,
+      height: 4,
+      rotation: 0,
+    };
+    expect(length(rect)).toBe(perimeter(rect));
+  });
+});
+
+describe('radius', () => {
+  it('returns the radius for circles', () => {
+    expect(radius({ type: 'circle', center: { x: 0, y: 0 }, radius: 7 })).toBe(7);
+  });
+  it('returns undefined for non-circles', () => {
+    expect(radius({ type: 'point', position: { x: 0, y: 0 } })).toBeUndefined();
+    expect(
+      radius({ type: 'rectangle', origin: { x: 0, y: 0 }, width: 1, height: 1, rotation: 0 }),
+    ).toBeUndefined();
+  });
+});
+
+describe('centroid', () => {
+  it('rectangle (no rotation): origin + (w/2, h/2)', () => {
+    expect(
+      centroid({
+        type: 'rectangle',
+        origin: { x: 10, y: 20 },
+        width: 6,
+        height: 8,
+        rotation: 0,
+      }),
+    ).toEqual({ x: 13, y: 24 });
+  });
+  it('rectangle (90° rotation): local (w/2, h/2) rotates about origin', () => {
+    const c = centroid({
+      type: 'rectangle',
+      origin: { x: 0, y: 0 },
+      width: 10,
+      height: 4,
+      rotation: 90,
+    });
+    expect(c.x).toBeCloseTo(-2);
+    expect(c.y).toBeCloseTo(5);
+  });
+  it('circle: center', () => {
+    expect(centroid({ type: 'circle', center: { x: 3, y: 4 }, radius: 7 })).toEqual({ x: 3, y: 4 });
+  });
+  it('line: midpoint', () => {
+    expect(centroid({ type: 'line', start: { x: 0, y: 0 }, end: { x: 6, y: 0 } })).toEqual({
+      x: 3,
+      y: 0,
+    });
+  });
+  it('polygon: average of vertices', () => {
+    expect(
+      centroid({
+        type: 'polygon',
+        points: [
+          { x: 0, y: 0 },
+          { x: 4, y: 0 },
+          { x: 4, y: 4 },
+          { x: 0, y: 4 },
+        ],
+      }),
+    ).toEqual({ x: 2, y: 2 });
+  });
+});
+
+describe('boundingBox', () => {
+  it('rectangle (no rotation)', () => {
+    expect(
+      boundingBox({ type: 'rectangle', origin: { x: 1, y: 2 }, width: 3, height: 4, rotation: 0 }),
+    ).toEqual({ min: { x: 1, y: 2 }, max: { x: 4, y: 6 } });
+  });
+  it('circle expands by radius in both directions', () => {
+    expect(boundingBox({ type: 'circle', center: { x: 5, y: 5 }, radius: 2 })).toEqual({
+      min: { x: 3, y: 3 },
+      max: { x: 7, y: 7 },
+    });
+  });
+  it('polyline covers all points', () => {
+    expect(
+      boundingBox({
+        type: 'polyline',
+        points: [
+          { x: -1, y: 4 },
+          { x: 7, y: 0 },
+          { x: 2, y: -3 },
+        ],
+      }),
+    ).toEqual({ min: { x: -1, y: -3 }, max: { x: 7, y: 4 } });
+  });
+});

--- a/packages/decoration/tests/unit/measurement.test.ts
+++ b/packages/decoration/tests/unit/measurement.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { formatMeasurement, toPhysicalArea, toPhysicalLength } from '../../src/measurement.js';
+
+describe('toPhysicalLength', () => {
+  it('returns pixels when no spacing is provided', () => {
+    expect(toPhysicalLength(100, undefined)).toEqual({ value: 100, unit: 'px' });
+  });
+  it('uses mean spacing by default', () => {
+    expect(toPhysicalLength(10, { x: 0.5, y: 0.7, unit: 'mm' })).toEqual({
+      value: 6,
+      unit: 'mm',
+    });
+  });
+  it('honors axis="x"', () => {
+    expect(toPhysicalLength(10, { x: 0.5, y: 0.7, unit: 'mm' }, 'x')).toEqual({
+      value: 5,
+      unit: 'mm',
+    });
+  });
+  it('honors axis="y"', () => {
+    expect(toPhysicalLength(10, { x: 0.5, y: 0.7, unit: 'mm' }, 'y')).toEqual({
+      value: 7,
+      unit: 'mm',
+    });
+  });
+});
+
+describe('toPhysicalArea', () => {
+  it('returns px² when no spacing is provided', () => {
+    expect(toPhysicalArea(50, undefined)).toEqual({ value: 50, unit: 'px²' });
+  });
+  it('multiplies by x*y product (anisotropic-safe)', () => {
+    expect(toPhysicalArea(100, { x: 0.5, y: 0.4, unit: 'mm' })).toEqual({
+      value: 20,
+      unit: 'mm²',
+    });
+  });
+});
+
+describe('formatMeasurement', () => {
+  it('default precision is 2 with a space separator', () => {
+    expect(formatMeasurement({ value: 12.34567, unit: 'mm' })).toBe('12.35 mm');
+  });
+  it('honors precision option', () => {
+    expect(formatMeasurement({ value: 1 / 3, unit: 'mm' }, { precision: 4 })).toBe('0.3333 mm');
+  });
+  it('honors unitSeparator', () => {
+    expect(formatMeasurement({ value: 5, unit: 'px' }, { unitSeparator: '' })).toBe('5.00px');
+  });
+});

--- a/packages/decoration/tsconfig.build.json
+++ b/packages/decoration/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", "dist", "tests", "**/*.test.ts"]
+}

--- a/packages/decoration/tsconfig.json
+++ b/packages/decoration/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "exactOptionalPropertyTypes": true,
+    "noFallthroughCasesInSwitch": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "tests"]
+}

--- a/packages/decoration/typedoc.json
+++ b/packages/decoration/typedoc.json
@@ -1,0 +1,3 @@
+{
+  "entryPoints": ["src/index.ts"]
+}

--- a/packages/decoration/vitest.config.ts
+++ b/packages/decoration/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['tests/**/*.test.ts'],
+    passWithNoTests: true,
+  },
+});

--- a/packages/fabric-osd/src/decoration/decoration-layer.ts
+++ b/packages/fabric-osd/src/decoration/decoration-layer.ts
@@ -118,7 +118,7 @@ export class DecorationLayer {
       const offsetX = d.offset?.x ?? 0;
       const offsetY = d.offset?.y ?? 0;
       const align = placementTranslate(d.placement);
-      el.style.transform = `translate(${screen.x + offsetX}px, ${screen.y + offsetY}px) translate(${align.x}, ${align.y})`;
+      el.style.transform = `translate3d(${screen.x + offsetX}px, ${screen.y + offsetY}px, 0) translate3d(${align.x}, ${align.y}, 0)`;
     }
   }
 
@@ -180,7 +180,9 @@ export class DecorationLayer {
 }
 
 function applyTextStyle(el: HTMLDivElement, decoration: TextDecoration): void {
-  el.textContent = decoration.text;
+  if (el.textContent !== decoration.text) {
+    el.textContent = decoration.text;
+  }
   el.dataset.decorationId = decoration.id;
   const style = decoration.style;
   el.style.color = style?.color ?? DEFAULT_TEXT_COLOR;
@@ -192,7 +194,10 @@ function applyTextStyle(el: HTMLDivElement, decoration: TextDecoration): void {
   el.style.borderRadius = style?.borderRadius ?? DEFAULT_TEXT_BORDER_RADIUS;
   el.style.whiteSpace = 'pre';
   el.style.userSelect = 'none';
-  el.className = style?.className ?? '';
+  const nextClassName = style?.className ?? '';
+  if (el.className !== nextClassName) {
+    el.className = nextClassName;
+  }
 }
 
 function placementTranslate(placement: TextPlacement | undefined): {

--- a/packages/fabric-osd/src/decoration/decoration-layer.ts
+++ b/packages/fabric-osd/src/decoration/decoration-layer.ts
@@ -1,0 +1,217 @@
+import { Line as FabricLine } from 'fabric';
+import type {
+  Decoration,
+  LineDecoration,
+  TextDecoration,
+  TextPlacement,
+} from '@osdlabel/decoration';
+import type { FabricOverlay } from '../overlay/fabric-overlay.js';
+
+const DEFAULT_TEXT_COLOR = '#ffffff';
+const DEFAULT_FONT_SIZE_PX = 12;
+const DEFAULT_FONT_FAMILY = 'sans-serif';
+const DEFAULT_TEXT_BACKGROUND = 'rgba(0, 0, 0, 0.55)';
+const DEFAULT_TEXT_PADDING = '2px 4px';
+const DEFAULT_TEXT_BORDER_RADIUS = '2px';
+const DEFAULT_LINE_STROKE = '#ffd700';
+const DEFAULT_LINE_STROKE_WIDTH = 1.5;
+const DEFAULT_LINE_OPACITY = 0.85;
+const DEFAULT_DASH_PATTERN = [6, 4] as const;
+
+/**
+ * Renderer for {@link Decoration}s on top of a {@link FabricOverlay}.
+ *
+ * Text decorations are rendered as absolutely-positioned DOM elements
+ * inside a host `<div>` appended to the OSD container — they stay upright,
+ * crisp, and constant screen-size at all zooms and rotations with no
+ * counter-transform math. Line decorations are rendered as non-interactive
+ * Fabric `Line` objects on the overlay's canvas, so they pan/zoom/rotate/
+ * flip with the image at zero per-frame cost.
+ *
+ * Construct once per cell, call `setDecorations` whenever the derived
+ * decoration list changes, and call `destroy` on cleanup.
+ */
+export class DecorationLayer {
+  private readonly _overlay: FabricOverlay;
+  private readonly _hostEl: HTMLDivElement;
+  private readonly _unsubscribeSync: () => void;
+  private readonly _textEls = new Map<string, HTMLDivElement>();
+  private readonly _lineObjects = new Map<string, FabricLine>();
+  private _decorations: readonly Decoration[] = [];
+  private _destroyed = false;
+
+  constructor(overlay: FabricOverlay) {
+    this._overlay = overlay;
+
+    this._hostEl = document.createElement('div');
+    this._hostEl.style.position = 'absolute';
+    this._hostEl.style.inset = '0';
+    this._hostEl.style.pointerEvents = 'none';
+    this._hostEl.style.overflow = 'hidden';
+    this._hostEl.dataset.osdlabel = 'decoration-layer';
+    overlay.overlayElement.appendChild(this._hostEl);
+
+    this._unsubscribeSync = overlay.onSync(() => this._repositionText());
+  }
+
+  /** Replace the current decorations. Diffed by id for stable element reuse. */
+  setDecorations(decorations: readonly Decoration[]): void {
+    if (this._destroyed) return;
+    this._decorations = decorations;
+    this._diffText(decorations);
+    this._diffLines(decorations);
+    this._repositionText();
+    this._overlay.canvas.requestRenderAll();
+  }
+
+  destroy(): void {
+    if (this._destroyed) return;
+    this._destroyed = true;
+    this._unsubscribeSync();
+    for (const obj of this._lineObjects.values()) {
+      this._overlay.canvas.remove(obj);
+    }
+    this._lineObjects.clear();
+    this._textEls.clear();
+    this._hostEl.remove();
+  }
+
+  // ── Text decorations (DOM) ────────────────────────────────────────────
+
+  private _diffText(decorations: readonly Decoration[]): void {
+    const wanted = new Map<string, TextDecoration>();
+    for (const d of decorations) {
+      if (d.type === 'text') wanted.set(d.id, d);
+    }
+
+    // Remove gone
+    for (const [id, el] of this._textEls) {
+      if (!wanted.has(id)) {
+        el.remove();
+        this._textEls.delete(id);
+      }
+    }
+
+    // Add new / update existing
+    for (const [id, decoration] of wanted) {
+      let el = this._textEls.get(id);
+      if (!el) {
+        el = document.createElement('div');
+        el.style.position = 'absolute';
+        el.style.top = '0';
+        el.style.left = '0';
+        el.style.willChange = 'transform';
+        el.dataset.osdlabel = 'decoration-text';
+        this._hostEl.appendChild(el);
+        this._textEls.set(id, el);
+      }
+      applyTextStyle(el, decoration);
+    }
+  }
+
+  private _repositionText(): void {
+    for (const d of this._decorations) {
+      if (d.type !== 'text') continue;
+      const el = this._textEls.get(d.id);
+      if (!el) continue;
+      const screen = this._overlay.imageToScreen(d.anchor);
+      const offsetX = d.offset?.x ?? 0;
+      const offsetY = d.offset?.y ?? 0;
+      const align = placementTranslate(d.placement);
+      el.style.transform = `translate(${screen.x + offsetX}px, ${screen.y + offsetY}px) translate(${align.x}, ${align.y})`;
+    }
+  }
+
+  // ── Line decorations (Fabric) ─────────────────────────────────────────
+
+  private _diffLines(decorations: readonly Decoration[]): void {
+    const wanted = new Map<string, LineDecoration>();
+    for (const d of decorations) {
+      if (d.type === 'line') wanted.set(d.id, d);
+    }
+
+    // Remove gone
+    for (const [id, obj] of this._lineObjects) {
+      if (!wanted.has(id)) {
+        this._overlay.canvas.remove(obj);
+        this._lineObjects.delete(id);
+      }
+    }
+
+    // Add new / update existing
+    for (const [id, decoration] of wanted) {
+      let obj = this._lineObjects.get(id);
+      if (!obj) {
+        obj = new FabricLine(
+          [decoration.start.x, decoration.start.y, decoration.end.x, decoration.end.y],
+          {
+            selectable: false,
+            evented: false,
+            strokeUniform: true,
+            objectCaching: false,
+            hoverCursor: 'default',
+          },
+        );
+        // `_readOnly:true` ensures FabricOverlay.setMode() keeps this object
+        // non-interactive in both navigation and annotation modes. We do NOT
+        // set `id` — that property is reserved for annotation objects and is
+        // how the host clears annotations on context switch.
+        obj._readOnly = true;
+        this._overlay.canvas.add(obj);
+        this._lineObjects.set(id, obj);
+      } else {
+        obj.set({
+          x1: decoration.start.x,
+          y1: decoration.start.y,
+          x2: decoration.end.x,
+          y2: decoration.end.y,
+        });
+      }
+      const style = decoration.style;
+      obj.set({
+        stroke: style?.stroke ?? DEFAULT_LINE_STROKE,
+        strokeWidth: style?.strokeWidth ?? DEFAULT_LINE_STROKE_WIDTH,
+        opacity: style?.opacity ?? DEFAULT_LINE_OPACITY,
+        strokeDashArray: decoration.dashed ? [...DEFAULT_DASH_PATTERN] : null,
+      });
+      obj.setCoords();
+    }
+  }
+}
+
+function applyTextStyle(el: HTMLDivElement, decoration: TextDecoration): void {
+  el.textContent = decoration.text;
+  el.dataset.decorationId = decoration.id;
+  const style = decoration.style;
+  el.style.color = style?.color ?? DEFAULT_TEXT_COLOR;
+  el.style.fontSize = `${style?.fontSize ?? DEFAULT_FONT_SIZE_PX}px`;
+  el.style.fontFamily = style?.fontFamily ?? DEFAULT_FONT_FAMILY;
+  el.style.fontWeight = style?.fontWeight !== undefined ? String(style.fontWeight) : '';
+  el.style.background = style?.background ?? DEFAULT_TEXT_BACKGROUND;
+  el.style.padding = style?.padding ?? DEFAULT_TEXT_PADDING;
+  el.style.borderRadius = style?.borderRadius ?? DEFAULT_TEXT_BORDER_RADIUS;
+  el.style.whiteSpace = 'pre';
+  el.style.userSelect = 'none';
+  el.className = style?.className ?? '';
+}
+
+function placementTranslate(placement: TextPlacement | undefined): {
+  readonly x: string;
+  readonly y: string;
+} {
+  switch (placement) {
+    case 'center':
+      return { x: '-50%', y: '-50%' };
+    case 'top':
+      return { x: '-50%', y: '0' };
+    case 'bottom':
+      return { x: '-50%', y: '-100%' };
+    case 'left':
+      return { x: '0', y: '-50%' };
+    case 'right':
+      return { x: '-100%', y: '-50%' };
+    case 'top-left':
+    case undefined:
+      return { x: '0', y: '0' };
+  }
+}

--- a/packages/fabric-osd/src/index.ts
+++ b/packages/fabric-osd/src/index.ts
@@ -1,2 +1,3 @@
 export { FabricOverlay, computeViewportTransform } from './overlay/fabric-overlay.js';
 export type { OverlayOptions, OverlayMode } from './overlay/fabric-overlay.js';
+export { DecorationLayer } from './decoration/decoration-layer.js';

--- a/packages/fabric-osd/src/overlay/fabric-overlay.ts
+++ b/packages/fabric-osd/src/overlay/fabric-overlay.ts
@@ -111,6 +111,9 @@ export class FabricOverlay {
    */
   private _panGestureActive = false;
 
+  /** Callbacks fired at the end of every `sync()`. */
+  private readonly _syncSubscribers = new Set<() => void>();
+
   // ── Bound OSD event handlers (for add/removeHandler) ─────────────
   private readonly _onAnimation = (): void => {
     this.sync();
@@ -229,6 +232,29 @@ export class FabricOverlay {
     return this._fabricCanvas;
   }
 
+  /**
+   * The OSD container element. Companion layers (e.g. decoration text in
+   * DOM) can append themselves here to be clipped/positioned together with
+   * the Fabric canvas.
+   */
+  get overlayElement(): HTMLElement {
+    return this._viewer.canvas;
+  }
+
+  /**
+   * Register a callback fired at the end of every `sync()` — i.e. on every
+   * OSD `animation`, `animation-finish`, `resize`, `open`, `flip`, `rotate`
+   * event. Used by companion layers to reposition screen-space content.
+   *
+   * Returns an unsubscribe function.
+   */
+  onSync(callback: () => void): () => void {
+    this._syncSubscribers.add(callback);
+    return () => {
+      this._syncSubscribers.delete(callback);
+    };
+  }
+
   /** Apply a view transform (rotation/flip) to the OpenSeadragon viewer */
   applyViewTransform(transform: CellTransform): void {
     let rotation = transform.rotation;
@@ -283,6 +309,9 @@ export class FabricOverlay {
     const vpt = computeViewportTransform(this._viewer);
     this._fabricCanvas.setViewportTransform(vpt);
     this._fabricCanvas.renderAll();
+    if (this._syncSubscribers.size > 0) {
+      for (const cb of this._syncSubscribers) cb();
+    }
   }
 
   /** Set the overlay interaction mode */
@@ -345,6 +374,7 @@ export class FabricOverlay {
 
   /** Clean up all event listeners and DOM elements */
   destroy(): void {
+    this._syncSubscribers.clear();
     this._overlayTracker.destroy();
     this._viewer.removeHandler(OSD_ANIMATION, this._onAnimation);
     this._viewer.removeHandler(OSD_ANIMATION_FINISH, this._onAnimationFinish);

--- a/packages/fabric-osd/src/overlay/fabric-overlay.ts
+++ b/packages/fabric-osd/src/overlay/fabric-overlay.ts
@@ -75,6 +75,49 @@ export function computeViewportTransform(viewer: OpenSeadragon.Viewer): TMat2D {
 }
 
 /**
+ * Convert an image-space point to screen-space, composing the same
+ * horizontal-flip mirror that {@link computeViewportTransform} applies.
+ *
+ * OSD's `imageToViewerElementCoordinates` ignores flip (flip is applied
+ * by OSD's drawer at render time). Without this composition, callers
+ * that use the result as an absolute screen coordinate — e.g. the
+ * `DecorationLayer` placing text divs — drift relative to the painted
+ * image when only one of `flippedH` or `flippedV` is set (when both
+ * are set the cell-level flip cancels: see
+ * `FabricOverlay.applyViewTransform`).
+ *
+ * Exported for unit testing and for callers that want flip-aware
+ * coordinates without a {@link FabricOverlay} instance.
+ */
+export function imageToScreenFlipAware(viewer: OpenSeadragon.Viewer, imagePoint: Point): Point {
+  const viewport = viewer.viewport;
+  const osdPoint = viewport.imageToViewerElementCoordinates(
+    new OpenSeadragon.Point(imagePoint.x, imagePoint.y),
+  );
+  let x = osdPoint.x;
+  if (viewport.getFlip()) {
+    x = viewport.getContainerSize().x - x;
+  }
+  return { x, y: osdPoint.y };
+}
+
+/**
+ * Inverse of {@link imageToScreenFlipAware}: convert a screen-space point
+ * to image-space, undoing the horizontal-flip mirror first.
+ */
+export function screenToImageFlipAware(viewer: OpenSeadragon.Viewer, screenPoint: Point): Point {
+  const viewport = viewer.viewport;
+  let sx = screenPoint.x;
+  if (viewport.getFlip()) {
+    sx = viewport.getContainerSize().x - sx;
+  }
+  const osdPoint = viewport.viewerElementToImageCoordinates(
+    new OpenSeadragon.Point(sx, screenPoint.y),
+  );
+  return { x: osdPoint.x, y: osdPoint.y };
+}
+
+/**
  * A Fabric.js canvas overlay synchronized with an OpenSeaDragon viewer.
  *
  * Handles event routing between OSD and Fabric using an OSD MouseTracker
@@ -356,20 +399,14 @@ export class FabricOverlay {
     return this._mode;
   }
 
-  /** Convert a point from screen-space to image-space */
+  /** Convert a point from screen-space to image-space. Flip-aware. */
   screenToImage(screenPoint: Point): Point {
-    const osdPoint = this._viewer.viewport.viewerElementToImageCoordinates(
-      new OpenSeadragon.Point(screenPoint.x, screenPoint.y),
-    );
-    return { x: osdPoint.x, y: osdPoint.y };
+    return screenToImageFlipAware(this._viewer, screenPoint);
   }
 
-  /** Convert a point from image-space to screen-space */
+  /** Convert a point from image-space to screen-space. Flip-aware. */
   imageToScreen(imagePoint: Point): Point {
-    const osdPoint = this._viewer.viewport.imageToViewerElementCoordinates(
-      new OpenSeadragon.Point(imagePoint.x, imagePoint.y),
-    );
-    return { x: osdPoint.x, y: osdPoint.y };
+    return imageToScreenFlipAware(this._viewer, imagePoint);
   }
 
   /** Clean up all event listeners and DOM elements */

--- a/packages/fabric-osd/tests/unit/decoration/decoration-layer.test.ts
+++ b/packages/fabric-osd/tests/unit/decoration/decoration-layer.test.ts
@@ -108,7 +108,7 @@ describe('DecorationLayer', () => {
     ]);
     const el = hostParent.querySelector('[data-decoration-id="x"]') as HTMLElement;
     // imageToScreen doubles the coords (mock) → (10, 14). Plus offset → (13, 13).
-    expect(el.style.transform).toContain('translate(13px, 13px)');
+    expect(el.style.transform).toContain('translate3d(13px, 13px, 0)');
     layer.destroy();
   });
 
@@ -126,13 +126,13 @@ describe('DecorationLayer', () => {
     ]);
     const el = hostParent.querySelector('[data-decoration-id="x"]') as HTMLElement;
     // Initial position: imageToScreen mock doubles → (2,2)
-    expect(el.style.transform).toContain('translate(2px, 2px)');
+    expect(el.style.transform).toContain('translate3d(2px, 2px, 0)');
     // Change the mock to triple, then fire sync
     (overlay.imageToScreen as ReturnType<typeof vi.fn>).mockImplementation(
       (p: { x: number; y: number }) => ({ x: p.x * 3, y: p.y * 3 }),
     );
     for (const cb of syncSubscribers) cb();
-    expect(el.style.transform).toContain('translate(3px, 3px)');
+    expect(el.style.transform).toContain('translate3d(3px, 3px, 0)');
     layer.destroy();
   });
 
@@ -150,7 +150,7 @@ describe('DecorationLayer', () => {
       },
     ]);
     const el = hostParent.querySelector('[data-decoration-id="centered"]') as HTMLElement;
-    expect(el.style.transform).toContain('translate(-50%, -50%)');
+    expect(el.style.transform).toContain('translate3d(-50%, -50%, 0)');
     layer.destroy();
   });
 

--- a/packages/fabric-osd/tests/unit/decoration/decoration-layer.test.ts
+++ b/packages/fabric-osd/tests/unit/decoration/decoration-layer.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { DecorationLayer } from '../../../src/decoration/decoration-layer.js';
+import type { FabricOverlay } from '../../../src/overlay/fabric-overlay.js';
+import type { AnnotationId } from '@osdlabel/annotation';
+import type { Decoration } from '@osdlabel/decoration';
+
+/**
+ * A mock FabricOverlay sufficient for unit-testing the DecorationLayer's
+ * DOM and Fabric-canvas interactions. Tests the diff/lifecycle logic
+ * without spinning up a real OSD viewer.
+ */
+function createMockOverlay(): {
+  overlay: FabricOverlay;
+  canvas: {
+    add: ReturnType<typeof vi.fn>;
+    remove: ReturnType<typeof vi.fn>;
+    requestRenderAll: ReturnType<typeof vi.fn>;
+  };
+  hostParent: HTMLElement;
+  syncSubscribers: Set<() => void>;
+} {
+  const hostParent = document.createElement('div');
+  document.body.appendChild(hostParent);
+  const syncSubscribers = new Set<() => void>();
+  const canvas = {
+    add: vi.fn(),
+    remove: vi.fn(),
+    requestRenderAll: vi.fn(),
+  };
+  const overlay = {
+    canvas,
+    overlayElement: hostParent,
+    imageToScreen: vi.fn((p: { x: number; y: number }) => ({ x: p.x * 2, y: p.y * 2 })),
+    onSync: vi.fn((cb: () => void) => {
+      syncSubscribers.add(cb);
+      return () => {
+        syncSubscribers.delete(cb);
+      };
+    }),
+  } as unknown as FabricOverlay;
+  return { overlay, canvas, hostParent, syncSubscribers };
+}
+
+const annId = (s: string): AnnotationId => s as AnnotationId;
+
+const textDeco = (id: string, text = id): Decoration => ({
+  type: 'text',
+  id,
+  relatedAnnotationIds: [annId(id)],
+  text,
+  anchor: { x: 10, y: 20 },
+});
+
+describe('DecorationLayer', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('mounts a host element on construction and subscribes to onSync', () => {
+    const { overlay, hostParent, syncSubscribers } = createMockOverlay();
+    const layer = new DecorationLayer(overlay);
+    expect(hostParent.querySelector('[data-osdlabel="decoration-layer"]')).not.toBeNull();
+    expect(syncSubscribers.size).toBe(1);
+    layer.destroy();
+  });
+
+  it('setDecorations adds DOM elements for text decorations', () => {
+    const { overlay, hostParent } = createMockOverlay();
+    const layer = new DecorationLayer(overlay);
+    layer.setDecorations([textDeco('a', 'Hello'), textDeco('b', 'World')]);
+    const els = hostParent.querySelectorAll('[data-osdlabel="decoration-text"]');
+    expect(els).toHaveLength(2);
+    const texts = Array.from(els).map((el) => el.textContent);
+    expect(texts).toContain('Hello');
+    expect(texts).toContain('World');
+    layer.destroy();
+  });
+
+  it('setDecorations re-running diffs by id (adds new, removes gone, keeps shared)', () => {
+    const { overlay, hostParent } = createMockOverlay();
+    const layer = new DecorationLayer(overlay);
+    layer.setDecorations([textDeco('a'), textDeco('b')]);
+    const elA1 = hostParent.querySelector('[data-decoration-id="a"]');
+    expect(elA1).not.toBeNull();
+
+    // Replace: remove b, add c, keep a (same id => element instance is reused)
+    layer.setDecorations([textDeco('a', 'A2'), textDeco('c')]);
+    const elA2 = hostParent.querySelector('[data-decoration-id="a"]');
+    expect(elA2).toBe(elA1); // element instance reused
+    expect(elA2!.textContent).toBe('A2');
+    expect(hostParent.querySelector('[data-decoration-id="b"]')).toBeNull();
+    expect(hostParent.querySelector('[data-decoration-id="c"]')).not.toBeNull();
+    layer.destroy();
+  });
+
+  it('positions text via overlay.imageToScreen + screen-px offset', () => {
+    const { overlay, hostParent } = createMockOverlay();
+    const layer = new DecorationLayer(overlay);
+    layer.setDecorations([
+      {
+        type: 'text',
+        id: 'x',
+        relatedAnnotationIds: [annId('x')],
+        text: 't',
+        anchor: { x: 5, y: 7 },
+        offset: { x: 3, y: -1 },
+      },
+    ]);
+    const el = hostParent.querySelector('[data-decoration-id="x"]') as HTMLElement;
+    // imageToScreen doubles the coords (mock) → (10, 14). Plus offset → (13, 13).
+    expect(el.style.transform).toContain('translate(13px, 13px)');
+    layer.destroy();
+  });
+
+  it('repositions text on overlay.onSync callback', () => {
+    const { overlay, hostParent, syncSubscribers } = createMockOverlay();
+    const layer = new DecorationLayer(overlay);
+    layer.setDecorations([
+      {
+        type: 'text',
+        id: 'x',
+        relatedAnnotationIds: [annId('x')],
+        text: 't',
+        anchor: { x: 1, y: 1 },
+      },
+    ]);
+    const el = hostParent.querySelector('[data-decoration-id="x"]') as HTMLElement;
+    // Initial position: imageToScreen mock doubles → (2,2)
+    expect(el.style.transform).toContain('translate(2px, 2px)');
+    // Change the mock to triple, then fire sync
+    (overlay.imageToScreen as ReturnType<typeof vi.fn>).mockImplementation(
+      (p: { x: number; y: number }) => ({ x: p.x * 3, y: p.y * 3 }),
+    );
+    for (const cb of syncSubscribers) cb();
+    expect(el.style.transform).toContain('translate(3px, 3px)');
+    layer.destroy();
+  });
+
+  it('applies placement via CSS transform suffix', () => {
+    const { overlay, hostParent } = createMockOverlay();
+    const layer = new DecorationLayer(overlay);
+    layer.setDecorations([
+      {
+        type: 'text',
+        id: 'centered',
+        relatedAnnotationIds: [annId('centered')],
+        text: 't',
+        anchor: { x: 0, y: 0 },
+        placement: 'center',
+      },
+    ]);
+    const el = hostParent.querySelector('[data-decoration-id="centered"]') as HTMLElement;
+    expect(el.style.transform).toContain('translate(-50%, -50%)');
+    layer.destroy();
+  });
+
+  it('destroy removes the host element and unsubscribes', () => {
+    const { overlay, hostParent, syncSubscribers } = createMockOverlay();
+    const layer = new DecorationLayer(overlay);
+    expect(syncSubscribers.size).toBe(1);
+    layer.destroy();
+    expect(hostParent.querySelector('[data-osdlabel="decoration-layer"]')).toBeNull();
+    expect(syncSubscribers.size).toBe(0);
+  });
+});

--- a/packages/fabric-osd/tests/unit/overlay/coordinate-transform.test.ts
+++ b/packages/fabric-osd/tests/unit/overlay/coordinate-transform.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { computeViewportTransform } from '../../../src/overlay/fabric-overlay.js';
+import {
+  computeViewportTransform,
+  imageToScreenFlipAware,
+  screenToImageFlipAware,
+} from '../../../src/overlay/fabric-overlay.js';
 import type OpenSeadragon from 'openseadragon';
 
 /**
@@ -286,4 +290,75 @@ describe('Flip matrix correctness', () => {
       expect(fy).toBeCloseTo(uy); // Y unchanged
     });
   }
+});
+
+describe('imageToScreenFlipAware / screenToImageFlipAware', () => {
+  it('matches OSD without flip', () => {
+    const viewer = createMockViewer({ scale: 2, offsetX: 30, offsetY: 20 });
+    const result = imageToScreenFlipAware(viewer, { x: 40, y: 60 });
+    const expected = viewer.viewport.imageToViewerElementCoordinates({
+      x: 40,
+      y: 60,
+    } as OpenSeadragon.Point);
+    expect(result.x).toBeCloseTo(expected.x);
+    expect(result.y).toBeCloseTo(expected.y);
+  });
+
+  it('agrees with the viewportTransform painted position under flip', () => {
+    // Regression: text decorations drifted at 2× pan speed under
+    // single-flip mode because imageToScreen returned the un-mirrored
+    // coord while Fabric painted at the mirrored coord.
+    const containerWidth = 800;
+    const viewer = createMockViewer({
+      scale: 2,
+      offsetX: 50,
+      offsetY: 30,
+      flip: true,
+      containerWidth,
+    });
+    const vpt = computeViewportTransform(viewer);
+    const imgX = 40;
+    const imgY = 60;
+
+    // Where Fabric paints the annotation
+    const paintedX = vpt[0] * imgX + vpt[2] * imgY + vpt[4];
+    const paintedY = vpt[1] * imgX + vpt[3] * imgY + vpt[5];
+
+    const overlayed = imageToScreenFlipAware(viewer, { x: imgX, y: imgY });
+    expect(overlayed.x).toBeCloseTo(paintedX);
+    expect(overlayed.y).toBeCloseTo(paintedY);
+  });
+
+  it('drift on horizontal pan is zero under flip (regression for text-decoration drift)', () => {
+    // Two viewers with the same flip + scale but different horizontal pans.
+    // The screen position of a fixed image point must change by exactly
+    // the negated delta (mirror geometry), and imageToScreenFlipAware
+    // must agree with that — pre-fix it shifted by +delta instead.
+    const containerWidth = 800;
+    const base = { scale: 2, offsetY: 0, flip: true, containerWidth };
+    const a = createMockViewer({ ...base, offsetX: 100 });
+    const b = createMockViewer({ ...base, offsetX: 160 });
+
+    const p = { x: 40, y: 60 };
+    const screenA = imageToScreenFlipAware(a, p);
+    const screenB = imageToScreenFlipAware(b, p);
+    // Painted position shifts by -(offsetB - offsetA) under flip
+    expect(screenB.x - screenA.x).toBeCloseTo(-60);
+  });
+
+  it('round-trips image → screen → image under flip', () => {
+    const viewer = createMockViewer({
+      scale: 1.5,
+      offsetX: 25,
+      offsetY: -10,
+      rotationDeg: 0,
+      flip: true,
+      containerWidth: 800,
+    });
+    const original = { x: 123, y: 456 };
+    const screen = imageToScreenFlipAware(viewer, original);
+    const back = screenToImageFlipAware(viewer, screen);
+    expect(back.x).toBeCloseTo(original.x, 6);
+    expect(back.y).toBeCloseTo(original.y, 6);
+  });
 });

--- a/packages/osdlabel/package.json
+++ b/packages/osdlabel/package.json
@@ -38,6 +38,7 @@
   "dependencies": {
     "@osdlabel/annotation": "workspace:*",
     "@osdlabel/annotation-context": "workspace:*",
+    "@osdlabel/decoration": "workspace:*",
     "@osdlabel/fabric-annotations": "workspace:*",
     "@osdlabel/fabric-osd": "workspace:*",
     "@osdlabel/validation": "workspace:*",

--- a/packages/osdlabel/src/index.ts
+++ b/packages/osdlabel/src/index.ts
@@ -28,6 +28,7 @@ export type {
   ImageSource,
 } from '@osdlabel/viewer-api';
 export { createImageId, DEFAULT_CELL_TRANSFORM, getAllAnnotationsFlat } from '@osdlabel/viewer-api';
+export type { PixelSpacing } from '@osdlabel/viewer-api';
 
 // Annotation context (re-exported from @osdlabel/annotation-context)
 export type {
@@ -74,8 +75,42 @@ export type {
 } from '@osdlabel/fabric-annotations';
 
 // Fabric-OSD overlay (re-exported from @osdlabel/fabric-osd)
-export { FabricOverlay, computeViewportTransform } from '@osdlabel/fabric-osd';
+export { FabricOverlay, computeViewportTransform, DecorationLayer } from '@osdlabel/fabric-osd';
 export type { OverlayOptions, OverlayMode } from '@osdlabel/fabric-osd';
+
+// Decorations (re-exported from @osdlabel/decoration)
+export type {
+  Decoration,
+  DecorationType,
+  TextDecoration,
+  TextDecorationStyle,
+  TextPlacement,
+  LineDecoration,
+  LineDecorationStyle,
+  DecorationContext,
+  DecorationProvider,
+  Measurement,
+  SpacingAxis,
+  FormatMeasurementOptions,
+  MeasurementProviderOptions,
+  LabelProviderOptions,
+} from '@osdlabel/decoration';
+export {
+  composeProviders,
+  createMeasurementProvider,
+  createLabelProvider,
+  toPhysicalLength,
+  toPhysicalArea,
+  formatMeasurement,
+  area,
+  perimeter,
+  length,
+  radius,
+  distance,
+  centroid,
+  midpoint,
+  boundingBox,
+} from '@osdlabel/decoration';
 
 // Validation schemas (re-exported from @osdlabel/validation)
 export {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -57,6 +57,7 @@
     "immer": "catalog:",
     "@osdlabel/annotation": "workspace:*",
     "@osdlabel/annotation-context": "workspace:*",
+    "@osdlabel/decoration": "workspace:*",
     "@osdlabel/fabric-annotations": "workspace:*",
     "@osdlabel/fabric-osd": "workspace:*",
     "@osdlabel/osd-helper": "workspace:*",

--- a/packages/react/src/components/ViewerCell.tsx
+++ b/packages/react/src/components/ViewerCell.tsx
@@ -107,25 +107,24 @@ export default function ViewerCell({
   // Annotation tool hook
   useAnnotationTool(overlay, imageSource?.id, isActive);
 
+  // Track only the annotation dictionary for this cell's image. Immer keeps
+  // structural sharing, so this reference only changes when annotations on
+  // THIS image mutate — drawing in another cell does not refire the memo
+  // or effects below.
+  const currentImageAnns = imageSource?.id ? annotationState.byImage[imageSource.id] : undefined;
+
   // Visible annotations for the current cell — shared by the annotation
   // sync effect (Fabric objects) and the decoration sync effect.
   const visibleAnnotations: readonly Annotation<OsdFields>[] = useMemo(() => {
-    const imageId = imageSource?.id;
-    if (!imageId) return [];
+    if (!currentImageAnns) return [];
     const activeContextId = contextState.activeContextId;
     const displayedIds = contextState.displayedContextIds;
     const visibleSet = new Set<AnnotationContextId>(displayedIds);
     if (activeContextId) visibleSet.add(activeContextId);
-    const imageAnns = annotationState.byImage[imageId] || {};
     return visibleSet.size > 0
-      ? Object.values(imageAnns).filter((a) => visibleSet.has(a.contextId))
-      : Object.values(imageAnns);
-  }, [
-    imageSource?.id,
-    annotationState,
-    contextState.activeContextId,
-    contextState.displayedContextIds,
-  ]);
+      ? Object.values(currentImageAnns).filter((a) => visibleSet.has(a.contextId))
+      : Object.values(currentImageAnns);
+  }, [currentImageAnns, contextState.activeContextId, contextState.displayedContextIds]);
 
   // Sync annotations to canvas
   useEffect(() => {
@@ -168,7 +167,6 @@ export default function ViewerCell({
   }, [
     overlay,
     imageSource?.id,
-    annotationState,
     contextState.activeContextId,
     contextState.displayedContextIds,
     isActive,

--- a/packages/react/src/components/ViewerCell.tsx
+++ b/packages/react/src/components/ViewerCell.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import OpenSeadragon from 'openseadragon';
-import { FabricOverlay } from '@osdlabel/fabric-osd';
+import { DecorationLayer, FabricOverlay } from '@osdlabel/fabric-osd';
 import { createFabricObjectFromRawData } from '@osdlabel/fabric-annotations';
 import type { OverlayMode } from '@osdlabel/fabric-osd';
 import type { AnnotationContextId } from '@osdlabel/annotation-context';
@@ -9,6 +9,8 @@ import type { ImageSource } from '@osdlabel/viewer-api';
 import { openImage } from '@osdlabel/osd-helper';
 import { useAnnotationTool } from '../hooks/useAnnotationTool.js';
 import { useAnnotator } from '../state/annotator-context.js';
+import type { Annotation } from '@osdlabel/annotation';
+import type { OsdFields } from 'osdlabel';
 
 export interface ViewerCellProps {
   readonly imageSource: ImageSource | undefined;
@@ -26,10 +28,18 @@ export default function ViewerCell({
   onActivate,
   onOverlayReady,
 }: ViewerCellProps) {
-  const { uiState, annotationState, contextState, testMode } = useAnnotator();
+  const {
+    uiState,
+    annotationState,
+    contextState,
+    testMode,
+    decorationProviders,
+    defaultPixelSpacing,
+  } = useAnnotator();
   const containerRef = useRef<HTMLDivElement>(null);
   const viewerRef = useRef<OpenSeadragon.Viewer | undefined>(undefined);
   const overlayRef = useRef<FabricOverlay | undefined>(undefined);
+  const decorationLayerRef = useRef<DecorationLayer | undefined>(undefined);
   const [overlay, setOverlay] = useState<FabricOverlay>();
 
   // Initialize OSD viewer on mount
@@ -52,6 +62,7 @@ export default function ViewerCell({
       if (!viewerRef.current || overlayRef.current) return;
       const ov = new FabricOverlay(viewerRef.current, { testMode });
       overlayRef.current = ov;
+      decorationLayerRef.current = new DecorationLayer(ov);
       setOverlay(ov);
       onOverlayReady?.(ov);
     });
@@ -62,6 +73,8 @@ export default function ViewerCell({
     }
 
     return () => {
+      decorationLayerRef.current?.destroy();
+      decorationLayerRef.current = undefined;
       overlayRef.current?.destroy();
       overlayRef.current = undefined;
       setOverlay(undefined);
@@ -94,22 +107,33 @@ export default function ViewerCell({
   // Annotation tool hook
   useAnnotationTool(overlay, imageSource?.id, isActive);
 
+  // Visible annotations for the current cell — shared by the annotation
+  // sync effect (Fabric objects) and the decoration sync effect.
+  const visibleAnnotations: readonly Annotation<OsdFields>[] = useMemo(() => {
+    const imageId = imageSource?.id;
+    if (!imageId) return [];
+    const activeContextId = contextState.activeContextId;
+    const displayedIds = contextState.displayedContextIds;
+    const visibleSet = new Set<AnnotationContextId>(displayedIds);
+    if (activeContextId) visibleSet.add(activeContextId);
+    const imageAnns = annotationState.byImage[imageId] || {};
+    return visibleSet.size > 0
+      ? Object.values(imageAnns).filter((a) => visibleSet.has(a.contextId))
+      : Object.values(imageAnns);
+  }, [
+    imageSource?.id,
+    annotationState,
+    contextState.activeContextId,
+    contextState.displayedContextIds,
+  ]);
+
   // Sync annotations to canvas
   useEffect(() => {
     if (!overlay || !imageSource?.id) return;
 
     const imageId = imageSource.id;
     const activeContextId = contextState.activeContextId;
-    const displayedIds = contextState.displayedContextIds;
-
-    const visibleSet = new Set<AnnotationContextId>(displayedIds);
-    if (activeContextId) visibleSet.add(activeContextId);
-
-    const imageAnns = annotationState.byImage[imageId] || {};
-    const matching =
-      visibleSet.size > 0
-        ? Object.values(imageAnns).filter((a) => visibleSet.has(a.contextId))
-        : Object.values(imageAnns);
+    const matching = visibleAnnotations;
 
     // Clear existing annotation objects
     const toRemove = overlay.canvas.getObjects().filter((obj) => obj.id);
@@ -148,6 +172,31 @@ export default function ViewerCell({
     contextState.activeContextId,
     contextState.displayedContextIds,
     isActive,
+    visibleAnnotations,
+  ]);
+
+  // Sync decorations to overlay (pure derivation of visible annotations +
+  // pixelSpacing + providers).
+  useEffect(() => {
+    const layer = decorationLayerRef.current;
+    if (!layer) return;
+    if (!decorationProviders || decorationProviders.length === 0) {
+      layer.setDecorations([]);
+      return;
+    }
+    const pixelSpacing = imageSource?.pixelSpacing ?? defaultPixelSpacing;
+    const ctx =
+      pixelSpacing !== undefined
+        ? { annotations: visibleAnnotations, pixelSpacing }
+        : { annotations: visibleAnnotations };
+    const decorations = decorationProviders.flatMap((p) => p(ctx));
+    layer.setDecorations(decorations);
+  }, [
+    overlay,
+    visibleAnnotations,
+    decorationProviders,
+    defaultPixelSpacing,
+    imageSource?.pixelSpacing,
   ]);
 
   return (

--- a/packages/react/src/state/annotator-context.tsx
+++ b/packages/react/src/state/annotator-context.tsx
@@ -9,9 +9,16 @@ import {
 } from 'react';
 import { castDraft, produce } from 'immer';
 import type { AnnotationId } from '@osdlabel/annotation';
-import type { ImageId, AnnotationState, KeyboardShortcutMap, UIState } from '@osdlabel/viewer-api';
+import type {
+  ImageId,
+  AnnotationState,
+  KeyboardShortcutMap,
+  PixelSpacing,
+  UIState,
+} from '@osdlabel/viewer-api';
 import { getAllAnnotationsFlat } from '@osdlabel/viewer-api';
 import type { ConstraintStatus, ContextState } from '@osdlabel/annotation-context';
+import type { DecorationProvider } from '@osdlabel/decoration';
 import type { OsdAnnotation, OsdFields } from 'osdlabel';
 import {
   DEFAULT_KEYBOARD_SHORTCUTS,
@@ -38,6 +45,8 @@ interface AnnotatorContextValue {
   shortcuts: KeyboardShortcutMap;
   activeImageId: ImageId | undefined;
   testMode: boolean;
+  decorationProviders: readonly DecorationProvider<OsdFields>[];
+  defaultPixelSpacing: PixelSpacing | undefined;
 }
 
 const AnnotatorContext = createContext<AnnotatorContextValue | null>(null);
@@ -50,6 +59,15 @@ export interface AnnotatorProviderProps {
   readonly keyboardShortcuts?: Partial<KeyboardShortcutMap> | undefined;
   readonly shouldSkipKeyboardShortcutPredicate?: ((target: HTMLElement) => boolean) | undefined;
   readonly testMode?: boolean | undefined;
+  /**
+   * Decoration providers — pure functions that derive text/line decorations
+   * from the visible annotations and pixel-spacing. Composed in array order.
+   */
+  readonly decorationProviders?: readonly DecorationProvider<OsdFields>[] | undefined;
+  /**
+   * Fallback pixel spacing used when an `ImageSource` does not specify its own.
+   */
+  readonly defaultPixelSpacing?: PixelSpacing | undefined;
 }
 
 export function AnnotatorProvider({
@@ -60,6 +78,8 @@ export function AnnotatorProvider({
   keyboardShortcuts,
   shouldSkipKeyboardShortcutPredicate,
   testMode = false,
+  decorationProviders,
+  defaultPixelSpacing,
 }: AnnotatorProviderProps) {
   const [annotationState, dispatchAnnotation] = useReducer(annotationReducer, undefined, () => {
     const initial = createInitialAnnotationState();
@@ -145,6 +165,8 @@ export function AnnotatorProvider({
     shouldSkipKeyboardShortcutPredicate,
   );
 
+  const stableDecorationProviders = useMemo(() => decorationProviders ?? [], [decorationProviders]);
+
   const value = useMemo<AnnotatorContextValue>(
     () => ({
       annotationState,
@@ -156,6 +178,8 @@ export function AnnotatorProvider({
       shortcuts: mergedShortcuts,
       activeImageId,
       testMode,
+      decorationProviders: stableDecorationProviders,
+      defaultPixelSpacing,
     }),
     [
       annotationState,
@@ -167,6 +191,8 @@ export function AnnotatorProvider({
       mergedShortcuts,
       activeImageId,
       testMode,
+      stableDecorationProviders,
+      defaultPixelSpacing,
     ],
   );
 

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -55,6 +55,7 @@
     "osdlabel": "workspace:*",
     "@osdlabel/annotation": "workspace:*",
     "@osdlabel/annotation-context": "workspace:*",
+    "@osdlabel/decoration": "workspace:*",
     "@osdlabel/fabric-annotations": "workspace:*",
     "@osdlabel/fabric-osd": "workspace:*",
     "@osdlabel/osd-helper": "workspace:*",

--- a/packages/solid/src/components/Annotator.tsx
+++ b/packages/solid/src/components/Annotator.tsx
@@ -126,6 +126,8 @@ const Annotator: Component<AnnotatorProps> = (props) => {
       keyboardShortcuts={props.keyboardShortcuts}
       shouldSkipKeyboardShortcutPredicate={props.shouldSkipKeyboardShortcutPredicate}
       testMode={props.testMode}
+      decorationProviders={props.decorationProviders}
+      defaultPixelSpacing={props.defaultPixelSpacing}
     >
       <AnnotatorSetup contexts={props.contexts} displayedContextIds={props.displayedContextIds} />
       <AnnotatorInner

--- a/packages/solid/src/components/ViewerCell.tsx
+++ b/packages/solid/src/components/ViewerCell.tsx
@@ -1,7 +1,7 @@
 import { onMount, onCleanup, createEffect, on, createSignal } from 'solid-js';
 import type { Component } from 'solid-js';
 import OpenSeadragon from 'openseadragon';
-import { FabricOverlay } from '@osdlabel/fabric-osd';
+import { DecorationLayer, FabricOverlay } from '@osdlabel/fabric-osd';
 import { createFabricObjectFromRawData } from '@osdlabel/fabric-annotations';
 import type { OverlayMode } from '@osdlabel/fabric-osd';
 import type { AnnotationContextId } from '@osdlabel/annotation-context';
@@ -10,6 +10,8 @@ import type { ImageSource } from '@osdlabel/viewer-api';
 import { openImage } from '@osdlabel/osd-helper';
 import { useAnnotationTool } from '../hooks/useAnnotationTool.js';
 import { useAnnotator } from '../state/annotator-context.js';
+import type { Annotation } from '@osdlabel/annotation';
+import type { OsdFields } from 'osdlabel';
 export interface ViewerCellProps {
   readonly imageSource: ImageSource | undefined;
   readonly isActive: boolean;
@@ -20,10 +22,18 @@ export interface ViewerCellProps {
 }
 
 const ViewerCell: Component<ViewerCellProps> = (props) => {
-  const { uiState, annotationState, contextState, testMode } = useAnnotator();
+  const {
+    uiState,
+    annotationState,
+    contextState,
+    testMode,
+    decorationProviders,
+    defaultPixelSpacing,
+  } = useAnnotator();
   let containerRef: HTMLDivElement | undefined;
   let viewer: OpenSeadragon.Viewer | undefined;
   const [overlay, setOverlay] = createSignal<FabricOverlay>();
+  const [decorationLayer, setDecorationLayer] = createSignal<DecorationLayer>();
 
   onMount(() => {
     if (!containerRef) return;
@@ -43,6 +53,7 @@ const ViewerCell: Component<ViewerCellProps> = (props) => {
       if (!viewer || overlay()) return;
       const ov = new FabricOverlay(viewer, { testMode });
       setOverlay(ov);
+      setDecorationLayer(new DecorationLayer(ov));
       props.onOverlayReady?.(ov);
     });
 
@@ -53,6 +64,8 @@ const ViewerCell: Component<ViewerCellProps> = (props) => {
   });
 
   onCleanup(() => {
+    decorationLayer()?.destroy();
+    setDecorationLayer(undefined);
     const ov = overlay();
     ov?.destroy();
     setOverlay(undefined);
@@ -94,27 +107,34 @@ const ViewerCell: Component<ViewerCellProps> = (props) => {
     () => props.isActive,
   );
 
+  // Compute visible annotations for the current cell — used by both the
+  // annotation sync effect (Fabric objects) and the decoration sync effect
+  // (text + line decorations).
+  const visibleAnnotations = (): readonly Annotation<OsdFields>[] => {
+    const imageId = props.imageSource?.id;
+    if (!imageId) return [];
+    const activeContextId = contextState.activeContextId;
+    const displayedIds = contextState.displayedContextIds;
+    const visibleSet = new Set<AnnotationContextId>(displayedIds);
+    if (activeContextId) visibleSet.add(activeContextId);
+    const imageAnns = annotationState.byImage[imageId] || {};
+    return visibleSet.size > 0
+      ? Object.values(imageAnns).filter((a) => visibleSet.has(a.contextId))
+      : Object.values(imageAnns);
+  };
+
   // Sync annotations from state to canvas (full clear-and-reload)
   createEffect(() => {
     const ov = overlay();
     const imageId = props.imageSource?.id;
     const activeContextId = contextState.activeContextId;
-    const displayedIds = contextState.displayedContextIds;
     // Track this as reactive dependencies so the effect re-runs
     void props.isActive;
+    void contextState.displayedContextIds;
 
     if (!ov || !imageId) return;
 
-    // Build set of all context IDs to display (active + explicitly displayed)
-    const visibleSet = new Set<AnnotationContextId>(displayedIds);
-    if (activeContextId) visibleSet.add(activeContextId);
-
-    // Filter annotations by imageId + visible contexts
-    const imageAnns = annotationState.byImage[imageId] || {};
-    const matching =
-      visibleSet.size > 0
-        ? Object.values(imageAnns).filter((a) => visibleSet.has(a.contextId))
-        : Object.values(imageAnns);
+    const matching = visibleAnnotations();
 
     // Clear all existing annotation objects from canvas
     const toRemove = ov.canvas.getObjects().filter((obj) => obj.id);
@@ -149,6 +169,27 @@ const ViewerCell: Component<ViewerCellProps> = (props) => {
       }
       ov.canvas.requestRenderAll();
     })();
+  });
+
+  // Sync decorations from state to canvas. Pure derivation: runs providers
+  // over visible annotations + the current image's pixelSpacing.
+  createEffect(() => {
+    const layer = decorationLayer();
+    if (!layer) return;
+    // Track dependencies
+    void annotationState.changeCounter;
+    void contextState.activeContextId;
+    void contextState.displayedContextIds;
+    const providers = decorationProviders;
+    if (!providers || providers.length === 0) {
+      layer.setDecorations([]);
+      return;
+    }
+    const annotations = visibleAnnotations();
+    const pixelSpacing = props.imageSource?.pixelSpacing ?? defaultPixelSpacing;
+    const ctx = pixelSpacing !== undefined ? { annotations, pixelSpacing } : { annotations };
+    const decorations = providers.flatMap((p) => p(ctx));
+    layer.setDecorations(decorations);
   });
 
   return (

--- a/packages/solid/src/state/annotator-context.tsx
+++ b/packages/solid/src/state/annotator-context.tsx
@@ -1,10 +1,11 @@
 import { createContext, useContext, createEffect, on, type JSX, type Accessor } from 'solid-js';
 import { produce } from 'solid-js/store';
 import type { AnnotationId } from '@osdlabel/annotation';
-import type { ImageId } from '@osdlabel/viewer-api';
+import type { ImageId, PixelSpacing } from '@osdlabel/viewer-api';
 import type { AnnotationState, KeyboardShortcutMap, UIState } from '@osdlabel/viewer-api';
 import { getAllAnnotationsFlat } from '@osdlabel/viewer-api';
 import type { ConstraintStatus, ContextState } from '@osdlabel/annotation-context';
+import type { DecorationProvider } from '@osdlabel/decoration';
 import type { OsdAnnotation, OsdFields } from 'osdlabel';
 import { DEFAULT_KEYBOARD_SHORTCUTS } from 'osdlabel';
 import { createAnnotationStore } from './annotation-store.js';
@@ -27,6 +28,8 @@ interface AnnotatorContextValue {
   shortcuts: KeyboardShortcutMap;
   activeImageId: Accessor<ImageId | undefined>;
   testMode: boolean;
+  decorationProviders: readonly DecorationProvider<OsdFields>[];
+  defaultPixelSpacing: PixelSpacing | undefined;
 }
 
 const KeyboardHandler = (props: {
@@ -53,6 +56,15 @@ export interface AnnotatorProviderProps {
   readonly shouldSkipKeyboardShortcutPredicate?: ((target: HTMLElement) => boolean) | undefined;
   /** When true, exposes internal instances on DOM elements for E2E test access */
   readonly testMode?: boolean | undefined;
+  /**
+   * Decoration providers — pure functions that derive text/line decorations
+   * from the visible annotations and pixel-spacing. Composed in array order.
+   */
+  readonly decorationProviders?: readonly DecorationProvider<OsdFields>[] | undefined;
+  /**
+   * Fallback pixel spacing used when an `ImageSource` does not specify its own.
+   */
+  readonly defaultPixelSpacing?: PixelSpacing | undefined;
 }
 
 export function AnnotatorProvider(props: AnnotatorProviderProps) {
@@ -122,6 +134,8 @@ export function AnnotatorProvider(props: AnnotatorProviderProps) {
     shortcuts: mergedShortcuts,
     activeImageId,
     testMode: props.testMode ?? false,
+    decorationProviders: props.decorationProviders ?? [],
+    defaultPixelSpacing: props.defaultPixelSpacing,
   };
 
   return (

--- a/packages/viewer-api/src/types.ts
+++ b/packages/viewer-api/src/types.ts
@@ -60,12 +60,32 @@ export interface AnnotationState<E extends object = Record<string, never>> {
 
 // ── Image Source ─────────────────────────────────────────────────────────
 
+/**
+ * Physical pixel spacing for an image. Used to convert pixel measurements
+ * (lengths, areas) into physical units. Typical sources are DICOM
+ * `PixelSpacing` tags or vendor calibration metadata.
+ */
+export interface PixelSpacing {
+  /** Physical units per pixel along the horizontal axis. */
+  readonly x: number;
+  /** Physical units per pixel along the vertical axis. */
+  readonly y: number;
+  /** Display unit, e.g. `'mm'`, `'µm'`, `'cm'`. */
+  readonly unit: string;
+}
+
 /** Image source descriptor */
 export interface ImageSource {
   readonly id: ImageId;
   readonly tileSource: string;
   readonly thumbnailUrl?: string | undefined;
   readonly label?: string | undefined;
+  /**
+   * Physical pixel spacing for this image. If omitted, the consumer's
+   * `defaultPixelSpacing` (if any) is used; otherwise measurements are
+   * rendered in pixels.
+   */
+  readonly pixelSpacing?: PixelSpacing | undefined;
 }
 
 // ── Keyboard Shortcuts ───────────────────────────────────────────────────

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -226,6 +226,22 @@ importers:
         specifier: 'catalog:'
         version: 3.0.5(@types/debug@4.1.12)(jsdom@26.1.0(canvas@3.2.1))(yaml@2.8.3)
 
+  packages/decoration:
+    dependencies:
+      '@osdlabel/annotation':
+        specifier: workspace:*
+        version: link:../annotation
+      '@osdlabel/viewer-api':
+        specifier: workspace:*
+        version: link:../viewer-api
+    devDependencies:
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 3.0.5(@types/debug@4.1.12)(jsdom@26.1.0(canvas@3.2.1))(yaml@2.8.3)
+
   packages/fabric-annotations:
     dependencies:
       '@osdlabel/annotation':
@@ -253,6 +269,9 @@ importers:
       '@osdlabel/annotation':
         specifier: workspace:*
         version: link:../annotation
+      '@osdlabel/decoration':
+        specifier: workspace:*
+        version: link:../decoration
       '@osdlabel/fabric-annotations':
         specifier: workspace:*
         version: link:../fabric-annotations
@@ -312,6 +331,9 @@ importers:
       '@osdlabel/annotation-context':
         specifier: workspace:*
         version: link:../annotation-context
+      '@osdlabel/decoration':
+        specifier: workspace:*
+        version: link:../decoration
       '@osdlabel/fabric-annotations':
         specifier: workspace:*
         version: link:../fabric-annotations
@@ -361,6 +383,9 @@ importers:
       '@osdlabel/annotation-context':
         specifier: workspace:*
         version: link:../annotation-context
+      '@osdlabel/decoration':
+        specifier: workspace:*
+        version: link:../decoration
       '@osdlabel/fabric-annotations':
         specifier: workspace:*
         version: link:../fabric-annotations
@@ -428,6 +453,9 @@ importers:
       '@osdlabel/annotation-context':
         specifier: workspace:*
         version: link:../annotation-context
+      '@osdlabel/decoration':
+        specifier: workspace:*
+        version: link:../decoration
       '@osdlabel/fabric-annotations':
         specifier: workspace:*
         version: link:../fabric-annotations


### PR DESCRIPTION
Introduce a declarative decoration system that renders text labels,
computed geometric measurements, and connector lines alongside
annotations — purely derived from annotation state, never serialized.

New @osdlabel/decoration package (zero framework deps):
- Decoration discriminated union (TextDecoration, LineDecoration) and
  DecorationProvider contract for pure (annotations, pixelSpacing) →
  Decoration[] functions, composable via composeProviders
- Geometry math utilities on the Geometry union: area, perimeter,
  length, radius, distance, centroid, midpoint, boundingBox (with
  shoelace polygon area and rotation-aware rectangle centroid)
- Unit conversion (toPhysicalLength, toPhysicalArea, formatMeasurement)
  driven by PixelSpacing
- Built-in providers: createMeasurementProvider (area, perimeter,
  length, radius) and createLabelProvider (annotation.label)

Renderer (added to @osdlabel/fabric-osd):
- DecorationLayer mounts text decorations as positioned DOM elements
  (upright, crisp, constant screen-size at any zoom/rotation/flip
  without counter-transform math) and line decorations as
  non-interactive Fabric Line objects in image-space (pan/zoom/rotate/
  flip for free via the existing viewportTransform)
- FabricOverlay gains additive onSync(cb) subscription and an
  overlayElement getter so companion layers can hook frame updates

Pixel spacing (added to @osdlabel/viewer-api):
- PixelSpacing type and optional ImageSource.pixelSpacing field
  (per-image, matching DICOM); Annotator gains a defaultPixelSpacing
  fallback prop

Wiring:
- Solid and React ViewerCell construct one DecorationLayer per overlay,
  recompute decorations in a reactive effect off annotation state and
  the active image's pixel spacing, and call setDecorations to diff
- decorationProviders and defaultPixelSpacing exposed via Annotator
  props and AnnotatorContext in both framework packages

Tests: 51 new unit tests (geometry math, measurement formatting,
built-in providers, DecorationLayer DOM diff + onSync repositioning).
All 24 typechecks and 11 test tasks pass.