### PR TITLE
fix: disable resize controls on point annotations

### DIFF
--- a/.changeset/fix-point-annotation-no-resize.md
+++ b/.changeset/fix-point-annotation-no-resize.md
@@ -1,0 +1,5 @@
+---
+"@osdlabel/fabric-annotations": patch
+---
+
+Fix point annotations being incorrectly resizable. Point annotations now have `hasControls: false` set both when first drawn and when loaded from serialized state, so they can only be moved, not scaled.

--- a/packages/fabric-annotations/src/fabric-utils.ts
+++ b/packages/fabric-annotations/src/fabric-utils.ts
@@ -68,6 +68,7 @@ export async function createFabricObjectFromRawData(
   obj.set({
     selectable: true,
     evented: true,
+    ...(annotation.geometry.type === 'point' ? { hasControls: false } : {}),
   });
 
   return obj;

--- a/packages/fabric-annotations/src/tools/point-tool.ts
+++ b/packages/fabric-annotations/src/tools/point-tool.ts
@@ -16,6 +16,7 @@ export class PointTool extends ShapeTool<Circle> {
       originY: 'center',
       selectable: false,
       evented: false,
+      hasControls: false,
     });
   }
 

--- a/packages/fabric-annotations/tests/unit/fabric-utils.test.ts
+++ b/packages/fabric-annotations/tests/unit/fabric-utils.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import { Circle } from 'fabric';
+import { createAnnotationId } from '@osdlabel/annotation';
+import { createFabricObjectFromRawData, serializeFabricObject } from '../../src/fabric-utils.js';
+import type { FabricFields } from '../../src/types.js';
+import type { Annotation } from '@osdlabel/annotation';
+import type { ImageIdFields } from '@osdlabel/viewer-api';
+import { createImageId } from '@osdlabel/viewer-api';
+import { createAnnotationContextId } from '@osdlabel/annotation-context';
+import type { ContextFields } from '@osdlabel/annotation-context';
+import { initFabricModule } from '../../src/fabric-module.js';
+
+// Register custom Fabric properties so toObject() includes `id`
+initFabricModule();
+
+type OsdAnnotation = Annotation<ImageIdFields & ContextFields & FabricFields>;
+
+function makePointAnnotation(): OsdAnnotation {
+  const id = createAnnotationId('test-point-1');
+  const circle = new Circle({
+    left: 100,
+    top: 200,
+    radius: 5,
+    originX: 'center',
+    originY: 'center',
+  });
+  // Attach the id so it round-trips through serialization
+  (circle as unknown as { id: string }).id = id;
+
+  return {
+    id,
+    imageId: createImageId('img-1'),
+    contextId: createAnnotationContextId('ctx-1'),
+    geometry: { type: 'point', position: { x: 100, y: 200 } },
+    style: {
+      fillColor: '#ff0000',
+      strokeColor: '#000000',
+      strokeWidth: 1,
+      opacity: 1,
+    },
+    rawAnnotationData: serializeFabricObject(circle),
+    type: 'point',
+  };
+}
+
+function makeCircleAnnotation(): OsdAnnotation {
+  const id = createAnnotationId('test-circle-1');
+  const circle = new Circle({
+    left: 50,
+    top: 50,
+    radius: 30,
+    originX: 'center',
+    originY: 'center',
+  });
+  (circle as unknown as { id: string }).id = id;
+
+  return {
+    id,
+    imageId: createImageId('img-1'),
+    contextId: createAnnotationContextId('ctx-1'),
+    geometry: { type: 'circle', center: { x: 50, y: 50 }, radius: 30 },
+    style: {
+      fillColor: '#00ff00',
+      strokeColor: '#000000',
+      strokeWidth: 1,
+      opacity: 1,
+    },
+    rawAnnotationData: serializeFabricObject(circle),
+    type: 'circle',
+  };
+}
+
+describe('createFabricObjectFromRawData', () => {
+  it('should set hasControls to false for point annotations', async () => {
+    const annotation = makePointAnnotation();
+    const obj = await createFabricObjectFromRawData(annotation);
+    expect(obj).not.toBeNull();
+    expect(obj!.hasControls).toBe(false);
+  });
+
+  it('should keep hasControls true for non-point annotations (e.g. circle)', async () => {
+    const annotation = makeCircleAnnotation();
+    const obj = await createFabricObjectFromRawData(annotation);
+    expect(obj).not.toBeNull();
+    // Circle annotations should still have controls (resizable)
+    expect(obj!.hasControls).toBe(true);
+  });
+
+  it('should make point annotation selectable and evented', async () => {
+    const annotation = makePointAnnotation();
+    const obj = await createFabricObjectFromRawData(annotation);
+    expect(obj!.selectable).toBe(true);
+    expect(obj!.evented).toBe(true);
+  });
+});

--- a/packages/fabric-annotations/tests/unit/tools/point-tool.test.ts
+++ b/packages/fabric-annotations/tests/unit/tools/point-tool.test.ts
@@ -132,6 +132,27 @@ describe('PointTool', () => {
     expect(mockCanvas.add).not.toHaveBeenCalled();
   });
 
+  it('should have hasControls false on preview (not resizable)', () => {
+    tool = new PointTool();
+    tool.activate(mockOverlay, imageId, mockCallbacks, mockShortcuts);
+
+    tool.onPointerDown({ type: 'pointerdown' } as PointerEvent, { x: 30, y: 30 });
+
+    const preview = mockCanvas.add.mock.calls[0][0] as Circle;
+    expect(preview.hasControls).toBe(false);
+  });
+
+  it('should have hasControls false on committed fabricObject (not resizable)', () => {
+    tool = new PointTool();
+    tool.activate(mockOverlay, imageId, mockCallbacks, mockShortcuts);
+
+    tool.onPointerDown({ type: 'pointerdown' } as PointerEvent, { x: 30, y: 30 });
+    tool.onPointerUp({ type: 'pointerup' } as PointerEvent, { x: 30, y: 30 });
+
+    const fabricObject = addedParams[0]!.fabricObject as Circle;
+    expect(fabricObject.hasControls).toBe(false);
+  });
+
   it('should cancel and remove preview on cancel()', () => {
     tool = new PointTool();
     tool.activate(mockOverlay, imageId, mockCallbacks, mockShortcuts);


### PR DESCRIPTION
Point annotations (rendered as Fabric Circle objects) were incorrectly
exposing resize handles. hasControls is now set to false both when a
new point is drawn (PointTool.createPreview) and when existing points
are loaded from storage (createFabricObjectFromRawData).

Fixes #107

https://claude.ai/code/session_01JTK7qvL6t2VyVCS3d1qdTc