### PR TITLE
Add DOM decorations for framework-rendered rich content

### DIFF
--- a/.changeset/dom-decorations.md
+++ b/.changeset/dom-decorations.md
@@ -1,0 +1,37 @@
+---
+"osdlabel": minor
+"@osdlabel/annotation": minor
+"@osdlabel/annotation-context": minor
+"@osdlabel/decoration": minor
+"@osdlabel/fabric-annotations": minor
+"@osdlabel/fabric-osd": minor
+"@osdlabel/osd-helper": minor
+"@osdlabel/react": minor
+"@osdlabel/solid": minor
+"@osdlabel/validation": minor
+"@osdlabel/viewer-api": minor
+---
+
+Add DOM decorations: framework-rendered rich annotation decorations.
+
+A new `DomDecoration` variant joins the `Decoration` union (alongside text and
+line). It exposes a positioned `<div>` root whose screen position and transforms
+are managed entirely by the Fabric/OSD `DecorationLayer`, while a UI framework
+renders an arbitrary component tree into it via its native portal — so the
+rendered tree shares the host app's context (state, theme, hooks). This enables
+interactive popovers, mini-forms, and charts attached to annotations.
+
+- `@osdlabel/decoration`: new `DomDecoration` + `DomDecorationStyle` types
+  (framework-agnostic, `content: unknown`). Interactive by default
+  (`pointer-events: auto`), configurable to `'none'`.
+- `@osdlabel/fabric-osd`: `DecorationLayer` creates, positions, and owns the DOM
+  roots (id-stable diffing, unified positioning with text decorations), and
+  exposes `onDomDecorations` — a subscription that fires on membership change
+  only, so portals never thrash during pan/zoom/drag. Entry identity is stable
+  so SolidJS `<For>` reuses rows. `content` is stable config; dynamic data flows
+  through the app's own reactivity inside the mounted component.
+- `@osdlabel/react` / `@osdlabel/solid`: new `renderDomDecoration` prop on the
+  annotator wires the bridge (React `createPortal`, Solid `<Portal>`).
+
+Also includes a prior dependency-maintenance chore: project dependencies were
+updated, notably patching the vulnerable `fabric` 7.2.0 to 7.4.0.

--- a/apps/dev-react/src/App.tsx
+++ b/apps/dev-react/src/App.tsx
@@ -12,10 +12,40 @@ import {
   serialize,
   deserialize,
   initFabricModule,
+  createLabelProvider,
+  centroid,
 } from '@osdlabel/react';
-import type { AnnotationContextId, AnnotationContext, ImageSource } from '@osdlabel/react';
+import type {
+  AnnotationContextId,
+  AnnotationContext,
+  ImageSource,
+  DecorationProvider,
+  DomDecoration,
+  OsdFields,
+} from '@osdlabel/react';
 
 initFabricModule();
+
+// Example DOM-decoration content payload (stable config).
+interface BadgeContent {
+  readonly annotationId: string;
+  readonly label: string;
+}
+
+// A consumer-authored provider: one interactive DOM badge per annotation,
+// anchored above the annotation's centroid.
+const domBadgeProvider: DecorationProvider<OsdFields> = ({ annotations }) =>
+  annotations.map(
+    (ann): DomDecoration => ({
+      type: 'dom',
+      id: `badge:${ann.id}`,
+      relatedAnnotationIds: [ann.id],
+      anchor: centroid(ann.geometry),
+      offset: { x: 0, y: -28 },
+      placement: 'bottom',
+      content: { annotationId: ann.id, label: ann.label ?? ann.toolType } satisfies BadgeContent,
+    }),
+  );
 
 const IMAGES: ImageSource[] = [
   {
@@ -384,6 +414,29 @@ export default function App() {
       onAnnotationsChange={(anns) => console.log('Annotations changed:', anns.length, 'total')}
       onConstraintChange={(status) => console.log('Constraint status changed:', status)}
       testMode={true}
+      decorationProviders={[createLabelProvider(), domBadgeProvider]}
+      renderDomDecoration={(decoration) => {
+        const content = decoration.content as BadgeContent;
+        return (
+          <button
+            type="button"
+            data-osdlabel-test="dom-badge"
+            style={{
+              background: '#9c27b0',
+              color: '#fff',
+              border: 'none',
+              borderRadius: '4px',
+              padding: '2px 8px',
+              fontSize: '12px',
+              cursor: 'pointer',
+              boxShadow: '0 1px 3px rgba(0,0,0,0.4)',
+            }}
+            onClick={() => console.log('DOM decoration clicked for', content.annotationId)}
+          >
+            ★ {content.label}
+          </button>
+        );
+      }}
     >
       <AppContent />
     </AnnotatorProvider>

--- a/apps/dev/src/App.tsx
+++ b/apps/dev/src/App.tsx
@@ -17,8 +17,16 @@ import {
   createLabelProvider,
   createDistanceProvider,
   withSelectionEmphasis,
+  centroid,
 } from '@osdlabel/solid';
-import type { AnnotationContextId, AnnotationContext, ImageSource } from '@osdlabel/solid';
+import type {
+  AnnotationContextId,
+  AnnotationContext,
+  ImageSource,
+  DecorationProvider,
+  DomDecoration,
+  OsdFields,
+} from '@osdlabel/solid';
 
 initFabricModule();
 
@@ -384,9 +392,53 @@ function AppContent() {
   );
 }
 
+// Example DOM-decoration content payload. `content` is stable config; any
+// dynamic data should be read reactively inside the rendered component.
+interface BadgeContent {
+  readonly annotationId: string;
+  readonly label: string;
+}
+
+// A consumer-authored provider: one interactive DOM badge per annotation,
+// anchored above the annotation's centroid.
+const domBadgeProvider: DecorationProvider<OsdFields> = ({ annotations }) =>
+  annotations.map(
+    (ann): DomDecoration => ({
+      type: 'dom',
+      id: `badge:${ann.id}`,
+      relatedAnnotationIds: [ann.id],
+      anchor: centroid(ann.geometry),
+      offset: { x: 0, y: -28 },
+      placement: 'bottom',
+      content: { annotationId: ann.id, label: ann.label ?? ann.toolType } satisfies BadgeContent,
+    }),
+  );
+
 function App() {
   return (
     <AnnotatorProvider
+      renderDomDecoration={(decoration) => {
+        const content = decoration.content as BadgeContent;
+        return (
+          <button
+            type="button"
+            data-osdlabel-test="dom-badge"
+            style={{
+              background: '#9c27b0',
+              color: '#fff',
+              border: 'none',
+              'border-radius': '4px',
+              padding: '2px 8px',
+              'font-size': '12px',
+              cursor: 'pointer',
+              'box-shadow': '0 1px 3px rgba(0,0,0,0.4)',
+            }}
+            onClick={() => console.log('DOM decoration clicked for', content.annotationId)}
+          >
+            ★ {content.label}
+          </button>
+        );
+      }}
       onAnnotationsChange={(anns) => console.log('Annotations changed:', anns.length, 'total')}
       onConstraintChange={(status) => console.log('Constraint status changed:', status)}
       testMode={true}
@@ -418,6 +470,7 @@ function App() {
             selectedTextStyle: { zIndex: 10, background: 'rgba(33, 150, 243, 0.9)', color: '#fff' },
           },
         ),
+        domBadgeProvider,
       ]}
     >
       <AppContent />

--- a/apps/dev/tests/e2e/dom-decorations.spec.ts
+++ b/apps/dev/tests/e2e/dom-decorations.spec.ts
@@ -59,16 +59,20 @@ test.describe('DOM decorations', () => {
     await page.mouse.up();
     await page.waitForTimeout(400);
 
-    const badge = page.locator('[data-osdlabel-test="dom-badge"]');
-    await expect(badge).toBeVisible();
-    const before = await badge.evaluate((el) => (el.parentElement as HTMLElement).style.transform);
+    // The decoration root (positioned by the layer) carries the transform — not
+    // the badge's immediate parent, which is the framework portal's wrapper.
+    const root = page.locator('[data-osdlabel="decoration-dom"]').first();
+    await expect(root).toBeVisible();
+    const before = await root.evaluate((el) => (el as HTMLElement).style.transform);
+    expect(before).toContain('translate3d');
 
-    // Zoom via the canvas; the decoration root repositions on OSD sync.
-    await page.mouse.move(box.x + 220, box.y + 140);
+    // Zoom with the focal point away from the badge's anchor so its screen
+    // position genuinely shifts; the root repositions on OSD sync.
+    await page.mouse.move(box.x + 450, box.y + 320);
     await page.mouse.wheel(0, -600);
-    await page.waitForTimeout(500);
+    await page.waitForTimeout(600);
 
-    const after = await badge.evaluate((el) => (el.parentElement as HTMLElement).style.transform);
+    const after = await root.evaluate((el) => (el as HTMLElement).style.transform);
     expect(after).not.toBe(before);
   });
 });

--- a/apps/dev/tests/e2e/dom-decorations.spec.ts
+++ b/apps/dev/tests/e2e/dom-decorations.spec.ts
@@ -43,7 +43,7 @@ test.describe('DOM decorations', () => {
     await expect(page.locator('[data-osdlabel-test="dom-badge"]')).toHaveCount(1);
   });
 
-  test('badge follows the image on zoom', async ({ page }) => {
+  test('badge follows the image when the viewport pans', async ({ page }) => {
     const canvas = page.locator('canvas.upper-canvas');
     await canvas.waitFor({ state: 'attached', timeout: 15000 });
     await page.waitForTimeout(1000);
@@ -66,10 +66,14 @@ test.describe('DOM decorations', () => {
     const before = await root.evaluate((el) => (el as HTMLElement).style.transform);
     expect(before).toContain('translate3d');
 
-    // Zoom with the focal point away from the badge's anchor so its screen
-    // position genuinely shifts; the root repositions on OSD sync.
-    await page.mouse.move(box.x + 450, box.y + 320);
-    await page.mouse.wheel(0, -600);
+    // Switch to navigate and pan the image; OSD fires its 'animation' sync,
+    // which repositions the decoration root. Panning is deterministic (every
+    // point shifts by the drag delta), unlike wheel-zoom against OSD.
+    await page.getByTestId('tool-navigate').click();
+    await page.mouse.move(box.x + 400, box.y + 320);
+    await page.mouse.down();
+    await page.mouse.move(box.x + 250, box.y + 220, { steps: 10 });
+    await page.mouse.up();
     await page.waitForTimeout(600);
 
     const after = await root.evaluate((el) => (el as HTMLElement).style.transform);

--- a/apps/dev/tests/e2e/dom-decorations.spec.ts
+++ b/apps/dev/tests/e2e/dom-decorations.spec.ts
@@ -1,0 +1,74 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('DOM decorations', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector('[data-testid="tool-navigate"]', { timeout: 10000 });
+  });
+
+  test('renders an interactive DOM badge over a drawn annotation', async ({ page }) => {
+    const canvas = page.locator('canvas.upper-canvas');
+    await canvas.waitFor({ state: 'attached', timeout: 15000 });
+    await page.waitForTimeout(1000);
+
+    // No annotations yet → no badges.
+    await expect(page.locator('[data-osdlabel-test="dom-badge"]')).toHaveCount(0);
+
+    const lineButton = page.getByTestId('tool-line');
+    await lineButton.click();
+    const box = await canvas.boundingBox();
+    if (!box) throw new Error('Canvas not found');
+
+    // Draw one line.
+    await page.mouse.move(box.x + 120, box.y + 140);
+    await page.mouse.down();
+    await page.mouse.move(box.x + 320, box.y + 140, { steps: 5 });
+    await page.mouse.up();
+    await page.waitForTimeout(400);
+
+    // A DOM badge (framework-rendered button) is mounted into the decoration root.
+    const badge = page.locator('[data-osdlabel-test="dom-badge"]');
+    await expect(badge).toHaveCount(1);
+    await expect(badge).toBeVisible();
+
+    // The badge is interactive — clicking it logs to console and must NOT start
+    // a pan/draw (the active tool stays unchanged, no new annotation created).
+    const messages: string[] = [];
+    page.on('console', (msg) => messages.push(msg.text()));
+    await badge.click();
+    await page.waitForTimeout(100);
+    expect(messages.some((m) => m.includes('DOM decoration clicked for'))).toBe(true);
+
+    // Still exactly one annotation (the click did not draw a new line).
+    await expect(page.locator('[data-osdlabel-test="dom-badge"]')).toHaveCount(1);
+  });
+
+  test('badge follows the image on zoom', async ({ page }) => {
+    const canvas = page.locator('canvas.upper-canvas');
+    await canvas.waitFor({ state: 'attached', timeout: 15000 });
+    await page.waitForTimeout(1000);
+
+    const lineButton = page.getByTestId('tool-line');
+    await lineButton.click();
+    const box = await canvas.boundingBox();
+    if (!box) throw new Error('Canvas not found');
+
+    await page.mouse.move(box.x + 120, box.y + 140);
+    await page.mouse.down();
+    await page.mouse.move(box.x + 320, box.y + 140, { steps: 5 });
+    await page.mouse.up();
+    await page.waitForTimeout(400);
+
+    const badge = page.locator('[data-osdlabel-test="dom-badge"]');
+    await expect(badge).toBeVisible();
+    const before = await badge.evaluate((el) => (el.parentElement as HTMLElement).style.transform);
+
+    // Zoom via the canvas; the decoration root repositions on OSD sync.
+    await page.mouse.move(box.x + 220, box.y + 140);
+    await page.mouse.wheel(0, -600);
+    await page.waitForTimeout(500);
+
+    const after = await badge.evaluate((el) => (el.parentElement as HTMLElement).style.transform);
+    expect(after).not.toBe(before);
+  });
+});

--- a/packages/decoration/src/decoration.ts
+++ b/packages/decoration/src/decoration.ts
@@ -27,6 +27,24 @@ export interface LineDecorationStyle {
   readonly opacity?: number | undefined;
 }
 
+/** Styling applied to a DOM decoration's root element. */
+export interface DomDecorationStyle {
+  /** Additional CSS class applied to the root element. */
+  readonly className?: string | undefined;
+  /** CSS z-index controlling stacking order among DOM decorations / text labels. */
+  readonly zIndex?: number | undefined;
+  /**
+   * Whether the root element captures pointer events. Defaults to `'auto'` so
+   * rich content (buttons, inputs, popovers) is interactive. Set `'none'` for
+   * purely-visual content that should let clicks fall through to the canvas.
+   */
+  readonly pointerEvents?: 'auto' | 'none' | undefined;
+  /** Optional fixed width in screen pixels; otherwise the root sizes to content. */
+  readonly width?: number | undefined;
+  /** Optional fixed height in screen pixels; otherwise the root sizes to content. */
+  readonly height?: number | undefined;
+}
+
 interface BaseDecoration {
   /**
    * Stable identifier used for diffing across recomputations. Providers must
@@ -81,13 +99,39 @@ export interface LineDecoration extends BaseDecoration {
 }
 
 /**
+ * A framework-rendered rich decoration.
+ *
+ * The renderer creates and positions a `<div>` root anchored to the image; a
+ * UI framework (React, Solid, …) renders an arbitrary component tree into that
+ * root via its native portal, so the tree shares the host app's context. The
+ * `content` payload is treated as stable configuration/identity — dynamic data
+ * should flow through the app's own reactivity inside the rendered component,
+ * not through `content` changing per frame.
+ */
+export interface DomDecoration extends BaseDecoration {
+  readonly type: 'dom';
+  /** Anchor point in image-space coordinates. */
+  readonly anchor: Point;
+  /**
+   * Optional screen-pixel offset added to the anchor's screen position before
+   * the root is placed.
+   */
+  readonly offset?: { readonly x: number; readonly y: number } | undefined;
+  /** How the root aligns to its anchor. Default: `'top-left'`. */
+  readonly placement?: TextPlacement | undefined;
+  /** Framework-agnostic configuration the render-prop interprets. */
+  readonly content: unknown;
+  readonly style?: DomDecorationStyle | undefined;
+}
+
+/**
  * Declarative description of something to render alongside annotations.
  *
  * Decorations are pure data: providers return them, the renderer turns them
  * into DOM/Fabric objects. Decorations are never serialized into annotation
  * data — they are always recomputed from current state.
  */
-export type Decoration = TextDecoration | LineDecoration;
+export type Decoration = TextDecoration | LineDecoration | DomDecoration;
 
 /** Discriminator values of `Decoration`. */
 export type DecorationType = Decoration['type'];

--- a/packages/decoration/src/index.ts
+++ b/packages/decoration/src/index.ts
@@ -6,6 +6,8 @@ export type {
   TextPlacement,
   LineDecoration,
   LineDecorationStyle,
+  DomDecoration,
+  DomDecorationStyle,
 } from './decoration.js';
 export type { DecorationContext, DecorationProvider } from './provider.js';
 export { composeProviders } from './provider.js';

--- a/packages/decoration/tests/unit/dom-decoration.test.ts
+++ b/packages/decoration/tests/unit/dom-decoration.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import type { AnnotationId } from '@osdlabel/annotation';
+import type { Decoration, DomDecoration, DecorationProvider } from '../../src/index.js';
+
+const annId = (s: string): AnnotationId => s as AnnotationId;
+
+describe('DomDecoration', () => {
+  it('is part of the Decoration union and narrows on type', () => {
+    const decorations: readonly Decoration[] = [
+      {
+        type: 'dom',
+        id: 'dom:a',
+        relatedAnnotationIds: [annId('a')],
+        anchor: { x: 1, y: 2 },
+        content: { annotationId: annId('a') },
+        style: { pointerEvents: 'auto', zIndex: 5, width: 120, height: 80 },
+      },
+    ];
+
+    const domOnly = decorations.filter((d): d is DomDecoration => d.type === 'dom');
+    expect(domOnly).toHaveLength(1);
+    expect(domOnly[0]!.content).toEqual({ annotationId: annId('a') });
+    expect(domOnly[0]!.style?.pointerEvents).toBe('auto');
+  });
+
+  it('can be produced by a consumer provider over annotations', () => {
+    // A minimal consumer-authored provider that maps each annotation to a DOM
+    // decoration anchored at the geometry's first point (point geometry here).
+    const provider: DecorationProvider = ({ annotations }) =>
+      annotations.map(
+        (ann): DomDecoration => ({
+          type: 'dom',
+          id: `panel:${ann.id}`,
+          relatedAnnotationIds: [ann.id],
+          anchor: ann.geometry.type === 'point' ? ann.geometry.position : { x: 0, y: 0 },
+          content: { annotationId: ann.id, label: ann.label },
+        }),
+      );
+
+    const result = provider({
+      annotations: [
+        {
+          id: annId('a'),
+          toolType: 'point',
+          geometry: { type: 'point', position: { x: 3, y: 4 } },
+          createdAt: '2020-01-01T00:00:00.000Z',
+          updatedAt: '2020-01-01T00:00:00.000Z',
+          label: 'Cell',
+        },
+      ],
+      selectedAnnotationId: null,
+    });
+
+    expect(result).toHaveLength(1);
+    const dom = result[0] as DomDecoration;
+    expect(dom.type).toBe('dom');
+    expect(dom.anchor).toEqual({ x: 3, y: 4 });
+    expect(dom.content).toEqual({ annotationId: annId('a'), label: 'Cell' });
+  });
+});

--- a/packages/fabric-osd/src/decoration/decoration-layer.ts
+++ b/packages/fabric-osd/src/decoration/decoration-layer.ts
@@ -20,6 +20,20 @@ export interface DomDecorationEntry {
   readonly decoration: DomDecoration;
 }
 
+/**
+ * Internal entry: same shape as {@link DomDecorationEntry} but with a mutable
+ * `decoration` so the layer can update it in place. Keeping the entry object's
+ * identity stable across recomputations is essential for SolidJS's `<For>`,
+ * which tracks rows by referential equality — allocating fresh entry objects
+ * each notification would tear down and remount every `<Portal>` (losing focus
+ * / input state in unrelated decorations) whenever any one is added or removed.
+ */
+interface MutableDomEntry {
+  readonly id: string;
+  readonly element: HTMLDivElement;
+  decoration: DomDecoration;
+}
+
 type DomDecorationsCallback = (entries: readonly DomDecorationEntry[]) => void;
 
 const DEFAULT_TEXT_COLOR = '#ffffff';
@@ -52,8 +66,7 @@ export class DecorationLayer {
   private readonly _unsubscribeSync: () => void;
   private readonly _textEls = new Map<string, HTMLDivElement>();
   private readonly _lineObjects = new Map<string, FabricLine>();
-  private readonly _domEls = new Map<string, HTMLDivElement>();
-  private readonly _domDecorations = new Map<string, DomDecoration>();
+  private readonly _domEntries = new Map<string, MutableDomEntry>();
   private readonly _domSubscribers = new Set<DomDecorationsCallback>();
   private _decorations: readonly Decoration[] = [];
   private _destroyed = false;
@@ -107,11 +120,10 @@ export class DecorationLayer {
     }
     this._lineObjects.clear();
     this._textEls.clear();
-    for (const el of this._domEls.values()) {
-      el.remove();
+    for (const entry of this._domEntries.values()) {
+      entry.element.remove();
     }
-    this._domEls.clear();
-    this._domDecorations.clear();
+    this._domEntries.clear();
     this._notifyDomSubscribers();
     this._domSubscribers.clear();
     this._hostEl.remove();
@@ -161,20 +173,21 @@ export class DecorationLayer {
     let membershipChanged = false;
 
     // Remove gone
-    for (const [id, el] of this._domEls) {
+    for (const [id, entry] of this._domEntries) {
       if (!wanted.has(id)) {
-        el.remove();
-        this._domEls.delete(id);
-        this._domDecorations.delete(id);
+        entry.element.remove();
+        this._domEntries.delete(id);
         membershipChanged = true;
       }
     }
 
-    // Add new / update existing
+    // Add new / update existing. On update we mutate the existing entry's
+    // `decoration` in place rather than replacing the entry, so its object
+    // identity stays stable for SolidJS's `<For>` (see MutableDomEntry).
     for (const [id, decoration] of wanted) {
-      let el = this._domEls.get(id);
-      if (!el) {
-        el = document.createElement('div');
+      let entry = this._domEntries.get(id);
+      if (!entry) {
+        const el = document.createElement('div');
         el.style.position = 'absolute';
         el.style.top = '0';
         el.style.left = '0';
@@ -182,23 +195,22 @@ export class DecorationLayer {
         el.dataset.osdlabel = 'decoration-dom';
         el.dataset.decorationId = id;
         this._hostEl.appendChild(el);
-        this._domEls.set(id, el);
+        entry = { id, element: el, decoration };
+        this._domEntries.set(id, entry);
         membershipChanged = true;
+      } else {
+        entry.decoration = decoration;
       }
-      applyDomStyle(el, decoration);
-      this._domDecorations.set(id, decoration);
+      applyDomStyle(entry.element, decoration);
     }
 
     if (membershipChanged) this._notifyDomSubscribers();
   }
 
   private _currentDomEntries(): readonly DomDecorationEntry[] {
-    const entries: DomDecorationEntry[] = [];
-    for (const [id, element] of this._domEls) {
-      const decoration = this._domDecorations.get(id);
-      if (decoration) entries.push({ id, element, decoration });
-    }
-    return entries;
+    // New array, but the entry object references are stable across calls so
+    // SolidJS's `<For>` reuses existing rows and only mounts the new ones.
+    return Array.from(this._domEntries.values());
   }
 
   private _notifyDomSubscribers(): void {
@@ -214,7 +226,7 @@ export class DecorationLayer {
         const el = this._textEls.get(d.id);
         if (el) this._positionEl(el, d.anchor, d.offset, d.placement);
       } else if (d.type === 'dom') {
-        const el = this._domEls.get(d.id);
+        const el = this._domEntries.get(d.id)?.element;
         if (el) this._positionEl(el, d.anchor, d.offset, d.placement);
       }
     }

--- a/packages/fabric-osd/src/decoration/decoration-layer.ts
+++ b/packages/fabric-osd/src/decoration/decoration-layer.ts
@@ -1,11 +1,26 @@
 import { Line as FabricLine } from 'fabric';
 import type {
   Decoration,
+  DomDecoration,
   LineDecoration,
   TextDecoration,
   TextPlacement,
 } from '@osdlabel/decoration';
+import type { Point } from '@osdlabel/annotation';
 import type { FabricOverlay } from '../overlay/fabric-overlay.js';
+
+/**
+ * A live DOM-decoration root: the `<div>` the renderer created and positions,
+ * paired with the decoration it represents. Frameworks render their component
+ * tree into `element` (via a portal) keyed by `id`.
+ */
+export interface DomDecorationEntry {
+  readonly id: string;
+  readonly element: HTMLElement;
+  readonly decoration: DomDecoration;
+}
+
+type DomDecorationsCallback = (entries: readonly DomDecorationEntry[]) => void;
 
 const DEFAULT_TEXT_COLOR = '#ffffff';
 const DEFAULT_FONT_SIZE_PX = 12;
@@ -37,6 +52,9 @@ export class DecorationLayer {
   private readonly _unsubscribeSync: () => void;
   private readonly _textEls = new Map<string, HTMLDivElement>();
   private readonly _lineObjects = new Map<string, FabricLine>();
+  private readonly _domEls = new Map<string, HTMLDivElement>();
+  private readonly _domDecorations = new Map<string, DomDecoration>();
+  private readonly _domSubscribers = new Set<DomDecorationsCallback>();
   private _decorations: readonly Decoration[] = [];
   private _destroyed = false;
 
@@ -51,7 +69,7 @@ export class DecorationLayer {
     this._hostEl.dataset.osdlabel = 'decoration-layer';
     overlay.overlayElement.appendChild(this._hostEl);
 
-    this._unsubscribeSync = overlay.onSync(() => this._repositionText());
+    this._unsubscribeSync = overlay.onSync(() => this._reposition());
   }
 
   /** Replace the current decorations. Diffed by id for stable element reuse. */
@@ -59,9 +77,25 @@ export class DecorationLayer {
     if (this._destroyed) return;
     this._decorations = decorations;
     this._diffText(decorations);
+    this._diffDom(decorations);
     this._diffLines(decorations);
-    this._repositionText();
+    this._reposition();
     this._overlay.canvas.requestRenderAll();
+  }
+
+  /**
+   * Subscribe to DOM-decoration lifecycle. The callback fires immediately with
+   * the current entries and again only when the set of DOM decorations changes
+   * (an id is added or removed) — never per content change or per frame. The
+   * div's screen position is owned by this layer; the subscriber owns only the
+   * content rendered into `entry.element`. Returns an unsubscribe function.
+   */
+  onDomDecorations(callback: DomDecorationsCallback): () => void {
+    this._domSubscribers.add(callback);
+    callback(this._currentDomEntries());
+    return () => {
+      this._domSubscribers.delete(callback);
+    };
   }
 
   destroy(): void {
@@ -73,6 +107,13 @@ export class DecorationLayer {
     }
     this._lineObjects.clear();
     this._textEls.clear();
+    for (const el of this._domEls.values()) {
+      el.remove();
+    }
+    this._domEls.clear();
+    this._domDecorations.clear();
+    this._notifyDomSubscribers();
+    this._domSubscribers.clear();
     this._hostEl.remove();
   }
 
@@ -109,17 +150,87 @@ export class DecorationLayer {
     }
   }
 
-  private _repositionText(): void {
-    for (const d of this._decorations) {
-      if (d.type !== 'text') continue;
-      const el = this._textEls.get(d.id);
-      if (!el) continue;
-      const screen = this._overlay.imageToScreen(d.anchor);
-      const offsetX = d.offset?.x ?? 0;
-      const offsetY = d.offset?.y ?? 0;
-      const align = placementTranslate(d.placement);
-      el.style.transform = `translate3d(${screen.x + offsetX}px, ${screen.y + offsetY}px, 0) translate3d(${align.x}, ${align.y}, 0)`;
+  // ── DOM decorations (framework-rendered) ──────────────────────────────
+
+  private _diffDom(decorations: readonly Decoration[]): void {
+    const wanted = new Map<string, DomDecoration>();
+    for (const d of decorations) {
+      if (d.type === 'dom') wanted.set(d.id, d);
     }
+
+    let membershipChanged = false;
+
+    // Remove gone
+    for (const [id, el] of this._domEls) {
+      if (!wanted.has(id)) {
+        el.remove();
+        this._domEls.delete(id);
+        this._domDecorations.delete(id);
+        membershipChanged = true;
+      }
+    }
+
+    // Add new / update existing
+    for (const [id, decoration] of wanted) {
+      let el = this._domEls.get(id);
+      if (!el) {
+        el = document.createElement('div');
+        el.style.position = 'absolute';
+        el.style.top = '0';
+        el.style.left = '0';
+        el.style.willChange = 'transform';
+        el.dataset.osdlabel = 'decoration-dom';
+        el.dataset.decorationId = id;
+        this._hostEl.appendChild(el);
+        this._domEls.set(id, el);
+        membershipChanged = true;
+      }
+      applyDomStyle(el, decoration);
+      this._domDecorations.set(id, decoration);
+    }
+
+    if (membershipChanged) this._notifyDomSubscribers();
+  }
+
+  private _currentDomEntries(): readonly DomDecorationEntry[] {
+    const entries: DomDecorationEntry[] = [];
+    for (const [id, element] of this._domEls) {
+      const decoration = this._domDecorations.get(id);
+      if (decoration) entries.push({ id, element, decoration });
+    }
+    return entries;
+  }
+
+  private _notifyDomSubscribers(): void {
+    const entries = this._currentDomEntries();
+    for (const cb of this._domSubscribers) cb(entries);
+  }
+
+  // ── Screen positioning (text + DOM share the same anchor model) ────────
+
+  private _reposition(): void {
+    for (const d of this._decorations) {
+      if (d.type === 'text') {
+        const el = this._textEls.get(d.id);
+        if (el) this._positionEl(el, d.anchor, d.offset, d.placement);
+      } else if (d.type === 'dom') {
+        const el = this._domEls.get(d.id);
+        if (el) this._positionEl(el, d.anchor, d.offset, d.placement);
+      }
+    }
+  }
+
+  private _positionEl(
+    el: HTMLElement,
+    anchor: Point,
+    offset: { readonly x: number; readonly y: number } | undefined,
+    placement: TextPlacement | undefined,
+  ): void {
+    const screen = this._overlay.imageToScreen(anchor);
+    const offsetX = offset?.x ?? 0;
+    const offsetY = offset?.y ?? 0;
+    const align = placementTranslate(placement);
+    el.style.transform = `translate3d(${screen.x + offsetX}px, ${screen.y + offsetY}px, 0) translate3d(${align.x}, ${align.y}, 0)`;
   }
 
   // ── Line decorations (Fabric) ─────────────────────────────────────────
@@ -201,6 +312,30 @@ function applyTextStyle(el: HTMLDivElement, decoration: TextDecoration): void {
   const nextZIndex = style?.zIndex !== undefined ? String(style.zIndex) : '';
   if (el.style.zIndex !== nextZIndex) {
     el.style.zIndex = nextZIndex;
+  }
+}
+
+function applyDomStyle(el: HTMLDivElement, decoration: DomDecoration): void {
+  const style = decoration.style;
+  const nextPointerEvents = style?.pointerEvents ?? 'auto';
+  if (el.style.pointerEvents !== nextPointerEvents) {
+    el.style.pointerEvents = nextPointerEvents;
+  }
+  const nextClassName = style?.className ?? '';
+  if (el.className !== nextClassName) {
+    el.className = nextClassName;
+  }
+  const nextZIndex = style?.zIndex !== undefined ? String(style.zIndex) : '';
+  if (el.style.zIndex !== nextZIndex) {
+    el.style.zIndex = nextZIndex;
+  }
+  const nextWidth = style?.width !== undefined ? `${style.width}px` : '';
+  if (el.style.width !== nextWidth) {
+    el.style.width = nextWidth;
+  }
+  const nextHeight = style?.height !== undefined ? `${style.height}px` : '';
+  if (el.style.height !== nextHeight) {
+    el.style.height = nextHeight;
   }
 }
 

--- a/packages/fabric-osd/src/index.ts
+++ b/packages/fabric-osd/src/index.ts
@@ -1,3 +1,4 @@
 export { FabricOverlay, computeViewportTransform } from './overlay/fabric-overlay.js';
 export type { OverlayOptions, OverlayMode } from './overlay/fabric-overlay.js';
 export { DecorationLayer } from './decoration/decoration-layer.js';
+export type { DomDecorationEntry } from './decoration/decoration-layer.js';

--- a/packages/fabric-osd/tests/unit/decoration/decoration-layer.test.ts
+++ b/packages/fabric-osd/tests/unit/decoration/decoration-layer.test.ts
@@ -304,6 +304,44 @@ describe('DecorationLayer', () => {
       layer.destroy();
     });
 
+    it('keeps entry object identity stable across membership changes (SolidJS <For>)', () => {
+      const { overlay } = createMockOverlay();
+      const layer = new DecorationLayer(overlay);
+      const notifications: (readonly DomDecorationEntry[])[] = [];
+      layer.onDomDecorations((entries) => notifications.push(entries));
+
+      layer.setDecorations([domDeco('a'), domDeco('b')]);
+      const firstA = notifications.at(-1)!.find((e) => e.id === 'a')!;
+      const firstB = notifications.at(-1)!.find((e) => e.id === 'b')!;
+
+      // Add 'c' (membership change) with brand-new decoration objects for a/b.
+      layer.setDecorations([domDeco('a'), domDeco('b'), domDeco('c')]);
+      const latest = notifications.at(-1)!;
+      // Surviving entries must be the SAME object references, so <For> reuses
+      // their rows instead of remounting every portal.
+      expect(latest.find((e) => e.id === 'a')).toBe(firstA);
+      expect(latest.find((e) => e.id === 'b')).toBe(firstB);
+      expect(latest.find((e) => e.id === 'c')).toBeDefined();
+      layer.destroy();
+    });
+
+    it('updates an entry decoration in place without changing its identity', () => {
+      const { overlay } = createMockOverlay();
+      const layer = new DecorationLayer(overlay);
+      let latest: readonly DomDecorationEntry[] = [];
+      layer.onDomDecorations((entries) => {
+        latest = entries;
+      });
+      layer.setDecorations([domDeco('a', { content: { v: 1 } }), domDeco('b')]);
+      const entryA = latest.find((e) => e.id === 'a')!;
+
+      // Re-emit with same id set but new content for 'a' → no notification, but
+      // the stable entry's decoration is updated in place.
+      layer.setDecorations([domDeco('a', { content: { v: 2 } }), domDeco('b')]);
+      expect(entryA.decoration.content).toEqual({ v: 2 });
+      layer.destroy();
+    });
+
     it('destroy removes dom roots and notifies subscribers with an empty set', () => {
       const { overlay, hostParent } = createMockOverlay();
       const layer = new DecorationLayer(overlay);

--- a/packages/fabric-osd/tests/unit/decoration/decoration-layer.test.ts
+++ b/packages/fabric-osd/tests/unit/decoration/decoration-layer.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { DecorationLayer } from '../../../src/decoration/decoration-layer.js';
 import type { FabricOverlay } from '../../../src/overlay/fabric-overlay.js';
 import type { AnnotationId } from '@osdlabel/annotation';
-import type { Decoration } from '@osdlabel/decoration';
+import type { Decoration, DomDecoration } from '@osdlabel/decoration';
+import type { DomDecorationEntry } from '../../../src/decoration/decoration-layer.js';
 
 /**
  * A mock FabricOverlay sufficient for unit-testing the DecorationLayer's
@@ -49,6 +50,15 @@ const textDeco = (id: string, text = id): Decoration => ({
   relatedAnnotationIds: [annId(id)],
   text,
   anchor: { x: 10, y: 20 },
+});
+
+const domDeco = (id: string, overrides: Partial<DomDecoration> = {}): DomDecoration => ({
+  type: 'dom',
+  id,
+  relatedAnnotationIds: [annId(id)],
+  anchor: { x: 10, y: 20 },
+  content: { id },
+  ...overrides,
 });
 
 describe('DecorationLayer', () => {
@@ -192,5 +202,118 @@ describe('DecorationLayer', () => {
     layer.destroy();
     expect(hostParent.querySelector('[data-osdlabel="decoration-layer"]')).toBeNull();
     expect(syncSubscribers.size).toBe(0);
+  });
+
+  describe('DOM decorations', () => {
+    it('creates a positioned root div per dom decoration (no text content)', () => {
+      const { overlay, hostParent } = createMockOverlay();
+      const layer = new DecorationLayer(overlay);
+      layer.setDecorations([domDeco('a'), domDeco('b')]);
+      const els = hostParent.querySelectorAll('[data-osdlabel="decoration-dom"]');
+      expect(els).toHaveLength(2);
+      // The layer must never write content into the root — the framework owns it.
+      expect(Array.from(els).every((el) => el.textContent === '')).toBe(true);
+      layer.destroy();
+    });
+
+    it('defaults pointer-events to auto and honors an explicit none', () => {
+      const { overlay, hostParent } = createMockOverlay();
+      const layer = new DecorationLayer(overlay);
+      layer.setDecorations([
+        domDeco('interactive'),
+        domDeco('visual', { style: { pointerEvents: 'none' } }),
+      ]);
+      const interactive = hostParent.querySelector(
+        '[data-decoration-id="interactive"]',
+      ) as HTMLElement;
+      const visual = hostParent.querySelector('[data-decoration-id="visual"]') as HTMLElement;
+      expect(interactive.style.pointerEvents).toBe('auto');
+      expect(visual.style.pointerEvents).toBe('none');
+      layer.destroy();
+    });
+
+    it('reuses the root div by id across re-runs (stable for portals/focus)', () => {
+      const { overlay, hostParent } = createMockOverlay();
+      const layer = new DecorationLayer(overlay);
+      layer.setDecorations([domDeco('a'), domDeco('b')]);
+      const elA1 = hostParent.querySelector('[data-decoration-id="a"]');
+      layer.setDecorations([domDeco('a'), domDeco('c')]);
+      const elA2 = hostParent.querySelector('[data-decoration-id="a"]');
+      expect(elA2).toBe(elA1);
+      expect(hostParent.querySelector('[data-decoration-id="b"]')).toBeNull();
+      expect(hostParent.querySelector('[data-decoration-id="c"]')).not.toBeNull();
+      layer.destroy();
+    });
+
+    it('positions and repositions dom roots like text (imageToScreen + offset + onSync)', () => {
+      const { overlay, hostParent, syncSubscribers } = createMockOverlay();
+      const layer = new DecorationLayer(overlay);
+      layer.setDecorations([domDeco('x', { anchor: { x: 5, y: 7 }, offset: { x: 3, y: -1 } })]);
+      const el = hostParent.querySelector('[data-decoration-id="x"]') as HTMLElement;
+      // imageToScreen mock doubles → (10,14); plus offset → (13,13).
+      expect(el.style.transform).toContain('translate3d(13px, 13px, 0)');
+      (overlay.imageToScreen as ReturnType<typeof vi.fn>).mockImplementation(
+        (p: { x: number; y: number }) => ({ x: p.x * 3, y: p.y * 3 }),
+      );
+      for (const cb of syncSubscribers) cb();
+      // Now triples → (15,21); plus offset → (18,20).
+      expect(el.style.transform).toContain('translate3d(18px, 20px, 0)');
+      layer.destroy();
+    });
+
+    it('notifies subscribers on membership change only — immediately, on add/remove, not on re-emit', () => {
+      const { overlay } = createMockOverlay();
+      const layer = new DecorationLayer(overlay);
+      const calls: number[] = [];
+      const unsubscribe = layer.onDomDecorations((entries: readonly DomDecorationEntry[]) => {
+        calls.push(entries.length);
+      });
+      // Immediate callback with current (empty) state.
+      expect(calls).toEqual([0]);
+
+      // Add two → one membership change.
+      layer.setDecorations([domDeco('a'), domDeco('b')]);
+      expect(calls).toEqual([0, 2]);
+
+      // Re-emit the same id set with new objects → NO notification.
+      layer.setDecorations([domDeco('a'), domDeco('b')]);
+      expect(calls).toEqual([0, 2]);
+
+      // Remove one → membership change.
+      layer.setDecorations([domDeco('a')]);
+      expect(calls).toEqual([0, 2, 1]);
+
+      unsubscribe();
+      layer.setDecorations([domDeco('a'), domDeco('b')]);
+      expect(calls).toEqual([0, 2, 1]); // unsubscribed: no further calls
+      layer.destroy();
+    });
+
+    it('subscription entries expose the live element and decoration', () => {
+      const { overlay, hostParent } = createMockOverlay();
+      const layer = new DecorationLayer(overlay);
+      let latest: readonly DomDecorationEntry[] = [];
+      layer.onDomDecorations((entries) => {
+        latest = entries;
+      });
+      layer.setDecorations([domDeco('a', { content: { kind: 'badge' } })]);
+      expect(latest).toHaveLength(1);
+      expect(latest[0]!.id).toBe('a');
+      expect(latest[0]!.element).toBe(hostParent.querySelector('[data-decoration-id="a"]'));
+      expect(latest[0]!.decoration.content).toEqual({ kind: 'badge' });
+      layer.destroy();
+    });
+
+    it('destroy removes dom roots and notifies subscribers with an empty set', () => {
+      const { overlay, hostParent } = createMockOverlay();
+      const layer = new DecorationLayer(overlay);
+      const calls: number[] = [];
+      layer.onDomDecorations((entries) => calls.push(entries.length));
+      layer.setDecorations([domDeco('a')]);
+      expect(calls).toEqual([0, 1]);
+      layer.destroy();
+      expect(hostParent.querySelector('[data-osdlabel="decoration-dom"]')).toBeNull();
+      expect(calls).toEqual([0, 1, 0]);
+    });
   });
 });

--- a/packages/osdlabel/src/index.ts
+++ b/packages/osdlabel/src/index.ts
@@ -76,7 +76,7 @@ export type {
 
 // Fabric-OSD overlay (re-exported from @osdlabel/fabric-osd)
 export { FabricOverlay, computeViewportTransform, DecorationLayer } from '@osdlabel/fabric-osd';
-export type { OverlayOptions, OverlayMode } from '@osdlabel/fabric-osd';
+export type { OverlayOptions, OverlayMode, DomDecorationEntry } from '@osdlabel/fabric-osd';
 
 // Decorations (re-exported from @osdlabel/decoration)
 export type {
@@ -87,6 +87,8 @@ export type {
   TextPlacement,
   LineDecoration,
   LineDecorationStyle,
+  DomDecoration,
+  DomDecorationStyle,
   DecorationContext,
   DecorationProvider,
   Measurement,

--- a/packages/react/src/components/ViewerCell.tsx
+++ b/packages/react/src/components/ViewerCell.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import OpenSeadragon from 'openseadragon';
 import { DecorationLayer, FabricOverlay } from '@osdlabel/fabric-osd';
+import type { DomDecorationEntry } from '@osdlabel/fabric-osd';
 import { createFabricObjectFromRawData } from '@osdlabel/fabric-annotations';
 import type { OverlayMode } from '@osdlabel/fabric-osd';
 import type { AnnotationContextId } from '@osdlabel/annotation-context';
@@ -36,12 +38,14 @@ export default function ViewerCell({
     testMode,
     decorationProviders,
     defaultPixelSpacing,
+    renderDomDecoration,
   } = useAnnotator();
   const containerRef = useRef<HTMLDivElement>(null);
   const viewerRef = useRef<OpenSeadragon.Viewer | undefined>(undefined);
   const overlayRef = useRef<FabricOverlay | undefined>(undefined);
   const decorationLayerRef = useRef<DecorationLayer | undefined>(undefined);
   const [overlay, setOverlay] = useState<FabricOverlay>();
+  const [domEntries, setDomEntries] = useState<readonly DomDecorationEntry[]>([]);
 
   // Initialize OSD viewer on mount
   useEffect(() => {
@@ -220,17 +224,32 @@ export default function ViewerCell({
     });
   }, [overlay]);
 
+  // Track DOM-decoration roots created by the layer. The subscription fires on
+  // membership change only; content is rendered via portals into the stable
+  // div the layer owns and positions.
+  useEffect(() => {
+    const layer = decorationLayerRef.current;
+    if (!overlay || !layer) return;
+    return layer.onDomDecorations(setDomEntries);
+  }, [overlay]);
+
   return (
-    <div
-      ref={containerRef}
-      onClick={() => onActivate()}
-      style={{
-        width: '100%',
-        height: '100%',
-        position: 'relative',
-        boxSizing: 'border-box',
-        border: isActive ? '2px solid #2196F3' : '2px solid transparent',
-      }}
-    />
+    <>
+      <div
+        ref={containerRef}
+        onClick={() => onActivate()}
+        style={{
+          width: '100%',
+          height: '100%',
+          position: 'relative',
+          boxSizing: 'border-box',
+          border: isActive ? '2px solid #2196F3' : '2px solid transparent',
+        }}
+      />
+      {renderDomDecoration &&
+        domEntries.map((entry) =>
+          createPortal(renderDomDecoration(entry.decoration), entry.element, entry.id),
+        )}
+    </>
   );
 }

--- a/packages/react/src/state/annotator-context.tsx
+++ b/packages/react/src/state/annotator-context.tsx
@@ -18,7 +18,7 @@ import type {
 } from '@osdlabel/viewer-api';
 import { getAllAnnotationsFlat } from '@osdlabel/viewer-api';
 import type { ConstraintStatus, ContextState } from '@osdlabel/annotation-context';
-import type { DecorationProvider } from '@osdlabel/decoration';
+import type { DecorationProvider, DomDecoration } from '@osdlabel/decoration';
 import type { OsdAnnotation, OsdFields } from 'osdlabel';
 import {
   DEFAULT_KEYBOARD_SHORTCUTS,
@@ -47,6 +47,7 @@ interface AnnotatorContextValue {
   testMode: boolean;
   decorationProviders: readonly DecorationProvider<OsdFields>[];
   defaultPixelSpacing: PixelSpacing | undefined;
+  renderDomDecoration: ((decoration: DomDecoration) => ReactNode) | undefined;
 }
 
 const AnnotatorContext = createContext<AnnotatorContextValue | null>(null);
@@ -68,6 +69,12 @@ export interface AnnotatorProviderProps {
    * Fallback pixel spacing used when an `ImageSource` does not specify its own.
    */
   readonly defaultPixelSpacing?: PixelSpacing | undefined;
+  /**
+   * Renders the content for a DOM decoration into its positioned root element
+   * (via a React portal, so the tree shares this provider's context). Receives
+   * the `DomDecoration` and returns the React node to mount.
+   */
+  readonly renderDomDecoration?: ((decoration: DomDecoration) => ReactNode) | undefined;
 }
 
 export function AnnotatorProvider({
@@ -80,6 +87,7 @@ export function AnnotatorProvider({
   testMode = false,
   decorationProviders,
   defaultPixelSpacing,
+  renderDomDecoration,
 }: AnnotatorProviderProps) {
   const [annotationState, dispatchAnnotation] = useReducer(annotationReducer, undefined, () => {
     const initial = createInitialAnnotationState();
@@ -180,6 +188,7 @@ export function AnnotatorProvider({
       testMode,
       decorationProviders: stableDecorationProviders,
       defaultPixelSpacing,
+      renderDomDecoration,
     }),
     [
       annotationState,
@@ -193,6 +202,7 @@ export function AnnotatorProvider({
       testMode,
       stableDecorationProviders,
       defaultPixelSpacing,
+      renderDomDecoration,
     ],
   );
 

--- a/packages/solid/src/components/ViewerCell.tsx
+++ b/packages/solid/src/components/ViewerCell.tsx
@@ -1,7 +1,9 @@
-import { onMount, onCleanup, createEffect, on, createSignal } from 'solid-js';
+import { onMount, onCleanup, createEffect, on, createSignal, For } from 'solid-js';
+import { Portal } from 'solid-js/web';
 import type { Component } from 'solid-js';
 import OpenSeadragon from 'openseadragon';
 import { DecorationLayer, FabricOverlay } from '@osdlabel/fabric-osd';
+import type { DomDecorationEntry } from '@osdlabel/fabric-osd';
 import { createFabricObjectFromRawData } from '@osdlabel/fabric-annotations';
 import type { OverlayMode } from '@osdlabel/fabric-osd';
 import type { AnnotationContextId } from '@osdlabel/annotation-context';
@@ -30,11 +32,13 @@ const ViewerCell: Component<ViewerCellProps> = (props) => {
     testMode,
     decorationProviders,
     defaultPixelSpacing,
+    renderDomDecoration,
   } = useAnnotator();
   let containerRef: HTMLDivElement | undefined;
   let viewer: OpenSeadragon.Viewer | undefined;
   const [overlay, setOverlay] = createSignal<FabricOverlay>();
   const [decorationLayer, setDecorationLayer] = createSignal<DecorationLayer>();
+  const [domEntries, setDomEntries] = createSignal<readonly DomDecorationEntry[]>([]);
 
   onMount(() => {
     if (!containerRef) return;
@@ -212,18 +216,35 @@ const ViewerCell: Component<ViewerCellProps> = (props) => {
     onCleanup(dispose);
   });
 
+  // Track DOM-decoration roots created by the layer. The subscription fires on
+  // membership change only; content is rendered via portals into the stable
+  // div the layer owns and positions.
+  createEffect(() => {
+    const layer = decorationLayer();
+    if (!layer) return;
+    const unsubscribe = layer.onDomDecorations(setDomEntries);
+    onCleanup(unsubscribe);
+  });
+
   return (
-    <div
-      ref={containerRef}
-      onClick={() => props.onActivate()}
-      style={{
-        width: '100%',
-        height: '100%',
-        position: 'relative',
-        'box-sizing': 'border-box',
-        border: props.isActive ? '2px solid #2196F3' : '2px solid transparent',
-      }}
-    />
+    <>
+      <div
+        ref={containerRef}
+        onClick={() => props.onActivate()}
+        style={{
+          width: '100%',
+          height: '100%',
+          position: 'relative',
+          'box-sizing': 'border-box',
+          border: props.isActive ? '2px solid #2196F3' : '2px solid transparent',
+        }}
+      />
+      <For each={domEntries()}>
+        {(entry) => (
+          <Portal mount={entry.element}>{renderDomDecoration?.(entry.decoration)}</Portal>
+        )}
+      </For>
+    </>
   );
 };
 

--- a/packages/solid/src/state/annotator-context.tsx
+++ b/packages/solid/src/state/annotator-context.tsx
@@ -5,7 +5,7 @@ import type { ImageId, PixelSpacing } from '@osdlabel/viewer-api';
 import type { AnnotationState, KeyboardShortcutMap, UIState } from '@osdlabel/viewer-api';
 import { getAllAnnotationsFlat } from '@osdlabel/viewer-api';
 import type { ConstraintStatus, ContextState } from '@osdlabel/annotation-context';
-import type { DecorationProvider } from '@osdlabel/decoration';
+import type { DecorationProvider, DomDecoration } from '@osdlabel/decoration';
 import type { OsdAnnotation, OsdFields } from 'osdlabel';
 import { DEFAULT_KEYBOARD_SHORTCUTS } from 'osdlabel';
 import { createAnnotationStore } from './annotation-store.js';
@@ -30,6 +30,7 @@ interface AnnotatorContextValue {
   testMode: boolean;
   decorationProviders: readonly DecorationProvider<OsdFields>[];
   defaultPixelSpacing: PixelSpacing | undefined;
+  renderDomDecoration: ((decoration: DomDecoration) => JSX.Element) | undefined;
 }
 
 const KeyboardHandler = (props: {
@@ -65,6 +66,12 @@ export interface AnnotatorProviderProps {
    * Fallback pixel spacing used when an `ImageSource` does not specify its own.
    */
   readonly defaultPixelSpacing?: PixelSpacing | undefined;
+  /**
+   * Renders the content for a DOM decoration into its positioned root element
+   * (via a Solid portal, so the tree shares this provider's context). Receives
+   * the `DomDecoration` and returns the element to mount.
+   */
+  readonly renderDomDecoration?: ((decoration: DomDecoration) => JSX.Element) | undefined;
 }
 
 export function AnnotatorProvider(props: AnnotatorProviderProps) {
@@ -136,6 +143,7 @@ export function AnnotatorProvider(props: AnnotatorProviderProps) {
     testMode: props.testMode ?? false,
     decorationProviders: props.decorationProviders ?? [],
     defaultPixelSpacing: props.defaultPixelSpacing,
+    renderDomDecoration: props.renderDomDecoration,
   };
 
   return (


### PR DESCRIPTION
Introduce a third decoration variant, DomDecoration, that exposes a
positioned <div> root which a UI framework renders a component tree into
via its native portal. The rendered tree shares the host app's context
(state, theme, hooks), enabling interactive popovers, mini-forms, and
charts attached to annotations.

- @osdlabel/decoration: add DomDecoration + DomDecorationStyle to the
  Decoration union (framework-agnostic, content: unknown). Interactive by
  default (pointer-events: auto), configurable to 'none'.
- DecorationLayer: create/position/own the dom root divs (id-stable diff,
  unified screen positioning with text via imageToScreen + translate3d),
  and expose onDomDecorations — a subscription that fires on membership
  change only (never per frame), so portals never thrash during pan/zoom
  or drag. Content is stable config; dynamic data flows through the app's
  own reactivity inside the mounted component.
- React/Solid bridges: renderDomDecoration prop threaded through the
  AnnotatorProvider; ViewerCell subscribes and renders keyed portals
  (React createPortal, Solid <Portal mount>).
- Dev apps: demonstrate an interactive DOM badge per annotation.
- Tests: DecorationLayer dom diff/lifecycle/positioning/subscription
  unit tests, a decoration-package type/provider test, and an e2e spec.

https://claude.ai/code/session_01VbKNm89ELcNsTfUkhdKHa4