### PR TITLE
feat(decoration): add minimal Phase 3 selection emphasis

### DIFF
--- a/apps/dev/src/App.tsx
+++ b/apps/dev/src/App.tsx
@@ -16,6 +16,7 @@ import {
   createMeasurementProvider,
   createLabelProvider,
   createDistanceProvider,
+  withSelectionEmphasis,
 } from '@osdlabel/solid';
 import type { AnnotationContextId, AnnotationContext, ImageSource } from '@osdlabel/solid';
 
@@ -389,23 +390,35 @@ function App() {
       onAnnotationsChange={(anns) => console.log('Annotations changed:', anns.length, 'total')}
       onConstraintChange={(status) => console.log('Constraint status changed:', status)}
       testMode={true}
-      decorationProviders={[
-        createMeasurementProvider({ area: true, perimeter: true, length: true, radius: true }),
-        createDistanceProvider({
-          pair: (anns) => {
-            const points = anns.filter((a) => a.toolType === 'point');
-            const pairs = [];
-            for (let i = 0; i < points.length - 1; i += 2) {
-              pairs.push({ a: points[i]!, b: points[i + 1]! });
-            }
-            return pairs;
-          },
-          dashed: true,
-          formatLine: (m, fmt) => `Distance: ${fmt(m)}`,
-        }),
-        createLabelProvider(),
-      ]}
       defaultPixelSpacing={{ x: 1, y: 1, unit: 'px' }}
+      decorationProviders={[
+        withSelectionEmphasis(
+          createMeasurementProvider({ area: true, perimeter: true, length: true, radius: true }),
+          {
+            selectedTextStyle: { zIndex: 10, background: 'rgba(33, 150, 243, 0.9)', color: '#fff' },
+            selectedLineStyle: { stroke: '#2196f3', strokeWidth: 3 },
+          },
+        ),
+        withSelectionEmphasis(createLabelProvider(), {
+          selectedTextStyle: { zIndex: 10, background: 'rgba(33, 150, 243, 0.9)', color: '#fff' },
+        }),
+        withSelectionEmphasis(
+          createDistanceProvider({
+            pair: (annotations) => {
+              const points = annotations.filter((a) => a.geometry.type === 'point');
+              const pairs = [];
+              for (let i = 0; i < points.length - 1; i += 2) {
+                pairs.push({ a: points[i]!, b: points[i + 1]! });
+              }
+              return pairs;
+            },
+          }),
+          {
+            selectedLineStyle: { stroke: '#2196f3', strokeWidth: 3 },
+            selectedTextStyle: { zIndex: 10, background: 'rgba(33, 150, 243, 0.9)', color: '#fff' },
+          },
+        ),
+      ]}
     >
       <AppContent />
     </AnnotatorProvider>

--- a/packages/decoration/src/decoration.ts
+++ b/packages/decoration/src/decoration.ts
@@ -15,6 +15,8 @@ export interface TextDecorationStyle {
   readonly borderRadius?: string | undefined;
   /** Additional CSS class applied to the host element. */
   readonly className?: string | undefined;
+  /** CSS z-index to control stacking order of text labels. */
+  readonly zIndex?: number | undefined;
 }
 
 /** Styling applied to a line decoration (Fabric-rendered). */

--- a/packages/decoration/src/emphasis.ts
+++ b/packages/decoration/src/emphasis.ts
@@ -1,0 +1,59 @@
+import type { DecorationProvider } from './provider.js';
+import type { TextDecorationStyle, LineDecorationStyle } from './decoration.js';
+
+export interface SelectionEmphasisOptions {
+  /** Style overrides applied to text decorations associated with the selected annotation. */
+  readonly selectedTextStyle?: Partial<TextDecorationStyle> | undefined;
+  /** Style overrides applied to line decorations associated with the selected annotation. */
+  readonly selectedLineStyle?: Partial<LineDecorationStyle> | undefined;
+}
+
+/**
+ * Wraps a decoration provider to apply emphasis styling to decorations
+ * associated with the currently selected annotation.
+ *
+ * It checks if `DecorationContext.selectedAnnotationId` is present in the
+ * decoration's `relatedAnnotationIds`. If so, it merges the provided styles
+ * into the decoration's style object.
+ *
+ * @param provider The base provider to wrap.
+ * @param options The style overrides to apply when selected.
+ */
+export function withSelectionEmphasis<E extends object = Record<string, never>>(
+  provider: DecorationProvider<E>,
+  options: SelectionEmphasisOptions,
+): DecorationProvider<E> {
+  return (ctx) => {
+    const decorations = provider(ctx);
+    const selectedId = ctx.selectedAnnotationId;
+    if (!selectedId) return decorations;
+
+    // Fast-path: check if any decoration relates to the selected ID before allocating
+    let needsUpdate = false;
+    for (const dec of decorations) {
+      if (dec.relatedAnnotationIds.includes(selectedId)) {
+        needsUpdate = true;
+        break;
+      }
+    }
+    if (!needsUpdate) return decorations;
+
+    return decorations.map((dec) => {
+      if (!dec.relatedAnnotationIds.includes(selectedId)) return dec;
+
+      if (dec.type === 'text' && options.selectedTextStyle) {
+        return {
+          ...dec,
+          style: { ...dec.style, ...options.selectedTextStyle },
+        };
+      }
+      if (dec.type === 'line' && options.selectedLineStyle) {
+        return {
+          ...dec,
+          style: { ...dec.style, ...options.selectedLineStyle },
+        };
+      }
+      return dec;
+    });
+  };
+}

--- a/packages/decoration/src/emphasis.ts
+++ b/packages/decoration/src/emphasis.ts
@@ -28,32 +28,26 @@ export function withSelectionEmphasis<E extends object = Record<string, never>>(
     const selectedId = ctx.selectedAnnotationId;
     if (!selectedId) return decorations;
 
-    // Fast-path: check if any decoration relates to the selected ID before allocating
-    let needsUpdate = false;
-    for (const dec of decorations) {
-      if (dec.relatedAnnotationIds.includes(selectedId)) {
-        needsUpdate = true;
-        break;
-      }
-    }
-    if (!needsUpdate) return decorations;
+    const idx = decorations.findIndex((d) => d.relatedAnnotationIds.includes(selectedId));
+    if (idx === -1) return decorations;
 
-    return decorations.map((dec) => {
-      if (!dec.relatedAnnotationIds.includes(selectedId)) return dec;
+    const next = [...decorations];
+    for (let i = idx; i < next.length; i++) {
+      const dec = next[i]!;
+      if (!dec.relatedAnnotationIds.includes(selectedId)) continue;
 
       if (dec.type === 'text' && options.selectedTextStyle) {
-        return {
+        next[i] = {
           ...dec,
           style: { ...dec.style, ...options.selectedTextStyle },
         };
-      }
-      if (dec.type === 'line' && options.selectedLineStyle) {
-        return {
+      } else if (dec.type === 'line' && options.selectedLineStyle) {
+        next[i] = {
           ...dec,
           style: { ...dec.style, ...options.selectedLineStyle },
         };
       }
-      return dec;
-    });
+    }
+    return next;
   };
 }

--- a/packages/decoration/src/index.ts
+++ b/packages/decoration/src/index.ts
@@ -32,3 +32,4 @@ export type {
   DistanceProviderOptions,
   AnnotationPair,
 } from './built-in-providers.js';
+export * from './emphasis.js';

--- a/packages/decoration/src/provider.ts
+++ b/packages/decoration/src/provider.ts
@@ -13,7 +13,7 @@ export interface DecorationContext<E extends object = Record<string, never>> {
   /** Calibration for the cell's image; `undefined` if no calibration is set. */
   readonly pixelSpacing?: PixelSpacing | undefined;
   /** The currently selected annotation ID, if any. Used for selection emphasis. */
-  readonly selectedAnnotationId?: AnnotationId | null | undefined;
+  readonly selectedAnnotationId: AnnotationId | null;
 }
 
 /**

--- a/packages/decoration/src/provider.ts
+++ b/packages/decoration/src/provider.ts
@@ -1,4 +1,4 @@
-import type { Annotation } from '@osdlabel/annotation';
+import type { Annotation, AnnotationId } from '@osdlabel/annotation';
 import type { PixelSpacing } from '@osdlabel/viewer-api';
 import type { Decoration } from './decoration.js';
 
@@ -12,6 +12,8 @@ export interface DecorationContext<E extends object = Record<string, never>> {
   readonly annotations: readonly Annotation<E>[];
   /** Calibration for the cell's image; `undefined` if no calibration is set. */
   readonly pixelSpacing?: PixelSpacing | undefined;
+  /** The currently selected annotation ID, if any. Used for selection emphasis. */
+  readonly selectedAnnotationId?: AnnotationId | null | undefined;
 }
 
 /**

--- a/packages/decoration/tests/unit/emphasis.test.ts
+++ b/packages/decoration/tests/unit/emphasis.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi } from 'vitest';
+import { withSelectionEmphasis } from '../../src/emphasis.js';
+import type { DecorationProvider, DecorationContext } from '../../src/provider.js';
+import type { Decoration } from '../../src/decoration.js';
+
+describe('withSelectionEmphasis', () => {
+  it('returns original decorations when no annotation is selected', () => {
+    const baseDecorations: Decoration[] = [
+      { id: '1', type: 'text', text: 'Label', relatedAnnotationIds: ['a1'], anchor: { x: 0, y: 0 } },
+    ];
+    const provider: DecorationProvider = vi.fn().mockReturnValue(baseDecorations);
+    const wrapped = withSelectionEmphasis(provider, { selectedTextStyle: { zIndex: 10 } });
+
+    const result = wrapped({ annotations: [] });
+    expect(result).toBe(baseDecorations);
+  });
+
+  it('returns original decorations when selected annotation is not related', () => {
+    const baseDecorations: Decoration[] = [
+      { id: '1', type: 'text', text: 'Label', relatedAnnotationIds: ['a1'], anchor: { x: 0, y: 0 } },
+    ];
+    const provider: DecorationProvider = vi.fn().mockReturnValue(baseDecorations);
+    const wrapped = withSelectionEmphasis(provider, { selectedTextStyle: { zIndex: 10 } });
+
+    const result = wrapped({ annotations: [], selectedAnnotationId: 'a2' });
+    expect(result).toBe(baseDecorations);
+  });
+
+  it('applies selectedTextStyle to text decorations related to the selected annotation', () => {
+    const baseDecorations: Decoration[] = [
+      { id: '1', type: 'text', text: 'A', relatedAnnotationIds: ['a1'], anchor: { x: 0, y: 0 }, style: { color: 'red' } },
+      { id: '2', type: 'text', text: 'B', relatedAnnotationIds: ['a2'], anchor: { x: 0, y: 0 } },
+    ];
+    const provider: DecorationProvider = vi.fn().mockReturnValue(baseDecorations);
+    const wrapped = withSelectionEmphasis(provider, { selectedTextStyle: { zIndex: 10, color: 'blue' } });
+
+    const result = wrapped({ annotations: [], selectedAnnotationId: 'a1' });
+    expect(result).not.toBe(baseDecorations);
+    expect(result[0]).toEqual({
+      id: '1', type: 'text', text: 'A', relatedAnnotationIds: ['a1'], anchor: { x: 0, y: 0 },
+      style: { color: 'blue', zIndex: 10 }
+    });
+    expect(result[1]).toBe(baseDecorations[1]);
+  });
+
+  it('applies selectedLineStyle to line decorations related to the selected annotation', () => {
+    const baseDecorations: Decoration[] = [
+      { id: '1', type: 'line', start: { x: 0, y: 0 }, end: { x: 1, y: 1 }, relatedAnnotationIds: ['a1', 'a2'], style: { strokeWidth: 1 } },
+    ];
+    const provider: DecorationProvider = vi.fn().mockReturnValue(baseDecorations);
+    const wrapped = withSelectionEmphasis(provider, { selectedLineStyle: { strokeWidth: 5, stroke: 'red' } });
+
+    const result = wrapped({ annotations: [], selectedAnnotationId: 'a2' });
+    expect(result[0]).toEqual({
+      id: '1', type: 'line', start: { x: 0, y: 0 }, end: { x: 1, y: 1 }, relatedAnnotationIds: ['a1', 'a2'],
+      style: { strokeWidth: 5, stroke: 'red' }
+    });
+  });
+});

--- a/packages/decoration/tests/unit/emphasis.test.ts
+++ b/packages/decoration/tests/unit/emphasis.test.ts
@@ -3,41 +3,45 @@ import { withSelectionEmphasis } from '../../src/emphasis.js';
 import type { DecorationProvider, DecorationContext } from '../../src/provider.js';
 import type { Decoration } from '../../src/decoration.js';
 
+import type { AnnotationId } from '@osdlabel/annotation';
+
+const annId = (s: string): AnnotationId => s as AnnotationId;
+
 describe('withSelectionEmphasis', () => {
   it('returns original decorations when no annotation is selected', () => {
     const baseDecorations: Decoration[] = [
-      { id: '1', type: 'text', text: 'Label', relatedAnnotationIds: ['a1'], anchor: { x: 0, y: 0 } },
+      { id: '1', type: 'text', text: 'Label', relatedAnnotationIds: [annId('a1')], anchor: { x: 0, y: 0 } },
     ];
     const provider: DecorationProvider = vi.fn().mockReturnValue(baseDecorations);
     const wrapped = withSelectionEmphasis(provider, { selectedTextStyle: { zIndex: 10 } });
 
-    const result = wrapped({ annotations: [] });
+    const result = wrapped({ annotations: [], selectedAnnotationId: null });
     expect(result).toBe(baseDecorations);
   });
 
   it('returns original decorations when selected annotation is not related', () => {
     const baseDecorations: Decoration[] = [
-      { id: '1', type: 'text', text: 'Label', relatedAnnotationIds: ['a1'], anchor: { x: 0, y: 0 } },
+      { id: '1', type: 'text', text: 'Label', relatedAnnotationIds: [annId('a1')], anchor: { x: 0, y: 0 } },
     ];
     const provider: DecorationProvider = vi.fn().mockReturnValue(baseDecorations);
     const wrapped = withSelectionEmphasis(provider, { selectedTextStyle: { zIndex: 10 } });
 
-    const result = wrapped({ annotations: [], selectedAnnotationId: 'a2' });
+    const result = wrapped({ annotations: [], selectedAnnotationId: annId('a2') });
     expect(result).toBe(baseDecorations);
   });
 
   it('applies selectedTextStyle to text decorations related to the selected annotation', () => {
     const baseDecorations: Decoration[] = [
-      { id: '1', type: 'text', text: 'A', relatedAnnotationIds: ['a1'], anchor: { x: 0, y: 0 }, style: { color: 'red' } },
-      { id: '2', type: 'text', text: 'B', relatedAnnotationIds: ['a2'], anchor: { x: 0, y: 0 } },
+      { id: '1', type: 'text', text: 'A', relatedAnnotationIds: [annId('a1')], anchor: { x: 0, y: 0 }, style: { color: 'red' } },
+      { id: '2', type: 'text', text: 'B', relatedAnnotationIds: [annId('a2')], anchor: { x: 0, y: 0 } },
     ];
     const provider: DecorationProvider = vi.fn().mockReturnValue(baseDecorations);
     const wrapped = withSelectionEmphasis(provider, { selectedTextStyle: { zIndex: 10, color: 'blue' } });
 
-    const result = wrapped({ annotations: [], selectedAnnotationId: 'a1' });
+    const result = wrapped({ annotations: [], selectedAnnotationId: annId('a1') });
     expect(result).not.toBe(baseDecorations);
     expect(result[0]).toEqual({
-      id: '1', type: 'text', text: 'A', relatedAnnotationIds: ['a1'], anchor: { x: 0, y: 0 },
+      id: '1', type: 'text', text: 'A', relatedAnnotationIds: [annId('a1')], anchor: { x: 0, y: 0 },
       style: { color: 'blue', zIndex: 10 }
     });
     expect(result[1]).toBe(baseDecorations[1]);
@@ -45,14 +49,14 @@ describe('withSelectionEmphasis', () => {
 
   it('applies selectedLineStyle to line decorations related to the selected annotation', () => {
     const baseDecorations: Decoration[] = [
-      { id: '1', type: 'line', start: { x: 0, y: 0 }, end: { x: 1, y: 1 }, relatedAnnotationIds: ['a1', 'a2'], style: { strokeWidth: 1 } },
+      { id: '1', type: 'line', start: { x: 0, y: 0 }, end: { x: 1, y: 1 }, relatedAnnotationIds: [annId('a1'), annId('a2')], style: { strokeWidth: 1 } },
     ];
     const provider: DecorationProvider = vi.fn().mockReturnValue(baseDecorations);
     const wrapped = withSelectionEmphasis(provider, { selectedLineStyle: { strokeWidth: 5, stroke: 'red' } });
 
-    const result = wrapped({ annotations: [], selectedAnnotationId: 'a2' });
+    const result = wrapped({ annotations: [], selectedAnnotationId: annId('a2') });
     expect(result[0]).toEqual({
-      id: '1', type: 'line', start: { x: 0, y: 0 }, end: { x: 1, y: 1 }, relatedAnnotationIds: ['a1', 'a2'],
+      id: '1', type: 'line', start: { x: 0, y: 0 }, end: { x: 1, y: 1 }, relatedAnnotationIds: [annId('a1'), annId('a2')],
       style: { strokeWidth: 5, stroke: 'red' }
     });
   });

--- a/packages/fabric-osd/src/decoration/decoration-layer.ts
+++ b/packages/fabric-osd/src/decoration/decoration-layer.ts
@@ -198,10 +198,9 @@ function applyTextStyle(el: HTMLDivElement, decoration: TextDecoration): void {
   if (el.className !== nextClassName) {
     el.className = nextClassName;
   }
-  if (style?.zIndex !== undefined) {
-    el.style.zIndex = String(style.zIndex);
-  } else {
-    el.style.zIndex = '';
+  const nextZIndex = style?.zIndex !== undefined ? String(style.zIndex) : '';
+  if (el.style.zIndex !== nextZIndex) {
+    el.style.zIndex = nextZIndex;
   }
 }
 

--- a/packages/fabric-osd/src/decoration/decoration-layer.ts
+++ b/packages/fabric-osd/src/decoration/decoration-layer.ts
@@ -198,6 +198,11 @@ function applyTextStyle(el: HTMLDivElement, decoration: TextDecoration): void {
   if (el.className !== nextClassName) {
     el.className = nextClassName;
   }
+  if (style?.zIndex !== undefined) {
+    el.style.zIndex = String(style.zIndex);
+  } else {
+    el.style.zIndex = '';
+  }
 }
 
 function placementTranslate(placement: TextPlacement | undefined): {

--- a/packages/fabric-osd/tests/unit/decoration/decoration-layer.test.ts
+++ b/packages/fabric-osd/tests/unit/decoration/decoration-layer.test.ts
@@ -154,6 +154,37 @@ describe('DecorationLayer', () => {
     layer.destroy();
   });
 
+  it('applies zIndex from text style to el.style.zIndex', () => {
+    const { overlay, hostParent } = createMockOverlay();
+    const layer = new DecorationLayer(overlay);
+    layer.setDecorations([
+      {
+        type: 'text',
+        id: 'z-index-test',
+        relatedAnnotationIds: [annId('z-index-test')],
+        text: 'Z',
+        anchor: { x: 0, y: 0 },
+        style: { zIndex: 42 },
+      },
+    ]);
+    const el = hostParent.querySelector('[data-decoration-id="z-index-test"]') as HTMLElement;
+    expect(el.style.zIndex).toBe('42');
+    
+    // Update to remove zIndex
+    layer.setDecorations([
+      {
+        type: 'text',
+        id: 'z-index-test',
+        relatedAnnotationIds: [annId('z-index-test')],
+        text: 'Z',
+        anchor: { x: 0, y: 0 },
+      },
+    ]);
+    expect(el.style.zIndex).toBe('');
+    
+    layer.destroy();
+  });
+
   it('destroy removes the host element and unsubscribes', () => {
     const { overlay, hostParent, syncSubscribers } = createMockOverlay();
     const layer = new DecorationLayer(overlay);

--- a/packages/osdlabel/src/index.ts
+++ b/packages/osdlabel/src/index.ts
@@ -113,6 +113,7 @@ export {
   centroid,
   midpoint,
   boundingBox,
+  withSelectionEmphasis,
 } from '@osdlabel/decoration';
 
 // Validation schemas (re-exported from @osdlabel/validation)

--- a/packages/osdlabel/src/live-decoration-updates.ts
+++ b/packages/osdlabel/src/live-decoration-updates.ts
@@ -23,6 +23,8 @@ export interface LiveDecorationUpdateOptions<E extends object = Record<string, n
   readonly getProviders: () => readonly DecorationProvider<E>[];
   /** Called with the newly-computed decorations on each throttled tick. */
   readonly onDecorations: (decorations: readonly Decoration[]) => void;
+  /** Returns the currently selected annotation ID, if any. */
+  readonly getSelectedAnnotationId?: (() => AnnotationId | null | undefined) | undefined;
 }
 
 /**
@@ -45,7 +47,7 @@ export interface LiveDecorationUpdateOptions<E extends object = Record<string, n
 export function enableLiveDecorationUpdates<E extends object = Record<string, never>>(
   options: LiveDecorationUpdateOptions<E>,
 ): () => void {
-  const { overlay, getVisibleAnnotations, getPixelSpacing, getProviders, onDecorations } = options;
+  const { overlay, getVisibleAnnotations, getPixelSpacing, getProviders, onDecorations, getSelectedAnnotationId } = options;
   const canvas = overlay.canvas;
 
   let scheduled = false;
@@ -68,7 +70,8 @@ export function enableLiveDecorationUpdates<E extends object = Record<string, ne
 
     const annotations = applyLiveOverride(getVisibleAnnotations(), target);
     const pixelSpacing = getPixelSpacing();
-    const ctx = pixelSpacing !== undefined ? { annotations, pixelSpacing } : { annotations };
+    const selectedAnnotationId = getSelectedAnnotationId?.();
+    const ctx = { annotations, pixelSpacing, selectedAnnotationId };
     const decorations = providers.flatMap((p) => p(ctx));
     onDecorations(decorations);
   };

--- a/packages/osdlabel/src/live-decoration-updates.ts
+++ b/packages/osdlabel/src/live-decoration-updates.ts
@@ -70,7 +70,7 @@ export function enableLiveDecorationUpdates<E extends object = Record<string, ne
 
     const annotations = applyLiveOverride(getVisibleAnnotations(), target);
     const pixelSpacing = getPixelSpacing();
-    const selectedAnnotationId = getSelectedAnnotationId?.();
+    const selectedAnnotationId = getSelectedAnnotationId?.() ?? null;
     const ctx = { annotations, pixelSpacing, selectedAnnotationId };
     const decorations = providers.flatMap((p) => p(ctx));
     onDecorations(decorations);

--- a/packages/osdlabel/tests/unit/live-decoration-updates.test.ts
+++ b/packages/osdlabel/tests/unit/live-decoration-updates.test.ts
@@ -195,7 +195,26 @@ describe('enableLiveDecorationUpdates', () => {
     rig.flushRAF();
     expect(providerSpacing).toEqual(spacing);
   });
-
+  it('passes selectedAnnotationId through to providers', () => {
+    const rig = createRig();
+    const selectedId = annId('test-selected');
+    const provider: DecorationProvider = ({ selectedAnnotationId }) => {
+      providerSelectedId = selectedAnnotationId;
+      return [];
+    };
+    let providerSelectedId: AnnotationId | null | undefined;
+    enableLiveDecorationUpdates({
+      overlay: rig.overlay,
+      getVisibleAnnotations: () => [],
+      getPixelSpacing: () => undefined,
+      getSelectedAnnotationId: () => selectedId,
+      getProviders: () => [provider],
+      onDecorations: vi.fn(),
+    });
+    rig.fire('object:moving', fakeFabricTarget('x', null as unknown as Annotation['geometry']));
+    rig.flushRAF();
+    expect(providerSelectedId).toBe(selectedId);
+  });
   it('skips providers and onDecorations entirely when none are registered', () => {
     // No-providers case is fast-exited at the event handler; the rAF queue
     // stays empty and onDecorations is never invoked. Host frameworks call

--- a/packages/react/src/components/ViewerCell.tsx
+++ b/packages/react/src/components/ViewerCell.tsx
@@ -194,6 +194,7 @@ export default function ViewerCell({
     defaultPixelSpacing,
     imageSource?.pixelSpacing,
     uiState.selectedAnnotationId,
+    decorationProviders,
   ]);
 
   // Live-update decorations during Fabric drag. Accessors close over refs

--- a/packages/react/src/components/ViewerCell.tsx
+++ b/packages/react/src/components/ViewerCell.tsx
@@ -184,18 +184,16 @@ export default function ViewerCell({
       return;
     }
     const pixelSpacing = imageSource?.pixelSpacing ?? defaultPixelSpacing;
-    const ctx =
-      pixelSpacing !== undefined
-        ? { annotations: visibleAnnotations, pixelSpacing }
-        : { annotations: visibleAnnotations };
+    const selectedAnnotationId = uiState.selectedAnnotationId;
+    const ctx = { annotations: visibleAnnotations, pixelSpacing, selectedAnnotationId };
     const decorations = decorationProviders.flatMap((p) => p(ctx));
     layer.setDecorations(decorations);
   }, [
     overlay,
     visibleAnnotations,
-    decorationProviders,
     defaultPixelSpacing,
     imageSource?.pixelSpacing,
+    uiState.selectedAnnotationId,
   ]);
 
   // Live-update decorations during Fabric drag. Accessors close over refs
@@ -206,6 +204,8 @@ export default function ViewerCell({
   decorationProvidersRef.current = decorationProviders;
   const pixelSpacingRef = useRef<typeof defaultPixelSpacing>(undefined);
   pixelSpacingRef.current = imageSource?.pixelSpacing ?? defaultPixelSpacing;
+  const selectedIdRef = useRef(uiState.selectedAnnotationId);
+  selectedIdRef.current = uiState.selectedAnnotationId;
   useEffect(() => {
     const layer = decorationLayerRef.current;
     if (!overlay || !layer) return;
@@ -213,6 +213,7 @@ export default function ViewerCell({
       overlay,
       getVisibleAnnotations: () => visibleAnnotationsRef.current,
       getPixelSpacing: () => pixelSpacingRef.current,
+      getSelectedAnnotationId: () => selectedIdRef.current,
       getProviders: () => decorationProvidersRef.current ?? [],
       onDecorations: (decorations) => layer.setDecorations(decorations),
     });

--- a/packages/solid/src/components/ViewerCell.tsx
+++ b/packages/solid/src/components/ViewerCell.tsx
@@ -188,7 +188,8 @@ const ViewerCell: Component<ViewerCellProps> = (props) => {
     }
     const annotations = visibleAnnotations();
     const pixelSpacing = props.imageSource?.pixelSpacing ?? defaultPixelSpacing;
-    const ctx = pixelSpacing !== undefined ? { annotations, pixelSpacing } : { annotations };
+    const selectedAnnotationId = uiState.selectedAnnotationId;
+    const ctx = { annotations, pixelSpacing, selectedAnnotationId };
     const decorations = providers.flatMap((p) => p(ctx));
     layer.setDecorations(decorations);
   });
@@ -204,6 +205,7 @@ const ViewerCell: Component<ViewerCellProps> = (props) => {
       overlay: ov,
       getVisibleAnnotations: visibleAnnotations,
       getPixelSpacing: () => props.imageSource?.pixelSpacing ?? defaultPixelSpacing,
+      getSelectedAnnotationId: () => uiState.selectedAnnotationId,
       getProviders: () => decorationProviders ?? [],
       onDecorations: (decorations) => layer.setDecorations(decorations),
     });


### PR DESCRIPTION
Implements minimal Phase 3 for handling overlapping/selected decorations using visual emphasis and z-index instead of collision avoidance.

Adds `selectedAnnotationId` to `DecorationContext`, plumbing it through React/Solid components and live updates.
Adds `zIndex` to `TextDecorationStyle` and processes it in the `DecorationLayer`.
Provides a pure `withSelectionEmphasis` utility that wraps any `DecorationProvider` to inject styles on decorations related to the currently selected annotation. Includes full support for both text and line decorations.