### PR TITLE
feat(dev): add distance provider demo

### DIFF
--- a/apps/dev/src/App.tsx
+++ b/apps/dev/src/App.tsx
@@ -13,6 +13,9 @@ import {
   serialize,
   deserialize,
   initFabricModule,
+  createMeasurementProvider,
+  createLabelProvider,
+  createDistanceProvider,
 } from '@osdlabel/solid';
 import type { AnnotationContextId, AnnotationContext, ImageSource } from '@osdlabel/solid';
 
@@ -386,6 +389,23 @@ function App() {
       onAnnotationsChange={(anns) => console.log('Annotations changed:', anns.length, 'total')}
       onConstraintChange={(status) => console.log('Constraint status changed:', status)}
       testMode={true}
+      decorationProviders={[
+        createMeasurementProvider({ area: true, perimeter: true, length: true, radius: true }),
+        createDistanceProvider({
+          pair: (anns) => {
+            const points = anns.filter((a) => a.toolType === 'point');
+            const pairs = [];
+            for (let i = 0; i < points.length - 1; i += 2) {
+              pairs.push({ a: points[i]!, b: points[i + 1]! });
+            }
+            return pairs;
+          },
+          dashed: true,
+          formatLine: (m, fmt) => `Distance: ${fmt(m)}`,
+        }),
+        createLabelProvider(),
+      ]}
+      defaultPixelSpacing={{ x: 1, y: 1, unit: 'px' }}
     >
       <AppContent />
     </AnnotatorProvider>


### PR DESCRIPTION
## Summary

This PR adds a practical, interactive demonstration of the new `createDistanceProvider` and live decoration update engine to the local development app.

## What's Included

* Injected `createDistanceProvider` into the `decorationProviders` array inside `apps/dev/src/App.tsx`.
* Configured a simple pairing heuristic: it automatically finds all **Point** annotations currently on the image and pairs them up sequentially (e.g. Point 1 to Point 2, Point 3 to Point 4, etc.).
* Customized the output using the new `formatLine` API to prepend `"Distance: "` to the built-in precision formatting.

## How to Test

1. Run the dev server (`pnpm dev`).
2. Switch to the **General** context in the top dropdown (this context has the Point tool enabled).
3. Select the **Point Tool** from the toolbar and place two points on the image.
4. You will instantly see a dashed connector line spanning the two points, labeled with the physical distance (calculated using the default `1px` pixel spacing).
5. Switch to the **Select Tool** and drag either of the points around. 
6. Observe the beautiful 60fps live decoration updates in action—the connector line and label follow the point in real-time, completely bypassing state re-renders!
