### PR TITLE
Add live decoration updates during Fabric drag operations

### DIFF
--- a/packages/decoration/src/built-in-providers.ts
+++ b/packages/decoration/src/built-in-providers.ts
@@ -204,8 +204,15 @@ export interface DistanceProviderOptions<E extends object = Record<string, never
   readonly lineStyle?: LineDecorationStyle | undefined;
   readonly textStyle?: TextDecorationStyle | undefined;
   readonly format?: FormatMeasurementOptions | undefined;
-  /** Custom formatter for the distance label; receives the value + unit. */
-  readonly formatLine?: ((measurement: Measurement) => string) | undefined;
+  /**
+   * Custom formatter for the distance label. Receives the value + unit and
+   * a `defaultFormatter` that applies `format` via `formatMeasurement`, so
+   * callers can wrap the standard rendering — e.g.
+   * `formatLine: (m, fmt) => 'Distance: ' + fmt(m)`.
+   */
+  readonly formatLine?:
+    | ((measurement: Measurement, defaultFormatter: (m: Measurement) => string) => string)
+    | undefined;
 }
 
 /**
@@ -218,6 +225,7 @@ export function createDistanceProvider<E extends object = Record<string, never>>
   options: DistanceProviderOptions<E>,
 ): DecorationProvider<E> {
   const dashed = options.dashed ?? true;
+  const defaultFormatter = (m: Measurement): string => formatMeasurement(m, options.format);
   return ({ annotations, pixelSpacing }) => {
     const pairs = options.pair(annotations);
     const decorations: Decoration[] = [];
@@ -227,8 +235,8 @@ export function createDistanceProvider<E extends object = Record<string, never>>
       const pxDistance = geom.distance(pA, pB);
       const measurement = toPhysicalLength(pxDistance, pixelSpacing, 'mean');
       const text = options.formatLine
-        ? options.formatLine(measurement)
-        : formatMeasurement(measurement, options.format);
+        ? options.formatLine(measurement, defaultFormatter)
+        : defaultFormatter(measurement);
       const pairId = pair.id ?? `${pair.a.id}-${pair.b.id}`;
       const relatedIds = [pair.a.id, pair.b.id] as const;
 

--- a/packages/decoration/src/built-in-providers.ts
+++ b/packages/decoration/src/built-in-providers.ts
@@ -2,6 +2,8 @@ import type { Annotation, BaseAnnotation, Geometry, Point } from '@osdlabel/anno
 import type { PixelSpacing } from '@osdlabel/viewer-api';
 import type {
   Decoration,
+  LineDecoration,
+  LineDecorationStyle,
   TextDecoration,
   TextDecorationStyle,
   TextPlacement,
@@ -171,6 +173,85 @@ export function createLabelProvider<E extends object = Record<string, never>>(
         ...(options?.style !== undefined ? { style: options.style } : {}),
       };
       decorations.push(decoration);
+    }
+    return decorations;
+  };
+}
+
+// ── createDistanceProvider ─────────────────────────────────────────────────
+
+/** A pair of annotations the distance provider will render a connector for. */
+export interface AnnotationPair<E extends object = Record<string, never>> {
+  readonly a: Annotation<E>;
+  readonly b: Annotation<E>;
+  /**
+   * Optional explicit id for the pair, used for stable decoration ids across
+   * recomputations. Defaults to `${a.id}-${b.id}`.
+   */
+  readonly id?: string | undefined;
+}
+
+export interface DistanceProviderOptions<E extends object = Record<string, never>> {
+  /**
+   * Pure pairing function. Receives all visible annotations and returns the
+   * pairs to connect. The library does not invent pairing semantics — callers
+   * decide whether to pair consecutive points, look up explicit links via
+   * metadata, etc.
+   */
+  readonly pair: (annotations: readonly Annotation<E>[]) => readonly AnnotationPair<E>[];
+  /** If true (default), the connector line is dashed. */
+  readonly dashed?: boolean | undefined;
+  readonly lineStyle?: LineDecorationStyle | undefined;
+  readonly textStyle?: TextDecorationStyle | undefined;
+  readonly format?: FormatMeasurementOptions | undefined;
+  /** Custom formatter for the distance label; receives the value + unit. */
+  readonly formatLine?: ((measurement: Measurement) => string) | undefined;
+}
+
+/**
+ * A provider that emits a connector line + distance label for each
+ * caller-supplied pair of annotations. Each annotation's anchor is its
+ * geometric centroid (see {@link centroid}); distance is in image pixels
+ * unless `pixelSpacing` converts it to physical units.
+ */
+export function createDistanceProvider<E extends object = Record<string, never>>(
+  options: DistanceProviderOptions<E>,
+): DecorationProvider<E> {
+  const dashed = options.dashed ?? true;
+  return ({ annotations, pixelSpacing }) => {
+    const pairs = options.pair(annotations);
+    const decorations: Decoration[] = [];
+    for (const pair of pairs) {
+      const pA = geom.centroid(pair.a.geometry);
+      const pB = geom.centroid(pair.b.geometry);
+      const pxDistance = geom.distance(pA, pB);
+      const measurement = toPhysicalLength(pxDistance, pixelSpacing, 'mean');
+      const text = options.formatLine
+        ? options.formatLine(measurement)
+        : formatMeasurement(measurement, options.format);
+      const pairId = pair.id ?? `${pair.a.id}-${pair.b.id}`;
+      const relatedIds = [pair.a.id, pair.b.id] as const;
+
+      const line: LineDecoration = {
+        type: 'line',
+        id: `distance-line:${pairId}`,
+        relatedAnnotationIds: relatedIds,
+        start: pA,
+        end: pB,
+        dashed,
+        ...(options.lineStyle !== undefined ? { style: options.lineStyle } : {}),
+      };
+      const label: TextDecoration = {
+        type: 'text',
+        id: `distance-text:${pairId}`,
+        relatedAnnotationIds: relatedIds,
+        text,
+        anchor: geom.midpoint(pA, pB),
+        offset: { x: 0, y: -6 },
+        placement: 'bottom',
+        ...(options.textStyle !== undefined ? { style: options.textStyle } : {}),
+      };
+      decorations.push(line, label);
     }
     return decorations;
   };

--- a/packages/decoration/src/index.ts
+++ b/packages/decoration/src/index.ts
@@ -21,5 +21,14 @@ export {
   midpoint,
   boundingBox,
 } from './geometry-math.js';
-export { createMeasurementProvider, createLabelProvider } from './built-in-providers.js';
-export type { MeasurementProviderOptions, LabelProviderOptions } from './built-in-providers.js';
+export {
+  createMeasurementProvider,
+  createLabelProvider,
+  createDistanceProvider,
+} from './built-in-providers.js';
+export type {
+  MeasurementProviderOptions,
+  LabelProviderOptions,
+  DistanceProviderOptions,
+  AnnotationPair,
+} from './built-in-providers.js';

--- a/packages/decoration/tests/unit/built-in-providers.test.ts
+++ b/packages/decoration/tests/unit/built-in-providers.test.ts
@@ -198,7 +198,8 @@ describe('createDistanceProvider', () => {
     expect(provider({ annotations: [a] })).toEqual([]);
   });
 
-  it('honors dashed:false and custom formatLine', () => {
+  it('honors dashed:false and a one-arg custom formatLine', () => {
+    // The defaultFormatter second arg is optional; consumers can ignore it.
     const a = ann('p1', 'point', { type: 'point', position: { x: 0, y: 0 } });
     const b = ann('p2', 'point', { type: 'point', position: { x: 3, y: 4 } });
     const provider = createDistanceProvider({
@@ -211,5 +212,19 @@ describe('createDistanceProvider', () => {
     const label = decorations.find((d) => d.type === 'text') as TextDecoration;
     expect(line.dashed).toBe(false);
     expect(label.text).toBe('d=5px');
+  });
+
+  it('passes a defaultFormatter to formatLine so consumers can wrap the standard output', () => {
+    const a = ann('p1', 'point', { type: 'point', position: { x: 0, y: 0 } });
+    const b = ann('p2', 'point', { type: 'point', position: { x: 3, y: 4 } });
+    const provider = createDistanceProvider({
+      pair: (anns) => [{ a: anns[0]!, b: anns[1]! }],
+      format: { precision: 1 },
+      formatLine: (m, fmt) => `Distance: ${fmt(m)}`,
+    });
+    const decorations = provider({ annotations: [a, b] });
+    const label = decorations.find((d) => d.type === 'text') as TextDecoration;
+    // defaultFormatter uses options.format → precision 1 → "5.0 px"
+    expect(label.text).toBe('Distance: 5.0 px');
   });
 });

--- a/packages/decoration/tests/unit/built-in-providers.test.ts
+++ b/packages/decoration/tests/unit/built-in-providers.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import type { Annotation, AnnotationId, ToolType } from '@osdlabel/annotation';
 import type { PixelSpacing } from '@osdlabel/viewer-api';
-import { createLabelProvider, createMeasurementProvider } from '../../src/built-in-providers.js';
-import type { TextDecoration } from '../../src/decoration.js';
+import {
+  createDistanceProvider,
+  createLabelProvider,
+  createMeasurementProvider,
+} from '../../src/built-in-providers.js';
+import type { LineDecoration, TextDecoration } from '../../src/decoration.js';
 
 function ann(
   id: string,
@@ -102,5 +106,110 @@ describe('createLabelProvider', () => {
     const a = ann('p1', 'point', { type: 'point', position: { x: 0, y: 0 } });
     const [d] = provider({ annotations: [a] });
     expect((d as TextDecoration).text).toBe('CUSTOM');
+  });
+});
+
+describe('createDistanceProvider', () => {
+  it('emits a line + text decoration per pair', () => {
+    const a = ann('p1', 'point', { type: 'point', position: { x: 0, y: 0 } });
+    const b = ann('p2', 'point', { type: 'point', position: { x: 3, y: 4 } });
+    const provider = createDistanceProvider({
+      pair: (anns) => (anns.length === 2 ? [{ a: anns[0]!, b: anns[1]! }] : []),
+    });
+    const decorations = provider({ annotations: [a, b] });
+    expect(decorations).toHaveLength(2);
+    const line = decorations.find((d) => d.type === 'line') as LineDecoration;
+    const label = decorations.find((d) => d.type === 'text') as TextDecoration;
+    expect(line.start).toEqual({ x: 0, y: 0 });
+    expect(line.end).toEqual({ x: 3, y: 4 });
+    expect(line.dashed).toBe(true);
+    expect(line.relatedAnnotationIds).toEqual(['p1', 'p2']);
+    expect(label.text).toBe('5.00 px');
+    expect(label.anchor).toEqual({ x: 1.5, y: 2 });
+    expect(label.relatedAnnotationIds).toEqual(['p1', 'p2']);
+  });
+
+  it('uses pixelSpacing to render the distance in physical units', () => {
+    const a = ann('p1', 'point', { type: 'point', position: { x: 0, y: 0 } });
+    const b = ann('p2', 'point', { type: 'point', position: { x: 6, y: 8 } });
+    const spacing: PixelSpacing = { x: 0.5, y: 0.5, unit: 'mm' };
+    const provider = createDistanceProvider({
+      pair: (anns) => [{ a: anns[0]!, b: anns[1]! }],
+    });
+    const decorations = provider({ annotations: [a, b], pixelSpacing: spacing });
+    const label = decorations.find((d) => d.type === 'text') as TextDecoration;
+    // px distance 10, * 0.5 mm/px = 5 mm
+    expect(label.text).toBe('5.00 mm');
+  });
+
+  it('produces stable pair-scoped ids derived from annotation ids', () => {
+    const a = ann('rect-1', 'rectangle', {
+      type: 'rectangle',
+      origin: { x: 0, y: 0 },
+      width: 2,
+      height: 2,
+      rotation: 0,
+    });
+    const b = ann('rect-2', 'rectangle', {
+      type: 'rectangle',
+      origin: { x: 10, y: 10 },
+      width: 2,
+      height: 2,
+      rotation: 0,
+    });
+    const provider = createDistanceProvider({
+      pair: (anns) => [{ a: anns[0]!, b: anns[1]! }],
+    });
+    const decorations = provider({ annotations: [a, b] });
+    const line = decorations.find((d) => d.type === 'line')!;
+    const label = decorations.find((d) => d.type === 'text')!;
+    expect(line.id).toBe('distance-line:rect-1-rect-2');
+    expect(label.id).toBe('distance-text:rect-1-rect-2');
+  });
+
+  it('honors an explicit pair id and uses centroids for non-point geometries', () => {
+    const a = ann('r1', 'rectangle', {
+      type: 'rectangle',
+      origin: { x: 0, y: 0 },
+      width: 10,
+      height: 10,
+      rotation: 0,
+    });
+    const b = ann('r2', 'rectangle', {
+      type: 'rectangle',
+      origin: { x: 100, y: 0 },
+      width: 10,
+      height: 10,
+      rotation: 0,
+    });
+    const provider = createDistanceProvider({
+      pair: (anns) => [{ a: anns[0]!, b: anns[1]!, id: 'pairX' }],
+    });
+    const [line] = provider({ annotations: [a, b] }) as [LineDecoration, TextDecoration];
+    // Rectangle centroids at (5,5) and (105,5)
+    expect(line.start).toEqual({ x: 5, y: 5 });
+    expect(line.end).toEqual({ x: 105, y: 5 });
+    expect(line.id).toBe('distance-line:pairX');
+  });
+
+  it('emits no decorations when pair returns an empty list', () => {
+    const a = ann('p1', 'point', { type: 'point', position: { x: 0, y: 0 } });
+    const provider = createDistanceProvider({ pair: () => [] });
+    expect(provider({ annotations: [a] })).toEqual([]);
+  });
+
+  it('honors dashed:false and custom formatLine', () => {
+    const a = ann('p1', 'point', { type: 'point', position: { x: 0, y: 0 } });
+    const b = ann('p2', 'point', { type: 'point', position: { x: 3, y: 4 } });
+    const provider = createDistanceProvider({
+      pair: (anns) => [{ a: anns[0]!, b: anns[1]! }],
+      dashed: false,
+      formatLine: (m) => `d=${m.value.toFixed(0)}${m.unit}`,
+    });
+    const decorations = provider({ annotations: [a, b] });
+    const line = decorations.find((d) => d.type === 'line') as LineDecoration;
+    const label = decorations.find((d) => d.type === 'text') as TextDecoration;
+    expect(line.dashed).toBe(false);
+    expect(label.text).toBe('d=5px');
   });
 });

--- a/packages/osdlabel/src/index.ts
+++ b/packages/osdlabel/src/index.ts
@@ -94,11 +94,14 @@ export type {
   FormatMeasurementOptions,
   MeasurementProviderOptions,
   LabelProviderOptions,
+  DistanceProviderOptions,
+  AnnotationPair,
 } from '@osdlabel/decoration';
 export {
   composeProviders,
   createMeasurementProvider,
   createLabelProvider,
+  createDistanceProvider,
   toPhysicalLength,
   toPhysicalArea,
   formatMeasurement,
@@ -161,3 +164,7 @@ export {
   processToolUpdateAnnotation,
 } from './tool-factory.js';
 export type { ToolCallbackAccessors, ToolCallbackDispatchers } from './tool-factory.js';
+
+// Live decoration update wiring
+export { enableLiveDecorationUpdates } from './live-decoration-updates.js';
+export type { LiveDecorationUpdateOptions } from './live-decoration-updates.js';

--- a/packages/osdlabel/src/live-decoration-updates.ts
+++ b/packages/osdlabel/src/live-decoration-updates.ts
@@ -75,6 +75,9 @@ export function enableLiveDecorationUpdates<E extends object = Record<string, ne
 
   const handler = (e: { target?: FabricObject }): void => {
     if (disposed) return;
+    // Fast exit when no providers are configured — drag events fire up to
+    // 60×/sec; skipping rAF scheduling avoids per-frame allocations entirely.
+    if (getProviders().length === 0) return;
     pendingTarget = e.target;
     if (scheduled) return;
     scheduled = true;
@@ -100,22 +103,55 @@ export function enableLiveDecorationUpdates<E extends object = Record<string, ne
 }
 
 /**
- * Replace the moving annotation's geometry in `annotations` with the live
- * geometry extracted from the Fabric object. Returns the input list
- * unchanged when there's no target, when the target carries no annotation
- * id, when the annotation isn't in the visible list, or when geometry
- * extraction fails.
+ * Replace the moving annotation(s) geometry in `annotations` with live
+ * geometry extracted from the Fabric target. Allocates at most one shallow
+ * array copy (and only when at least one override is applied); non-target
+ * items keep their identity for downstream memo-stability.
+ *
+ * Handles multi-select drag: when Fabric fires `object:moving` with an
+ * `ActiveSelection` target (which carries no `.id`), we iterate its
+ * children and override each one that has an annotation id.
+ *
+ * Caveat for `ActiveSelection`: child objects' `left/top` are reported
+ * relative to the parent group, not the canvas. `getGeometryFromFabricObject`
+ * is matrix-based for line/polyline/polygon (exact under groups) but reads
+ * `left/top` / `getCenterPoint()` directly for rectangle/circle/point — those
+ * may be slightly off during a multi-select drag. The commit on mouse-up
+ * (via `object:modified`) is always correct because Fabric dissolves the
+ * ActiveSelection before firing it.
  */
 function applyLiveOverride<E extends object>(
   annotations: readonly Annotation<E>[],
   target: FabricObject | undefined,
 ): readonly Annotation<E>[] {
   if (!target) return annotations;
-  const targetId = target.id as AnnotationId | undefined;
-  if (!targetId) return annotations;
-  const original = annotations.find((a) => a.id === targetId);
-  if (!original) return annotations;
-  const geometry = getGeometryFromFabricObject(target, toolTypeToGeometryType(original.toolType));
-  if (!geometry) return annotations;
-  return annotations.map((a) => (a.id === targetId ? { ...a, geometry } : a));
+  const targets = childrenOfDragTarget(target);
+  let next: Annotation<E>[] | undefined;
+  for (const t of targets) {
+    const targetId = t.id as AnnotationId | undefined;
+    if (!targetId) continue;
+    const source = next ?? annotations;
+    const idx = source.findIndex((a) => a.id === targetId);
+    if (idx === -1) continue;
+    const original = source[idx]!;
+    const geometry = getGeometryFromFabricObject(t, toolTypeToGeometryType(original.toolType));
+    if (!geometry) continue;
+    if (!next) next = [...annotations];
+    next[idx] = { ...original, geometry };
+  }
+  return next ?? annotations;
+}
+
+/**
+ * Returns the Fabric objects to apply live geometry overrides to. For a
+ * normal drag this is just `[target]`. For an `ActiveSelection` (multi-drag)
+ * it's the group's children. Detected via duck-typing on `getObjects()` to
+ * avoid coupling to Fabric's `type` string casing.
+ */
+function childrenOfDragTarget(target: FabricObject): readonly FabricObject[] {
+  const maybeGroup = target as FabricObject & { getObjects?: () => FabricObject[] };
+  if (target.id === undefined && typeof maybeGroup.getObjects === 'function') {
+    return maybeGroup.getObjects();
+  }
+  return [target];
 }

--- a/packages/osdlabel/src/live-decoration-updates.ts
+++ b/packages/osdlabel/src/live-decoration-updates.ts
@@ -1,0 +1,121 @@
+import type { Annotation, AnnotationId } from '@osdlabel/annotation';
+import { toolTypeToGeometryType } from '@osdlabel/annotation';
+import type { Decoration, DecorationProvider } from '@osdlabel/decoration';
+import { getGeometryFromFabricObject } from '@osdlabel/fabric-annotations';
+import type { FabricOverlay } from '@osdlabel/fabric-osd';
+import type { PixelSpacing } from '@osdlabel/viewer-api';
+import type { FabricObject } from 'fabric';
+
+/**
+ * Options for {@link enableLiveDecorationUpdates}.
+ *
+ * The accessors are called on every drag frame, so they should be cheap.
+ * Framework integrations typically wire them to a current-value ref so
+ * the handler always sees the latest reactive state.
+ */
+export interface LiveDecorationUpdateOptions<E extends object = Record<string, never>> {
+  readonly overlay: FabricOverlay;
+  /** Returns the annotations currently visible in the overlay's cell. */
+  readonly getVisibleAnnotations: () => readonly Annotation<E>[];
+  /** Returns the active image's pixel spacing, or `undefined`. */
+  readonly getPixelSpacing: () => PixelSpacing | undefined;
+  /** Returns the active decoration providers. */
+  readonly getProviders: () => readonly DecorationProvider<E>[];
+  /** Called with the newly-computed decorations on each throttled tick. */
+  readonly onDecorations: (decorations: readonly Decoration[]) => void;
+}
+
+/**
+ * Subscribe to Fabric `object:moving` / `object:scaling` / `object:rotating`
+ * on the overlay's canvas. While the user drags, the moving annotation's
+ * geometry in state is stale (state only updates on `object:modified`); this
+ * helper overlays the *live* Fabric geometry on top of the state-derived
+ * annotations, re-runs the decoration providers, and calls `onDecorations`.
+ *
+ * Recomputation is throttled to one call per `requestAnimationFrame` so the
+ * cost is bounded at 60fps regardless of how often Fabric fires the event.
+ *
+ * On `object:modified` (commit), the host framework's reactive effect
+ * already re-runs the providers from state — no override is needed and
+ * none is applied here.
+ *
+ * Returns a teardown function that unsubscribes and cancels any pending
+ * scheduled tick.
+ */
+export function enableLiveDecorationUpdates<E extends object = Record<string, never>>(
+  options: LiveDecorationUpdateOptions<E>,
+): () => void {
+  const { overlay, getVisibleAnnotations, getPixelSpacing, getProviders, onDecorations } = options;
+  const canvas = overlay.canvas;
+
+  let scheduled = false;
+  let pendingTarget: FabricObject | undefined;
+  let rafHandle = 0;
+  let disposed = false;
+
+  const flush = (): void => {
+    scheduled = false;
+    rafHandle = 0;
+    if (disposed) return;
+    const target = pendingTarget;
+    pendingTarget = undefined;
+
+    const providers = getProviders();
+    if (providers.length === 0) {
+      onDecorations([]);
+      return;
+    }
+
+    const annotations = applyLiveOverride(getVisibleAnnotations(), target);
+    const pixelSpacing = getPixelSpacing();
+    const ctx = pixelSpacing !== undefined ? { annotations, pixelSpacing } : { annotations };
+    const decorations = providers.flatMap((p) => p(ctx));
+    onDecorations(decorations);
+  };
+
+  const handler = (e: { target?: FabricObject }): void => {
+    if (disposed) return;
+    pendingTarget = e.target;
+    if (scheduled) return;
+    scheduled = true;
+    rafHandle = requestAnimationFrame(flush);
+  };
+
+  canvas.on('object:moving', handler);
+  canvas.on('object:scaling', handler);
+  canvas.on('object:rotating', handler);
+
+  return () => {
+    disposed = true;
+    canvas.off('object:moving', handler);
+    canvas.off('object:scaling', handler);
+    canvas.off('object:rotating', handler);
+    if (rafHandle !== 0) {
+      cancelAnimationFrame(rafHandle);
+      rafHandle = 0;
+    }
+    scheduled = false;
+    pendingTarget = undefined;
+  };
+}
+
+/**
+ * Replace the moving annotation's geometry in `annotations` with the live
+ * geometry extracted from the Fabric object. Returns the input list
+ * unchanged when there's no target, when the target carries no annotation
+ * id, when the annotation isn't in the visible list, or when geometry
+ * extraction fails.
+ */
+function applyLiveOverride<E extends object>(
+  annotations: readonly Annotation<E>[],
+  target: FabricObject | undefined,
+): readonly Annotation<E>[] {
+  if (!target) return annotations;
+  const targetId = target.id as AnnotationId | undefined;
+  if (!targetId) return annotations;
+  const original = annotations.find((a) => a.id === targetId);
+  if (!original) return annotations;
+  const geometry = getGeometryFromFabricObject(target, toolTypeToGeometryType(original.toolType));
+  if (!geometry) return annotations;
+  return annotations.map((a) => (a.id === targetId ? { ...a, geometry } : a));
+}

--- a/packages/osdlabel/tests/unit/live-decoration-updates.test.ts
+++ b/packages/osdlabel/tests/unit/live-decoration-updates.test.ts
@@ -90,6 +90,14 @@ function fakeFabricTarget(id: string, geometry: Annotation['geometry']): FabricO
   return { id, __mockGeometry: geometry } as unknown as FabricObject;
 }
 
+/** Mock ActiveSelection wrapping the given child targets. No `id` (groups carry none). */
+function fakeActiveSelection(children: readonly FabricObject[]): FabricObject {
+  return {
+    type: 'activeselection',
+    getObjects: () => [...children],
+  } as unknown as FabricObject;
+}
+
 describe('enableLiveDecorationUpdates', () => {
   it('subscribes to object:moving, object:scaling, and object:rotating', () => {
     const rig = createRig();
@@ -188,10 +196,13 @@ describe('enableLiveDecorationUpdates', () => {
     expect(providerSpacing).toEqual(spacing);
   });
 
-  it('calls onDecorations with [] and skips providers entirely when none are registered', () => {
+  it('skips providers and onDecorations entirely when none are registered', () => {
+    // No-providers case is fast-exited at the event handler; the rAF queue
+    // stays empty and onDecorations is never invoked. Host frameworks call
+    // setDecorations([]) themselves when providers go empty, so cleanup is
+    // not this helper's responsibility.
     const rig = createRig();
     const onDecorations = vi.fn();
-    const provider = vi.fn();
     enableLiveDecorationUpdates({
       overlay: rig.overlay,
       getVisibleAnnotations: () => [],
@@ -201,8 +212,7 @@ describe('enableLiveDecorationUpdates', () => {
     });
     rig.fire('object:moving', fakeFabricTarget('x', null as unknown as Annotation['geometry']));
     rig.flushRAF();
-    expect(onDecorations).toHaveBeenCalledWith([]);
-    expect(provider).not.toHaveBeenCalled();
+    expect(onDecorations).not.toHaveBeenCalled();
   });
 
   it('falls back to the state-derived geometry when the target carries no id', () => {
@@ -245,6 +255,99 @@ describe('enableLiveDecorationUpdates', () => {
     rig.fire('object:moving', { id: 'a' } as unknown as FabricObject);
     rig.flushRAF();
     expect(seen).toEqual([a.geometry]);
+  });
+
+  it('preserves identity of non-target items (no per-item realloc)', () => {
+    const rig = createRig();
+    const a = rectAnnotation('a', 0, 0);
+    const b = rectAnnotation('b', 5, 5);
+    const c = rectAnnotation('c', 10, 10);
+    let seen: readonly Annotation[] | undefined;
+    const provider: DecorationProvider = ({ annotations }) => {
+      seen = annotations;
+      return [];
+    };
+    enableLiveDecorationUpdates({
+      overlay: rig.overlay,
+      getVisibleAnnotations: () => [a, b, c],
+      getPixelSpacing: () => undefined,
+      getProviders: () => [provider],
+      onDecorations: vi.fn(),
+    });
+    rig.fire(
+      'object:moving',
+      fakeFabricTarget('b', {
+        type: 'rectangle',
+        origin: { x: 99, y: 99 },
+        width: 1,
+        height: 1,
+        rotation: 0,
+      }),
+    );
+    rig.flushRAF();
+    // Target item is replaced; siblings keep their identity for memo stability.
+    expect(seen![0]).toBe(a);
+    expect(seen![2]).toBe(c);
+    expect(seen![1]).not.toBe(b);
+    expect(seen![1]!.id).toBe('b');
+  });
+
+  it('overrides geometry for every id-bearing child of an ActiveSelection drag', () => {
+    const rig = createRig();
+    const a = rectAnnotation('a', 0, 0);
+    const b = rectAnnotation('b', 10, 10);
+    const c = rectAnnotation('c', 20, 20);
+    const seenGeoms: Record<string, Annotation['geometry']> = {};
+    const provider: DecorationProvider = ({ annotations }) => {
+      for (const ann of annotations) seenGeoms[ann.id] = ann.geometry;
+      return [];
+    };
+    enableLiveDecorationUpdates({
+      overlay: rig.overlay,
+      getVisibleAnnotations: () => [a, b, c],
+      getPixelSpacing: () => undefined,
+      getProviders: () => [provider],
+      onDecorations: vi.fn(),
+    });
+    const liveA: Annotation['geometry'] = {
+      type: 'rectangle',
+      origin: { x: 50, y: 50 },
+      width: 1,
+      height: 1,
+      rotation: 0,
+    };
+    const liveB: Annotation['geometry'] = {
+      type: 'rectangle',
+      origin: { x: 60, y: 60 },
+      width: 1,
+      height: 1,
+      rotation: 0,
+    };
+    const selection = fakeActiveSelection([
+      fakeFabricTarget('a', liveA),
+      fakeFabricTarget('b', liveB),
+    ]);
+    rig.fire('object:moving', selection);
+    rig.flushRAF();
+    expect(seenGeoms['a']).toEqual(liveA);
+    expect(seenGeoms['b']).toEqual(liveB);
+    // Unselected annotation untouched.
+    expect(seenGeoms['c']).toEqual(c.geometry);
+  });
+
+  it('does not schedule a rAF when providers are empty (fast-exit)', () => {
+    const rig = createRig();
+    enableLiveDecorationUpdates({
+      overlay: rig.overlay,
+      getVisibleAnnotations: () => [],
+      getPixelSpacing: () => undefined,
+      getProviders: () => [],
+      onDecorations: vi.fn(),
+    });
+    rig.fire('object:moving', fakeFabricTarget('x', null as unknown as Annotation['geometry']));
+    rig.fire('object:scaling', fakeFabricTarget('x', null as unknown as Annotation['geometry']));
+    rig.fire('object:rotating', fakeFabricTarget('x', null as unknown as Annotation['geometry']));
+    expect(rafQueue).toHaveLength(0);
   });
 
   it('teardown unsubscribes from all events and cancels a pending rAF', () => {

--- a/packages/osdlabel/tests/unit/live-decoration-updates.test.ts
+++ b/packages/osdlabel/tests/unit/live-decoration-updates.test.ts
@@ -1,0 +1,288 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Annotation, AnnotationId } from '@osdlabel/annotation';
+import type { Decoration, DecorationProvider } from '@osdlabel/decoration';
+import type { FabricOverlay } from '@osdlabel/fabric-osd';
+import type { PixelSpacing } from '@osdlabel/viewer-api';
+import type { FabricObject } from 'fabric';
+import { enableLiveDecorationUpdates } from '../../src/live-decoration-updates.js';
+
+// Stub out the Fabric-coupled extractor so tests stay in pure JS land.
+// `target.__mockGeometry` is read back as the "live" geometry; `undefined`
+// simulates an extraction failure.
+vi.mock('@osdlabel/fabric-annotations', () => ({
+  getGeometryFromFabricObject: (target: { __mockGeometry?: unknown }) =>
+    target.__mockGeometry ?? null,
+}));
+
+interface MockCanvas {
+  on: ReturnType<typeof vi.fn>;
+  off: ReturnType<typeof vi.fn>;
+}
+
+interface TestRig {
+  overlay: FabricOverlay;
+  canvas: MockCanvas;
+  handlers: Record<string, Array<(e: { target?: FabricObject }) => void>>;
+  fire(event: string, target?: FabricObject): void;
+  flushRAF(): void;
+}
+
+function createRig(): TestRig {
+  const handlers: TestRig['handlers'] = {};
+  const canvas: MockCanvas = {
+    on: vi.fn((event: string, h: (e: { target?: FabricObject }) => void) => {
+      (handlers[event] ??= []).push(h);
+    }),
+    off: vi.fn((event: string, h: (e: { target?: FabricObject }) => void) => {
+      handlers[event] = (handlers[event] ?? []).filter((x) => x !== h);
+    }),
+  };
+  const overlay = { canvas } as unknown as FabricOverlay;
+  return {
+    overlay,
+    canvas,
+    handlers,
+    fire(event, target) {
+      for (const h of handlers[event] ?? []) h({ target });
+    },
+    flushRAF() {
+      const cbs = [...rafQueue];
+      rafQueue.length = 0;
+      for (const cb of cbs) cb(0);
+    },
+  };
+}
+
+let rafQueue: FrameRequestCallback[] = [];
+let cancelAnimationFrameImpl: (id: number) => void = (id) => {
+  rafQueue.splice(id - 1, 1);
+};
+
+beforeEach(() => {
+  rafQueue = [];
+  cancelAnimationFrameImpl = (id) => {
+    rafQueue.splice(id - 1, 1);
+  };
+  (
+    globalThis as unknown as { requestAnimationFrame: typeof requestAnimationFrame }
+  ).requestAnimationFrame = (cb: FrameRequestCallback) => {
+    rafQueue.push(cb);
+    return rafQueue.length;
+  };
+  (
+    globalThis as unknown as { cancelAnimationFrame: typeof cancelAnimationFrame }
+  ).cancelAnimationFrame = (id: number) => cancelAnimationFrameImpl(id);
+});
+
+const annId = (s: string): AnnotationId => s as AnnotationId;
+
+function rectAnnotation(id: string, x: number, y: number): Annotation {
+  return {
+    id: annId(id),
+    geometry: { type: 'rectangle', origin: { x, y }, width: 10, height: 10, rotation: 0 },
+    toolType: 'rectangle',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  };
+}
+
+function fakeFabricTarget(id: string, geometry: Annotation['geometry']): FabricObject {
+  return { id, __mockGeometry: geometry } as unknown as FabricObject;
+}
+
+describe('enableLiveDecorationUpdates', () => {
+  it('subscribes to object:moving, object:scaling, and object:rotating', () => {
+    const rig = createRig();
+    const dispose = enableLiveDecorationUpdates({
+      overlay: rig.overlay,
+      getVisibleAnnotations: () => [],
+      getPixelSpacing: () => undefined,
+      getProviders: () => [],
+      onDecorations: vi.fn(),
+    });
+    expect(rig.canvas.on).toHaveBeenCalledTimes(3);
+    const events = rig.canvas.on.mock.calls.map((c) => c[0]);
+    expect(events).toEqual(['object:moving', 'object:scaling', 'object:rotating']);
+    dispose();
+  });
+
+  it('throttles multiple events within a frame to one onDecorations call', () => {
+    const rig = createRig();
+    const onDecorations = vi.fn();
+    const provider: DecorationProvider = () => [];
+    enableLiveDecorationUpdates({
+      overlay: rig.overlay,
+      getVisibleAnnotations: () => [],
+      getPixelSpacing: () => undefined,
+      getProviders: () => [provider],
+      onDecorations,
+    });
+
+    const t = fakeFabricTarget('a', {
+      type: 'rectangle',
+      origin: { x: 0, y: 0 },
+      width: 1,
+      height: 1,
+      rotation: 0,
+    });
+    rig.fire('object:moving', t);
+    rig.fire('object:scaling', t);
+    rig.fire('object:rotating', t);
+    expect(onDecorations).not.toHaveBeenCalled();
+    rig.flushRAF();
+    expect(onDecorations).toHaveBeenCalledTimes(1);
+  });
+
+  it('overrides the moving annotation geometry with the live Fabric geometry', () => {
+    const rig = createRig();
+    const onDecorations = vi.fn();
+    const a = rectAnnotation('a', 0, 0);
+    const b = rectAnnotation('b', 100, 100);
+
+    // Provider that snapshots the geometry it received for each annotation.
+    const seenGeoms: Record<string, Annotation['geometry']> = {};
+    const provider: DecorationProvider = ({ annotations }) => {
+      for (const ann of annotations) seenGeoms[ann.id] = ann.geometry;
+      return [];
+    };
+    enableLiveDecorationUpdates({
+      overlay: rig.overlay,
+      getVisibleAnnotations: () => [a, b],
+      getPixelSpacing: () => undefined,
+      getProviders: () => [provider],
+      onDecorations,
+    });
+
+    const liveGeometry: Annotation['geometry'] = {
+      type: 'rectangle',
+      origin: { x: 50, y: 60 },
+      width: 70,
+      height: 80,
+      rotation: 0,
+    };
+    rig.fire('object:moving', fakeFabricTarget('a', liveGeometry));
+    rig.flushRAF();
+
+    expect(seenGeoms['a']).toEqual(liveGeometry);
+    // Other annotation untouched
+    expect(seenGeoms['b']).toEqual(b.geometry);
+  });
+
+  it('passes pixel spacing through to providers', () => {
+    const rig = createRig();
+    const spacing: PixelSpacing = { x: 0.5, y: 0.5, unit: 'mm' };
+    const provider: DecorationProvider = ({ pixelSpacing }) => {
+      providerSpacing = pixelSpacing;
+      return [];
+    };
+    let providerSpacing: PixelSpacing | undefined;
+    enableLiveDecorationUpdates({
+      overlay: rig.overlay,
+      getVisibleAnnotations: () => [],
+      getPixelSpacing: () => spacing,
+      getProviders: () => [provider],
+      onDecorations: vi.fn(),
+    });
+    rig.fire('object:moving', fakeFabricTarget('x', null as unknown as Annotation['geometry']));
+    rig.flushRAF();
+    expect(providerSpacing).toEqual(spacing);
+  });
+
+  it('calls onDecorations with [] and skips providers entirely when none are registered', () => {
+    const rig = createRig();
+    const onDecorations = vi.fn();
+    const provider = vi.fn();
+    enableLiveDecorationUpdates({
+      overlay: rig.overlay,
+      getVisibleAnnotations: () => [],
+      getPixelSpacing: () => undefined,
+      getProviders: () => [],
+      onDecorations,
+    });
+    rig.fire('object:moving', fakeFabricTarget('x', null as unknown as Annotation['geometry']));
+    rig.flushRAF();
+    expect(onDecorations).toHaveBeenCalledWith([]);
+    expect(provider).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the state-derived geometry when the target carries no id', () => {
+    const rig = createRig();
+    const a = rectAnnotation('a', 1, 2);
+    const seen: Annotation['geometry'][] = [];
+    const provider: DecorationProvider = ({ annotations }) => {
+      for (const ann of annotations) seen.push(ann.geometry);
+      return [];
+    };
+    enableLiveDecorationUpdates({
+      overlay: rig.overlay,
+      getVisibleAnnotations: () => [a],
+      getPixelSpacing: () => undefined,
+      getProviders: () => [provider],
+      onDecorations: vi.fn(),
+    });
+    // Target has no .id — override should be skipped
+    rig.fire('object:moving', { __mockGeometry: { type: 'rectangle' } } as unknown as FabricObject);
+    rig.flushRAF();
+    expect(seen).toEqual([a.geometry]);
+  });
+
+  it('calls providers with the original list when geometry extraction fails', () => {
+    const rig = createRig();
+    const a = rectAnnotation('a', 1, 2);
+    const seen: Annotation['geometry'][] = [];
+    const provider: DecorationProvider = ({ annotations }) => {
+      for (const ann of annotations) seen.push(ann.geometry);
+      return [];
+    };
+    enableLiveDecorationUpdates({
+      overlay: rig.overlay,
+      getVisibleAnnotations: () => [a],
+      getPixelSpacing: () => undefined,
+      getProviders: () => [provider],
+      onDecorations: vi.fn(),
+    });
+    // Target has id but __mockGeometry is undefined → extractor returns null
+    rig.fire('object:moving', { id: 'a' } as unknown as FabricObject);
+    rig.flushRAF();
+    expect(seen).toEqual([a.geometry]);
+  });
+
+  it('teardown unsubscribes from all events and cancels a pending rAF', () => {
+    const rig = createRig();
+    const onDecorations = vi.fn();
+    const dispose = enableLiveDecorationUpdates({
+      overlay: rig.overlay,
+      getVisibleAnnotations: () => [],
+      getPixelSpacing: () => undefined,
+      getProviders: () => [() => []],
+      onDecorations,
+    });
+    rig.fire('object:moving', fakeFabricTarget('x', null as unknown as Annotation['geometry']));
+    // rAF scheduled but not yet flushed
+    dispose();
+    expect(rig.canvas.off).toHaveBeenCalledTimes(3);
+    rig.flushRAF();
+    // Even if the cancelAnimationFrame mock didn't fully clear, the disposed
+    // flag guards onDecorations from firing post-teardown.
+    expect(onDecorations).not.toHaveBeenCalled();
+  });
+
+  it('does not return decorations from disposed instance even if rAF still fires', () => {
+    // Belt-and-suspenders: simulate a buggy host where cancelAnimationFrame
+    // is a no-op. The disposed guard inside flush() must still suppress calls.
+    const rig = createRig();
+    cancelAnimationFrameImpl = () => {};
+    const onDecorations = vi.fn();
+    const dispose = enableLiveDecorationUpdates({
+      overlay: rig.overlay,
+      getVisibleAnnotations: () => [],
+      getPixelSpacing: () => undefined,
+      getProviders: () => [() => []],
+      onDecorations,
+    });
+    rig.fire('object:moving', fakeFabricTarget('x', null as unknown as Annotation['geometry']));
+    dispose();
+    rig.flushRAF();
+    expect(onDecorations).not.toHaveBeenCalled();
+  });
+});

--- a/packages/react/src/components/ViewerCell.tsx
+++ b/packages/react/src/components/ViewerCell.tsx
@@ -11,6 +11,7 @@ import { useAnnotationTool } from '../hooks/useAnnotationTool.js';
 import { useAnnotator } from '../state/annotator-context.js';
 import type { Annotation } from '@osdlabel/annotation';
 import type { OsdFields } from 'osdlabel';
+import { enableLiveDecorationUpdates } from 'osdlabel';
 
 export interface ViewerCellProps {
   readonly imageSource: ImageSource | undefined;
@@ -196,6 +197,26 @@ export default function ViewerCell({
     defaultPixelSpacing,
     imageSource?.pixelSpacing,
   ]);
+
+  // Live-update decorations during Fabric drag. Accessors close over refs
+  // so each rAF tick observes the latest reactive state without resubscribing.
+  const visibleAnnotationsRef = useRef(visibleAnnotations);
+  visibleAnnotationsRef.current = visibleAnnotations;
+  const decorationProvidersRef = useRef(decorationProviders);
+  decorationProvidersRef.current = decorationProviders;
+  const pixelSpacingRef = useRef<typeof defaultPixelSpacing>(undefined);
+  pixelSpacingRef.current = imageSource?.pixelSpacing ?? defaultPixelSpacing;
+  useEffect(() => {
+    const layer = decorationLayerRef.current;
+    if (!overlay || !layer) return;
+    return enableLiveDecorationUpdates<OsdFields>({
+      overlay,
+      getVisibleAnnotations: () => visibleAnnotationsRef.current,
+      getPixelSpacing: () => pixelSpacingRef.current,
+      getProviders: () => decorationProvidersRef.current ?? [],
+      onDecorations: (decorations) => layer.setDecorations(decorations),
+    });
+  }, [overlay]);
 
   return (
     <div

--- a/packages/solid/src/components/ViewerCell.tsx
+++ b/packages/solid/src/components/ViewerCell.tsx
@@ -12,6 +12,7 @@ import { useAnnotationTool } from '../hooks/useAnnotationTool.js';
 import { useAnnotator } from '../state/annotator-context.js';
 import type { Annotation } from '@osdlabel/annotation';
 import type { OsdFields } from 'osdlabel';
+import { enableLiveDecorationUpdates } from 'osdlabel';
 export interface ViewerCellProps {
   readonly imageSource: ImageSource | undefined;
   readonly isActive: boolean;
@@ -190,6 +191,23 @@ const ViewerCell: Component<ViewerCellProps> = (props) => {
     const ctx = pixelSpacing !== undefined ? { annotations, pixelSpacing } : { annotations };
     const decorations = providers.flatMap((p) => p(ctx));
     layer.setDecorations(decorations);
+  });
+
+  // Live-update decorations during Fabric drag (object:moving/scaling/rotating).
+  // The accessors close over reactive state so each rAF tick sees the latest
+  // visible annotations, providers, and pixel spacing.
+  createEffect(() => {
+    const ov = overlay();
+    const layer = decorationLayer();
+    if (!ov || !layer) return;
+    const dispose = enableLiveDecorationUpdates<OsdFields>({
+      overlay: ov,
+      getVisibleAnnotations: visibleAnnotations,
+      getPixelSpacing: () => props.imageSource?.pixelSpacing ?? defaultPixelSpacing,
+      getProviders: () => decorationProviders ?? [],
+      onDecorations: (decorations) => layer.setDecorations(decorations),
+    });
+    onCleanup(dispose);
   });
 
   return (


### PR DESCRIPTION
## Summary

Implements real-time decoration updates while the user drags, scales, or rotates annotations in Fabric. During drag operations, the annotation geometry in state is stale (only updated on `object:modified`), so this feature overlays the *live* Fabric geometry on top of state-derived annotations, re-runs decoration providers, and updates the UI at 60fps.

## Key Changes

- **New `enableLiveDecorationUpdates` function** (`packages/osdlabel/src/live-decoration-updates.ts`):
  - Subscribes to Fabric `object:moving`, `object:scaling`, and `object:rotating` events
  - Throttles recomputation to one call per `requestAnimationFrame` (bounded at 60fps)
  - Applies live geometry extracted from the Fabric object to override the moving annotation's state-derived geometry
  - Passes the modified annotations to decoration providers for real-time visual feedback
  - Returns a teardown function that unsubscribes and cancels pending scheduled work
  - Includes comprehensive error handling for missing IDs, extraction failures, and post-disposal rAF callbacks

- **New `createDistanceProvider` decoration provider** (`packages/decoration/src/built-in-providers.ts`):
  - Emits connector lines and distance labels for caller-supplied annotation pairs
  - Uses geometric centroids as anchor points for non-point geometries
  - Converts pixel distances to physical units when `pixelSpacing` is available
  - Supports customizable line style, text style, and distance formatting
  - Generates stable decoration IDs derived from annotation IDs for consistent reuse

- **React integration** (`packages/react/src/components/ViewerCell.tsx`):
  - Wires `enableLiveDecorationUpdates` into the viewer cell lifecycle
  - Uses refs to close over reactive state so each rAF tick observes the latest annotations, providers, and pixel spacing without resubscribing

- **Solid integration** (`packages/solid/src/components/ViewerCell.tsx`):
  - Wires `enableLiveDecorationUpdates` into a `createEffect` that depends on the overlay
  - Accessors close over reactive state for consistent live updates

- **Exports** (`packages/osdlabel/src/index.ts`, `packages/decoration/src/index.ts`):
  - Exports `enableLiveDecorationUpdates`, `createDistanceProvider`, `DistanceProviderOptions`, and `AnnotationPair`

- **Comprehensive test suite** (`packages/osdlabel/tests/unit/live-decoration-updates.test.ts`):
  - 288 lines of unit tests covering event subscription, throttling, geometry override, pixel spacing passthrough, provider invocation, error handling, and teardown semantics
  - Includes belt-and-suspenders tests for disposal guards against buggy `cancelAnimationFrame` implementations

- **Distance provider tests** (`packages/decoration/tests/unit/built-in-providers.test.ts`):
  - Tests for line + text decoration emission, physical unit conversion, stable pair-scoped IDs, centroid calculation, and custom formatting

## Implementation Details

- The live override is applied only to the annotation currently being dragged; other annotations remain unchanged
- Geometry extraction failures gracefully fall back to state-derived geometry
- The `disposed` flag prevents callbacks from firing after teardown, even if `cancelAnimationFrame` is a no-op
- Decoration providers are skipped entirely when none are registered, optimizing the common case
- The feature integrates seamlessly with the existing decoration system and requires no changes to the annotation model or state management

https://claude.ai/code/session_01VYxhCn5wHUe6iqx2UoH86Q