### PR TITLE
docs: showcase decorations in the interactive demo with live toggles

### DIFF
--- a/apps/docs/public/llms.txt
+++ b/apps/docs/public/llms.txt
@@ -2332,7 +2332,7 @@ render(() => <App />, document.getElementById('app')!);
 
 # Decorations & Measurements
 
-A full real-world wiring of the decoration system: three built-in providers (measurements, labels, distance lines), each wrapped with `withSelectionEmphasis` so the selected annotation's labels lift visually above the rest. This is exactly what the dev app uses; you can see it running on the [Interactive Demo](/osdlabel/demo/) page.
+A full real-world wiring of the decoration system: three built-in providers (measurements, labels, distance lines), each wrapped with `withSelectionEmphasis` so the selected annotation's labels lift visually above the rest. This is exactly what the dev app uses; you can see it running on the [Interactive Demo](/osdlabel/demo/) page, which exposes **Measurements / Labels / Distance** toggles so you can switch each provider on and off live.
 
 Examples use `@osdlabel/solid`; the React equivalents (`@osdlabel/react`) have identical APIs.
 

--- a/apps/docs/src/components/demos/full-demo/AnnotateView.tsx
+++ b/apps/docs/src/components/demos/full-demo/AnnotateView.tsx
@@ -1,4 +1,4 @@
-import { createSignal, createEffect, For } from 'solid-js';
+import { createSignal, createEffect, For, type Accessor, type Setter } from 'solid-js';
 import {
   Toolbar,
   StatusBar,
@@ -10,8 +10,46 @@ import {
   useAnnotator,
   serialize,
   deserialize,
+  createMeasurementProvider,
+  createLabelProvider,
+  createDistanceProvider,
+  withSelectionEmphasis,
 } from '@osdlabel/solid';
-import type { AnnotationContextId, AnnotationContext, ImageSource } from '@osdlabel/solid';
+import type {
+  AnnotationContextId,
+  AnnotationContext,
+  ImageSource,
+  DecorationProvider,
+  OsdFields,
+} from '@osdlabel/solid';
+
+const selectedTextStyle = {
+  zIndex: 10,
+  background: 'rgba(33, 150, 243, 0.9)',
+  color: '#fff',
+};
+const selectedLineStyle = { stroke: '#2196f3', strokeWidth: 3 };
+
+// Gate a provider behind a reactive toggle. The returned provider reads the
+// signal at call time; because ViewerCell invokes providers inside its
+// decoration `createEffect`, Solid tracks the signal and re-runs the effect
+// (and `setDecorations`) whenever the toggle flips — live, without remounting.
+const gate =
+  (
+    enabled: Accessor<boolean>,
+    provider: DecorationProvider<OsdFields>,
+  ): DecorationProvider<OsdFields> =>
+  (ctx) =>
+    enabled() ? provider(ctx) : [];
+
+interface DecorationToggles {
+  showMeasurements: Accessor<boolean>;
+  setShowMeasurements: Setter<boolean>;
+  showLabels: Accessor<boolean>;
+  setShowLabels: Setter<boolean>;
+  showDistance: Accessor<boolean>;
+  setShowDistance: Setter<boolean>;
+}
 
 export interface AnnotateViewProps {
   images: readonly ImageSource[];
@@ -19,7 +57,7 @@ export interface AnnotateViewProps {
   onReconfigure: () => void;
 }
 
-function AppContent(props: AnnotateViewProps) {
+function AppContent(props: AnnotateViewProps & { toggles: DecorationToggles }) {
   const { uiState, annotationState, actions, activeImageId } = useAnnotator();
   const [copyLabel, setCopyLabel] = createSignal('Copy JSON');
   const [activeCtxIdx, setActiveCtxIdx] = createSignal(0);
@@ -153,6 +191,38 @@ function AppContent(props: AnnotateViewProps) {
                   }}
                 />
                 {ctx.label}
+              </label>
+            )}
+          </For>
+        </div>
+
+        <div style={{ display: 'flex', gap: '8px', 'align-items': 'center' }}>
+          <span style={{ 'font-size': '12px', color: '#aaa' }}>Decorations:</span>
+          <For
+            each={
+              [
+                ['Measurements', props.toggles.showMeasurements, props.toggles.setShowMeasurements],
+                ['Labels', props.toggles.showLabels, props.toggles.setShowLabels],
+                ['Distance', props.toggles.showDistance, props.toggles.setShowDistance],
+              ] as const
+            }
+          >
+            {([label, get, set]) => (
+              <label
+                style={{
+                  display: 'flex',
+                  gap: '4px',
+                  'align-items': 'center',
+                  'font-size': '12px',
+                  cursor: 'pointer',
+                }}
+              >
+                <input
+                  type="checkbox"
+                  checked={get()}
+                  onChange={(e) => set(e.currentTarget.checked)}
+                />
+                {label}
               </label>
             )}
           </For>
@@ -323,9 +393,53 @@ function AppContent(props: AnnotateViewProps) {
 }
 
 export default function AnnotateView(props: AnnotateViewProps) {
+  const [showMeasurements, setShowMeasurements] = createSignal(true);
+  const [showLabels, setShowLabels] = createSignal(true);
+  const [showDistance, setShowDistance] = createSignal(true);
+
+  const decorationProviders: readonly DecorationProvider<OsdFields>[] = [
+    gate(
+      showMeasurements,
+      withSelectionEmphasis(
+        createMeasurementProvider({ area: true, perimeter: true, length: true, radius: true }),
+        { selectedTextStyle, selectedLineStyle },
+      ),
+    ),
+    gate(showLabels, withSelectionEmphasis(createLabelProvider(), { selectedTextStyle })),
+    gate(
+      showDistance,
+      withSelectionEmphasis(
+        createDistanceProvider({
+          // Pair every two consecutive point annotations.
+          pair: (annotations) => {
+            const points = annotations.filter((a) => a.geometry.type === 'point');
+            const pairs: { a: (typeof points)[number]; b: (typeof points)[number] }[] = [];
+            for (let i = 0; i < points.length - 1; i += 2) {
+              pairs.push({ a: points[i]!, b: points[i + 1]! });
+            }
+            return pairs;
+          },
+        }),
+        { selectedTextStyle, selectedLineStyle },
+      ),
+    ),
+  ];
+
+  const toggles: DecorationToggles = {
+    showMeasurements,
+    setShowMeasurements,
+    showLabels,
+    setShowLabels,
+    showDistance,
+    setShowDistance,
+  };
+
   return (
-    <AnnotatorProvider>
-      <AppContent {...props} />
+    <AnnotatorProvider
+      decorationProviders={decorationProviders}
+      defaultPixelSpacing={{ x: 1, y: 1, unit: 'px' }}
+    >
+      <AppContent {...props} toggles={toggles} />
     </AnnotatorProvider>
   );
 }

--- a/apps/docs/src/content/docs/examples/decorations.mdx
+++ b/apps/docs/src/content/docs/examples/decorations.mdx
@@ -3,7 +3,7 @@ title: Decorations & Measurements
 description: Wiring built-in decoration providers with selection emphasis and pixel-spacing calibration
 ---
 
-A full real-world wiring of the decoration system: three built-in providers (measurements, labels, distance lines), each wrapped with `withSelectionEmphasis` so the selected annotation's labels lift visually above the rest. This is exactly what the dev app uses; you can see it running on the [Interactive Demo](/osdlabel/demo/) page.
+A full real-world wiring of the decoration system: three built-in providers (measurements, labels, distance lines), each wrapped with `withSelectionEmphasis` so the selected annotation's labels lift visually above the rest. This is exactly what the dev app uses; you can see it running on the [Interactive Demo](/osdlabel/demo/) page, which exposes **Measurements / Labels / Distance** toggles so you can switch each provider on and off live.
 
 Examples use `@osdlabel/solid`; the React equivalents (`@osdlabel/react`) have identical APIs.
 

--- a/apps/docs/src/content/docs/llm.md
+++ b/apps/docs/src/content/docs/llm.md
@@ -2326,7 +2326,7 @@ render(() => <App />, document.getElementById('app')!);
 
 # Decorations & Measurements
 
-A full real-world wiring of the decoration system: three built-in providers (measurements, labels, distance lines), each wrapped with `withSelectionEmphasis` so the selected annotation's labels lift visually above the rest. This is exactly what the dev app uses; you can see it running on the [Interactive Demo](/osdlabel/demo/) page.
+A full real-world wiring of the decoration system: three built-in providers (measurements, labels, distance lines), each wrapped with `withSelectionEmphasis` so the selected annotation's labels lift visually above the rest. This is exactly what the dev app uses; you can see it running on the [Interactive Demo](/osdlabel/demo/) page, which exposes **Measurements / Labels / Distance** toggles so you can switch each provider on and off live.
 
 Examples use `@osdlabel/solid`; the React equivalents (`@osdlabel/react`) have identical APIs.
 


### PR DESCRIPTION
## Summary

The "Decorations & Measurements" example page told visitors that the wiring it documents "is exactly what the dev app uses; you can see it running on the Interactive Demo page." That claim was **false**: the demo rendered `<AnnotatorProvider>` with no props, so no decoration providers and no pixel spacing were configured — measurements, labels, and distance lines never appeared. Only the local dev app actually showcased the feature.

This PR makes the claim true and goes a step further by letting visitors toggle each provider on and off live.

## What changed

**Interactive demo (`apps/docs/src/components/demos/full-demo/AnnotateView.tsx`)**
- Pass the dev-app decoration providers into the demo's `AnnotatorProvider`: `createMeasurementProvider` (area / perimeter / length / radius), `createLabelProvider`, and `createDistanceProvider` (pairs consecutive point annotations) — each wrapped in `withSelectionEmphasis` so the selected annotation's labels/lines lift visually above the rest.
- Pass `defaultPixelSpacing={{ x: 1, y: 1, unit: 'px' }}` (matching the dev app — the demo's example DZI images have no real calibration).
- Add **Measurements / Labels / Distance** toggle checkboxes to the toolbar so each provider can be switched on and off interactively.

**Docs copy (`apps/docs/.../examples/decorations.mdx`)**
- Mention the demo's new toggles. Regenerates the build-time `llm.md` / `llms.txt` artifacts.

## How the live toggles work (no library changes)

Each provider is gated behind a SolidJS signal that it reads **at call time**. Because `ViewerCell` invokes providers inside its decoration `createEffect`, Solid tracks the signal as a dependency and re-runs `setDecorations` whenever a toggle flips — updating decorations live, with no remount and without losing annotations. All changes are isolated to `apps/docs`; no library package is touched.

## Verification

- `tsc` (strict + `exactOptionalPropertyTypes`) on the demo component → 0 errors
- `pnpm build` (all 14 packages) and `pnpm --filter @osdlabel/docs build` → clean

To try it: `pnpm docs:dev` → open `/osdlabel/demo/` → Launch → pick the "General" context → draw a rectangle/circle/line (area/perimeter/length labels appear) and drop two points (dashed connector + distance label). Toggle the checkboxes to show/hide each provider live; select an annotation to see selection emphasis.

https://claude.ai/code/session_01DoXX4UUxedboJJHkFVWK8T

---
_Generated by [Claude Code](https://claude.ai/code/session_01DoXX4UUxedboJJHkFVWK8T)_