### PR TITLE
Fix: Prevent point annotations from being resized

### DIFF
--- a/packages/fabric-annotations/src/fabric-utils.ts
+++ b/packages/fabric-annotations/src/fabric-utils.ts
@@ -65,10 +65,16 @@ export async function createFabricObjectFromRawData(
   const obj = await deserializeFabricObject(annotation.rawAnnotationData);
   if (!obj) return null;
 
-  obj.set({
+  const options: Record<string, any> = {
     selectable: true,
     evented: true,
-  });
+  };
+
+  if (annotation.toolType === 'point') {
+    options.hasControls = false;
+  }
+
+  obj.set(options);
 
   return obj;
 }

--- a/packages/fabric-annotations/src/tools/point-tool.ts
+++ b/packages/fabric-annotations/src/tools/point-tool.ts
@@ -16,6 +16,7 @@ export class PointTool extends ShapeTool<Circle> {
       originY: 'center',
       selectable: false,
       evented: false,
+      hasControls: false,
     });
   }
 

--- a/test-fabric-controls.js
+++ b/test-fabric-controls.js
@@ -1,0 +1,6 @@
+import { Circle, FabricObject } from 'fabric';
+
+FabricObject.customProperties = ['hasControls'];
+const c = new Circle({ radius: 5, hasControls: false, lockScalingX: true, lockScalingY: true });
+const obj = c.toObject();
+console.log("serialized lockScalingX:", obj.lockScalingX);

--- a/test-fabric-serialize.js
+++ b/test-fabric-serialize.js
@@ -1,0 +1,10 @@
+import { Circle, FabricObject } from 'fabric';
+
+FabricObject.customProperties = ['hasControls'];
+const c = new Circle({ radius: 5, hasControls: false });
+console.log("hasControls before:", c.hasControls);
+const obj = c.toObject();
+console.log("serialized:", obj.hasControls);
+
+const c2 = await Circle.fromObject(obj);
+console.log("hasControls after:", c2.hasControls);

--- a/test-fabric.js
+++ b/test-fabric.js
@@ -1,0 +1,4 @@
+import { Circle } from 'fabric';
+
+const c = new Circle({ radius: 5, hasControls: false });
+console.log(c.toObject());


### PR DESCRIPTION
Fixes #107 point annotations being resizable when they should only be movable.

This is done by setting `hasControls: false` when generating the preview shape in PointTool and correctly applying `hasControls: false` on point tools on deserialization within `createFabricObjectFromRawData`.

---
*PR created automatically by Jules for task [6957130349159152](https://jules.google.com/task/6957130349159152) started by @guyo13*