### PR TITLE
feat: add customControl overlay mode for drag-driven viewer input

### DIFF
--- a/.changeset/custom-control-drag-viewer-input.md
+++ b/.changeset/custom-control-drag-viewer-input.md
@@ -1,0 +1,20 @@
+---
+'osdlabel': minor
+'@osdlabel/annotation': minor
+'@osdlabel/annotation-context': minor
+'@osdlabel/decoration': minor
+'@osdlabel/fabric-annotations': minor
+'@osdlabel/fabric-osd': minor
+'@osdlabel/osd-helper': minor
+'@osdlabel/react': minor
+'@osdlabel/solid': minor
+'@osdlabel/validation': minor
+'@osdlabel/viewer-api': minor
+---
+
+Add a `customControl` overlay mode that forwards mouse click/drag input to a registered handler instead of OpenSeadragon or the Fabric annotation layer.
+
+- `FabricOverlay` gains the `customControl` mode, a `CustomControlHandler` contract, and `setCustomControlHandler()`. A `setMode` no-op guard prevents redundant re-applies from clobbering an in-progress gesture.
+- New framework-agnostic `createDragValueControl()` helper maps drag distance onto a clamped numeric value, reusable for any drag-driven viewer function.
+- New `UIState.activeViewerControl` (`ViewerControlId`) field, mutually exclusive with `activeTool`, drives the mode via the single existing mode-authority effect in both the SolidJS and React `useAnnotationTool` hooks.
+- `ViewControls` (Solid + React) gains a drag-to-adjust-exposure toggle button as the first use case.

--- a/apps/dev/tests/e2e/view-controls.spec.ts
+++ b/apps/dev/tests/e2e/view-controls.spec.ts
@@ -117,6 +117,43 @@ test.describe('View Controls', () => {
     await expect(drawerCanvas).toHaveCSS('filter', 'brightness(0)');
   });
 
+  test('Exposure drag mode adjusts brightness continuously', async ({ page }) => {
+    const dragBtn = page.locator('[data-testid="view-exposure-drag"]');
+    const resetBtn = page.locator('[data-testid="view-reset"]');
+    const drawerCanvas = page.locator('.openseadragon-canvas canvas').nth(0);
+    const viewer = page.locator('.openseadragon-canvas');
+
+    // Enter drag-exposure (customControl) mode — button shows active state.
+    await expect(dragBtn).toHaveCSS('background-color', 'rgb(51, 51, 51)');
+    await dragBtn.click();
+    await expect(dragBtn).toHaveCSS('background-color', 'rgb(33, 150, 243)');
+
+    const box = await viewer.boundingBox();
+    if (!box) throw new Error('viewer canvas not found');
+    const startX = box.x + box.width / 2;
+    const y = box.y + box.height / 2;
+
+    // Drag right by 50px → +0.5 exposure (sensitivity 0.01/px) → brightness(1.5).
+    await page.mouse.move(startX, y);
+    await page.mouse.down();
+    await page.mouse.move(startX + 50, y, { steps: 10 });
+    await page.mouse.up();
+
+    await expect(drawerCanvas).toHaveCSS('filter', 'brightness(1.5)');
+    await expect(resetBtn).toBeVisible();
+
+    // Exiting the mode restores the inactive button styling; exposure persists.
+    await dragBtn.click();
+    await expect(dragBtn).toHaveCSS('background-color', 'rgb(51, 51, 51)');
+    await expect(drawerCanvas).toHaveCSS('filter', 'brightness(1.5)');
+
+    // Selecting a tool also exits the control (mutual exclusivity).
+    await dragBtn.click();
+    await expect(dragBtn).toHaveCSS('background-color', 'rgb(33, 150, 243)');
+    await page.locator('[data-testid="tool-rectangle"]').click();
+    await expect(dragBtn).toHaveCSS('background-color', 'rgb(51, 51, 51)');
+  });
+
   test('Reset clears rotation and flip', async ({ page }) => {
     const rotateCwBtn = page.locator('[data-testid="view-rotate-cw"]');
     const flipVBtn = page.locator('[data-testid="view-flip-v"]');

--- a/apps/dev/tests/e2e/view-controls.spec.ts
+++ b/apps/dev/tests/e2e/view-controls.spec.ts
@@ -123,6 +123,17 @@ test.describe('View Controls', () => {
     const drawerCanvas = page.locator('.openseadragon-canvas canvas').nth(0);
     const viewer = page.locator('.openseadragon-canvas');
 
+    // The FabricOverlay (and thus the customControl handler) is created on OSD's
+    // 'open' event. Wait for the viewer to be open before dragging so the drag
+    // isn't lost to a not-yet-registered handler. testMode exposes the viewer on
+    // its container element.
+    await page.waitForFunction(() => {
+      const el = document.querySelector('.openseadragon-canvas') as
+        | (Element & { __osdViewer?: { isOpen?: () => boolean } })
+        | null;
+      return el?.__osdViewer?.isOpen?.() === true;
+    });
+
     // Enter drag-exposure (customControl) mode — button shows active state.
     await expect(dragBtn).toHaveCSS('background-color', 'rgb(51, 51, 51)');
     await dragBtn.click();
@@ -136,10 +147,14 @@ test.describe('View Controls', () => {
     // Drag up well past the range so exposure saturates at its max (1) →
     // brightness(2). Asserting the clamped value keeps this deterministic
     // regardless of exact pixel distance and the 0.025 step resolution (a
-    // mid-range target would be sensitive to subpixel mouse jitter).
+    // mid-range target would be sensitive to subpixel mouse jitter). Use several
+    // held moves so the gesture reliably registers and the cumulative distance
+    // clears the clamp even if an intermediate move is dropped.
     await page.mouse.move(x, startY);
     await page.mouse.down();
-    await page.mouse.move(x, box.y + 10, { steps: 12 });
+    await page.mouse.move(x, startY - 80, { steps: 4 });
+    await page.mouse.move(x, startY - 160, { steps: 4 });
+    await page.mouse.move(x, box.y + 10, { steps: 4 });
     await page.mouse.up();
 
     await expect(drawerCanvas).toHaveCSS('filter', 'brightness(2)');

--- a/apps/dev/tests/e2e/view-controls.spec.ts
+++ b/apps/dev/tests/e2e/view-controls.spec.ts
@@ -133,19 +133,22 @@ test.describe('View Controls', () => {
     const x = box.x + box.width / 2;
     const startY = box.y + box.height / 2;
 
-    // Drag up by 50px → +0.5 exposure (y-axis, sensitivity 0.01/px) → brightness(1.5).
+    // Drag up well past the range so exposure saturates at its max (1) →
+    // brightness(2). Asserting the clamped value keeps this deterministic
+    // regardless of exact pixel distance and the 0.025 step resolution (a
+    // mid-range target would be sensitive to subpixel mouse jitter).
     await page.mouse.move(x, startY);
     await page.mouse.down();
-    await page.mouse.move(x, startY - 50, { steps: 10 });
+    await page.mouse.move(x, box.y + 10, { steps: 12 });
     await page.mouse.up();
 
-    await expect(drawerCanvas).toHaveCSS('filter', 'brightness(1.5)');
+    await expect(drawerCanvas).toHaveCSS('filter', 'brightness(2)');
     await expect(resetBtn).toBeVisible();
 
     // Exiting the mode restores the inactive button styling; exposure persists.
     await dragBtn.click();
     await expect(dragBtn).toHaveCSS('background-color', 'rgb(51, 51, 51)');
-    await expect(drawerCanvas).toHaveCSS('filter', 'brightness(1.5)');
+    await expect(drawerCanvas).toHaveCSS('filter', 'brightness(2)');
 
     // Selecting a tool also exits the control (mutual exclusivity).
     await dragBtn.click();

--- a/apps/dev/tests/e2e/view-controls.spec.ts
+++ b/apps/dev/tests/e2e/view-controls.spec.ts
@@ -130,13 +130,13 @@ test.describe('View Controls', () => {
 
     const box = await viewer.boundingBox();
     if (!box) throw new Error('viewer canvas not found');
-    const startX = box.x + box.width / 2;
-    const y = box.y + box.height / 2;
+    const x = box.x + box.width / 2;
+    const startY = box.y + box.height / 2;
 
-    // Drag right by 50px → +0.5 exposure (sensitivity 0.01/px) → brightness(1.5).
-    await page.mouse.move(startX, y);
+    // Drag up by 50px → +0.5 exposure (y-axis, sensitivity 0.01/px) → brightness(1.5).
+    await page.mouse.move(x, startY);
     await page.mouse.down();
-    await page.mouse.move(startX + 50, y, { steps: 10 });
+    await page.mouse.move(x, startY - 50, { steps: 10 });
     await page.mouse.up();
 
     await expect(drawerCanvas).toHaveCSS('filter', 'brightness(1.5)');

--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -67,6 +67,7 @@ export default defineConfig({
           items: [
             { label: 'Packages & Architecture', slug: 'guides/packages-and-architecture' },
             { label: 'Basic Controls', slug: 'guides/basic-controls' },
+            { label: 'Custom Drag Controls', slug: 'guides/custom-controls' },
             { label: 'Keyboard Shortcuts', slug: 'guides/keyboard-shortcuts' },
             { label: 'Viewer Grid', slug: 'guides/viewer-grid' },
             { label: 'Annotation Contexts', slug: 'guides/annotation-contexts' },

--- a/apps/docs/src/content/docs/guides/custom-controls.md
+++ b/apps/docs/src/content/docs/guides/custom-controls.md
@@ -1,0 +1,81 @@
+---
+title: Custom Drag Controls
+description: Drive viewer functions with mouse drag using the customControl overlay mode
+---
+
+Some viewer functions are easier to operate by **dragging** than by clicking discrete buttons — adjusting exposure is the obvious example. osdlabel supports this through a dedicated overlay interaction mode, `customControl`, which forwards raw pointer events to a handler you supply instead of letting OpenSeadragon or the Fabric annotation layer consume them.
+
+## The three overlay modes
+
+`FabricOverlay` routes pointer input through an OSD `MouseTracker`. Its mode selects who owns the mouse:
+
+| Mode            | OSD navigation | Fabric annotation | Pointer events go to                   |
+| --------------- | -------------- | ----------------- | -------------------------------------- |
+| `navigation`    | ✅ enabled     | display-only      | OSD (pan / zoom)                       |
+| `annotation`    | disabled\*     | ✅ active         | Fabric (select / move / draw)          |
+| `customControl` | disabled       | inert             | your registered `CustomControlHandler` |
+
+\* In `annotation` mode, `Ctrl`/`Cmd`+drag still passes through to OSD for panning.
+
+In `customControl` mode every pointer event is captured and handed to your handler; OSD does not pan and Fabric objects are non-interactive. `Ctrl`/`Cmd`+scroll still zooms the image, so users don't lose zoom while a control is engaged.
+
+## The handler contract
+
+```ts
+import type { CustomControlHandler, CustomControlEvent } from 'osdlabel';
+
+interface CustomControlEvent {
+  readonly originalEvent: PointerEvent; // raw DOM event (has buttons, modifiers…)
+  readonly screenPoint: Point; // CSS px relative to the viewer element
+  readonly imagePoint: Point; // image-space, flip-aware
+}
+
+interface CustomControlHandler {
+  onPointerDown?(event: CustomControlEvent): void;
+  onPointerMove?(event: CustomControlEvent): void;
+  onPointerUp?(event: CustomControlEvent): void;
+}
+```
+
+`onPointerMove` fires on **every** pointer move while the mode is active, regardless of button state, so a drag-based handler must track whether a press is in progress.
+
+Register (or clear) the handler on the overlay:
+
+```ts
+overlay.setCustomControlHandler(handler);
+overlay.setMode('customControl');
+// …later
+overlay.setCustomControlHandler(null);
+```
+
+## `createDragValueControl`
+
+For the common case — map drag distance onto a clamped number — use the built-in factory rather than writing the gesture bookkeeping yourself:
+
+```ts
+import { createDragValueControl } from 'osdlabel';
+
+const handler = createDragValueControl({
+  getValue: () => currentExposure, // read at pointer-down
+  setValue: (v) => setExposure(v), // called continuously during drag
+  axis: 'x', // 'x' (default) or 'y'
+  sensitivity: 0.01, // value-units per CSS pixel
+  min: -1,
+  max: 1,
+});
+```
+
+It captures the starting value on `pointerdown`, then on each move sets `startValue + delta * sensitivity` clamped to `[min, max]`. It is framework-agnostic and side-effect-free apart from your `getValue`/`setValue`, and it is defensive about lost pointer captures: a move with no button held (e.g. a dropped `pointercancel`) disarms the drag so hovering can't keep mutating the value. Redundant writes are skipped, so holding at a clamp boundary doesn't spam `setValue`.
+
+## How the bundled UI wires exposure
+
+The Solid and React `ViewControls` expose a drag-to-adjust-exposure toggle. Selecting it sets a UI field, `activeViewerControl`, which is **mutually exclusive** with the active annotation tool — picking a tool exits the control and vice versa. The single mode-authority effect in `useAnnotationTool` resolves the overlay mode by precedence (`customControl` > `annotation` > `navigation`) and registers a `createDragValueControl` handler that reads the active cell's exposure and dispatches `setActiveImageExposure` on drag.
+
+## Behavior notes
+
+- **No `Ctrl`/`Cmd`+drag pan in `customControl`.** Unlike annotation mode, `customControl` swallows all pointer drags. To pan, exit the control first; `Ctrl`/`Cmd`+scroll zoom remains available.
+- **Switching the active cell keeps the control armed.** `activeViewerControl` is not cleared on cell change — the drag simply retargets the newly active cell. Selecting a tool, or toggling the control off, exits it.
+
+## Adding your own viewer control
+
+To add another drag-driven function, give it a `ViewerControlId`, branch on it where the exposure control is wired (or, once there's more than one, extract a small registry mapping each id to a handler factory), and add a toggle to your toolbar that calls `setActiveViewerControl(id)`.

--- a/apps/docs/src/content/docs/guides/custom-controls.md
+++ b/apps/docs/src/content/docs/guides/custom-controls.md
@@ -58,18 +58,19 @@ import { createDragValueControl } from 'osdlabel';
 const handler = createDragValueControl({
   getValue: () => currentExposure, // read at pointer-down
   setValue: (v) => setExposure(v), // called continuously during drag
-  axis: 'x', // 'x' (default) or 'y'
+  axis: 'y', // 'x' (default) or 'y'
   sensitivity: 0.01, // value-units per CSS pixel
+  step: 0.025, // resolution of change (omit for continuous)
   min: -1,
   max: 1,
 });
 ```
 
-It captures the starting value on `pointerdown`, then on each move sets `startValue + delta * sensitivity` clamped to `[min, max]`. It is framework-agnostic and side-effect-free apart from your `getValue`/`setValue`, and it is defensive about lost pointer captures: a move with no button held (e.g. a dropped `pointercancel`) disarms the drag so hovering can't keep mutating the value. Redundant writes are skipped, so holding at a clamp boundary doesn't spam `setValue`.
+It captures the starting value on `pointerdown`, then on each move sets `startValue + delta * sensitivity`, optionally quantized to `step` (the resolution of change) and clamped to `[min, max]`. It is framework-agnostic and side-effect-free apart from your `getValue`/`setValue`, and it is defensive about lost pointer captures: a move with no button held (e.g. a dropped `pointercancel`) disarms the drag so hovering can't keep mutating the value. Redundant writes are skipped, so holding at a clamp boundary doesn't spam `setValue`.
 
 ## How the bundled UI wires exposure
 
-The Solid and React `ViewControls` expose a drag-to-adjust-exposure toggle. Selecting it sets a UI field, `activeViewerControl`, which is **mutually exclusive** with the active annotation tool — picking a tool exits the control and vice versa. The single mode-authority effect in `useAnnotationTool` resolves the overlay mode by precedence (`customControl` > `annotation` > `navigation`) and registers a `createDragValueControl` handler that reads the active cell's exposure and dispatches `setActiveImageExposure` on drag.
+The Solid and React `ViewControls` expose a drag-to-adjust-exposure toggle. Selecting it sets a UI field, `activeViewerControl`, which is **mutually exclusive** with the active annotation tool — picking a tool exits the control and vice versa. The single mode-authority effect in `useAnnotationTool` resolves the overlay mode by precedence (`customControl` > `annotation` > `navigation`) and registers a `createDragValueControl` handler that reads the active cell's exposure and dispatches `setActiveImageExposure` on drag. The control drags along the y-axis (up = brighter) with a resolution of `0.025`; the `SET_EXPOSURE` reducer stores the value faithfully, so the control owns the resolution rather than the reducer snapping to a coarser grid.
 
 ## Behavior notes
 

--- a/packages/fabric-osd/src/controls/drag-value-control.ts
+++ b/packages/fabric-osd/src/controls/drag-value-control.ts
@@ -1,0 +1,64 @@
+import type { CustomControlEvent, CustomControlHandler } from '../overlay/fabric-overlay.js';
+
+/** Configuration for {@link createDragValueControl}. */
+export interface DragValueControlConfig {
+  /** Read the current value when a drag begins. */
+  readonly getValue: () => number;
+  /** Write the new value on each drag move (continuous). */
+  readonly setValue: (value: number) => void;
+  /** Drag axis driving the value. Default `'x'`. */
+  readonly axis?: 'x' | 'y';
+  /**
+   * Value-units changed per CSS pixel of drag along {@link axis}. Default `1`.
+   * For the y-axis, dragging up (decreasing screen y) increases the value.
+   */
+  readonly sensitivity?: number;
+  /** Lower clamp (inclusive). */
+  readonly min?: number;
+  /** Upper clamp (inclusive). */
+  readonly max?: number;
+}
+
+/**
+ * Build a {@link CustomControlHandler} that maps pointer-drag distance onto a
+ * numeric value. The handler captures the start value and pointer position on
+ * `pointerdown`, then on each `pointermove` sets
+ * `startValue + delta(axis) * sensitivity`, clamped to `[min, max]`.
+ *
+ * Framework-agnostic and side-effect-free apart from the supplied
+ * `getValue`/`setValue`, so it is reusable for any drag-driven viewer function
+ * (exposure being the first) and trivial to unit test.
+ */
+export function createDragValueControl(config: DragValueControlConfig): CustomControlHandler {
+  const axis = config.axis ?? 'x';
+  const sensitivity = config.sensitivity ?? 1;
+  const min = config.min ?? Number.NEGATIVE_INFINITY;
+  const max = config.max ?? Number.POSITIVE_INFINITY;
+
+  let dragging = false;
+  let startScreen = 0;
+  let startValue = 0;
+
+  const coord = (event: CustomControlEvent): number =>
+    axis === 'x' ? event.screenPoint.x : event.screenPoint.y;
+
+  return {
+    onPointerDown(event: CustomControlEvent): void {
+      dragging = true;
+      startScreen = coord(event);
+      startValue = config.getValue();
+    },
+    onPointerMove(event: CustomControlEvent): void {
+      if (!dragging) return;
+      // For the y-axis, dragging up (smaller screen y) should increase the
+      // value, matching the convention that "up" means "more".
+      const rawDelta = coord(event) - startScreen;
+      const delta = axis === 'y' ? -rawDelta : rawDelta;
+      const next = Math.min(Math.max(startValue + delta * sensitivity, min), max);
+      config.setValue(next);
+    },
+    onPointerUp(): void {
+      dragging = false;
+    },
+  };
+}

--- a/packages/fabric-osd/src/controls/drag-value-control.ts
+++ b/packages/fabric-osd/src/controls/drag-value-control.ts
@@ -38,6 +38,7 @@ export function createDragValueControl(config: DragValueControlConfig): CustomCo
   let dragging = false;
   let startScreen = 0;
   let startValue = 0;
+  let lastValue = 0;
 
   const coord = (event: CustomControlEvent): number =>
     axis === 'x' ? event.screenPoint.x : event.screenPoint.y;
@@ -47,14 +48,25 @@ export function createDragValueControl(config: DragValueControlConfig): CustomCo
       dragging = true;
       startScreen = coord(event);
       startValue = config.getValue();
+      lastValue = startValue;
     },
     onPointerMove(event: CustomControlEvent): void {
       if (!dragging) return;
+      // Defensive: if no button is held the drag is over even though we never
+      // saw a pointerup (e.g. a lost pointercancel). Disarm so hovering does
+      // not keep mutating the value.
+      if (event.originalEvent.buttons === 0) {
+        dragging = false;
+        return;
+      }
       // For the y-axis, dragging up (smaller screen y) should increase the
       // value, matching the convention that "up" means "more".
       const rawDelta = coord(event) - startScreen;
       const delta = axis === 'y' ? -rawDelta : rawDelta;
       const next = Math.min(Math.max(startValue + delta * sensitivity, min), max);
+      // Skip redundant writes — notably while clamped at min/max during a drag.
+      if (next === lastValue) return;
+      lastValue = next;
       config.setValue(next);
     },
     onPointerUp(): void {

--- a/packages/fabric-osd/src/controls/drag-value-control.ts
+++ b/packages/fabric-osd/src/controls/drag-value-control.ts
@@ -17,13 +17,20 @@ export interface DragValueControlConfig {
   readonly min?: number;
   /** Upper clamp (inclusive). */
   readonly max?: number;
+  /**
+   * Quantize the emitted value to multiples of this step (the resolution of
+   * change). When omitted the value is continuous. Example: `0.025` snaps a
+   * drag to the nearest 0.025.
+   */
+  readonly step?: number;
 }
 
 /**
  * Build a {@link CustomControlHandler} that maps pointer-drag distance onto a
  * numeric value. The handler captures the start value and pointer position on
  * `pointerdown`, then on each `pointermove` sets
- * `startValue + delta(axis) * sensitivity`, clamped to `[min, max]`.
+ * `startValue + delta(axis) * sensitivity`, optionally quantized to `step`
+ * and clamped to `[min, max]`.
  *
  * Framework-agnostic and side-effect-free apart from the supplied
  * `getValue`/`setValue`, so it is reusable for any drag-driven viewer function
@@ -34,6 +41,7 @@ export function createDragValueControl(config: DragValueControlConfig): CustomCo
   const sensitivity = config.sensitivity ?? 1;
   const min = config.min ?? Number.NEGATIVE_INFINITY;
   const max = config.max ?? Number.POSITIVE_INFINITY;
+  const step = config.step;
 
   let dragging = false;
   let startScreen = 0;
@@ -63,8 +71,15 @@ export function createDragValueControl(config: DragValueControlConfig): CustomCo
       // value, matching the convention that "up" means "more".
       const rawDelta = coord(event) - startScreen;
       const delta = axis === 'y' ? -rawDelta : rawDelta;
-      const next = Math.min(Math.max(startValue + delta * sensitivity, min), max);
-      // Skip redundant writes — notably while clamped at min/max during a drag.
+      let next = startValue + delta * sensitivity;
+      // Quantize to the configured resolution before clamping so the value
+      // lands on a clean grid (e.g. multiples of 0.025).
+      if (step !== undefined && step > 0) {
+        next = Math.round(next / step) * step;
+      }
+      next = Math.min(Math.max(next, min), max);
+      // Skip redundant writes — notably while clamped at min/max or held within
+      // the same step during a drag.
       if (next === lastValue) return;
       lastValue = next;
       config.setValue(next);

--- a/packages/fabric-osd/src/index.ts
+++ b/packages/fabric-osd/src/index.ts
@@ -1,4 +1,11 @@
 export { FabricOverlay, computeViewportTransform } from './overlay/fabric-overlay.js';
-export type { OverlayOptions, OverlayMode } from './overlay/fabric-overlay.js';
+export type {
+  OverlayOptions,
+  OverlayMode,
+  CustomControlEvent,
+  CustomControlHandler,
+} from './overlay/fabric-overlay.js';
+export { createDragValueControl } from './controls/drag-value-control.js';
+export type { DragValueControlConfig } from './controls/drag-value-control.js';
 export { DecorationLayer } from './decoration/decoration-layer.js';
 export type { DomDecorationEntry } from './decoration/decoration-layer.js';

--- a/packages/fabric-osd/src/overlay/fabric-overlay.ts
+++ b/packages/fabric-osd/src/overlay/fabric-overlay.ts
@@ -17,7 +17,36 @@ import {
 } from './constants.js';
 
 /** Overlay interaction modes */
-export type OverlayMode = 'navigation' | 'annotation';
+export type OverlayMode = 'navigation' | 'annotation' | 'customControl';
+
+/**
+ * A pointer event delivered to a {@link CustomControlHandler} while the
+ * overlay is in `customControl` mode.
+ */
+export interface CustomControlEvent {
+  /** The raw DOM pointer event. */
+  readonly originalEvent: PointerEvent;
+  /** Pointer position in CSS pixels relative to the viewer element. */
+  readonly screenPoint: Point;
+  /** Pointer position in image-space (flip-aware). */
+  readonly imagePoint: Point;
+}
+
+/**
+ * Receives pointer events while the overlay is in `customControl` mode. In
+ * this mode neither OpenSeadragon nor the Fabric annotation layer reacts to
+ * the mouse — every pointer event is forwarded here instead, letting the host
+ * drive a custom viewer function (e.g. drag-to-adjust exposure).
+ *
+ * Handlers manage their own gesture state: `onPointerMove` fires on every
+ * pointer move regardless of button state, so a drag-based handler must track
+ * whether a press is in progress.
+ */
+export interface CustomControlHandler {
+  onPointerDown?(event: CustomControlEvent): void;
+  onPointerMove?(event: CustomControlEvent): void;
+  onPointerUp?(event: CustomControlEvent): void;
+}
 
 /** Options for creating a FabricOverlay */
 export interface OverlayOptions {
@@ -125,10 +154,13 @@ export function screenToImageFlipAware(viewer: OpenSeadragon.Viewer, screenPoint
  * as synthetic PointerEvents with a re-entrancy guard to prevent infinite
  * recursion (dispatched events bubble back to the tracker's element).
  *
- * Two interaction modes:
+ * Three interaction modes:
  * - **navigation**: OSD handles all input, Fabric is display-only.
  * - **annotation**: Fabric handles all input (select, move, draw).
  *   Ctrl+drag or Command+drag pans OSD within annotation mode.
+ * - **customControl**: neither OSD nor Fabric reacts; pointer events are
+ *   forwarded to a registered {@link CustomControlHandler} (e.g. drag-to-adjust
+ *   exposure). Ctrl/Cmd+scroll still zooms OSD.
  */
 export class FabricOverlay {
   // ── Core references ──────────────────────────────────────────────
@@ -140,6 +172,9 @@ export class FabricOverlay {
 
   // ── State ────────────────────────────────────────────────────────
   private _mode: OverlayMode = 'navigation';
+
+  /** Handler invoked for pointer events while in `customControl` mode. */
+  private _customControlHandler: CustomControlHandler | null = null;
 
   /**
    * Re-entrancy guard for forwardToFabric. When true, the synthetic
@@ -357,8 +392,21 @@ export class FabricOverlay {
     }
   }
 
+  /**
+   * Register (or clear with `null`) the handler that receives pointer events
+   * while the overlay is in `customControl` mode.
+   */
+  setCustomControlHandler(handler: CustomControlHandler | null): void {
+    this._customControlHandler = handler;
+  }
+
   /** Set the overlay interaction mode */
   setMode(mode: OverlayMode): void {
+    // No-op guard: re-applying the current mode would needlessly
+    // discardActiveObject() and re-walk every object, which can clobber an
+    // in-progress gesture (e.g. a selection or an active custom-control drag).
+    if (mode === this._mode) return;
+
     this._mode = mode;
     this._panGestureActive = false;
 
@@ -389,6 +437,20 @@ export class FabricOverlay {
         });
         this._viewer.setMouseNavEnabled(false);
         break;
+
+      case 'customControl':
+        // Neither OSD nor Fabric reacts: the tracker intercepts events and
+        // forwards them to the registered CustomControlHandler. Fabric is fully
+        // inert and OSD mouse nav is disabled.
+        this._overlayTracker.setTracking(true);
+        this._fabricCanvas.selection = false;
+        this._fabricCanvas.forEachObject((obj) => {
+          obj.selectable = false;
+          obj.evented = false;
+        });
+        this._fabricCanvas.discardActiveObject();
+        this._viewer.setMouseNavEnabled(false);
+        break;
     }
 
     this._fabricCanvas.renderAll();
@@ -411,6 +473,7 @@ export class FabricOverlay {
 
   /** Clean up all event listeners and DOM elements */
   destroy(): void {
+    this._customControlHandler = null;
     this._syncSubscribers.clear();
     this._overlayTracker.destroy();
     this._viewer.removeHandler(OSD_ANIMATION, this._onAnimation);
@@ -478,6 +541,21 @@ export class FabricOverlay {
     return false;
   }
 
+  /**
+   * Build the {@link CustomControlEvent} payload from a raw DOM pointer event:
+   * the screen point is element-relative CSS pixels and the image point is the
+   * flip-aware image-space conversion.
+   */
+  private _buildCustomControlEvent(originalEvent: PointerEvent): CustomControlEvent {
+    const rect = this._fabricContainer.getBoundingClientRect();
+    const screenPoint: Point = {
+      x: originalEvent.clientX - rect.left,
+      y: originalEvent.clientY - rect.top,
+    };
+    const imagePoint = this.screenToImage(screenPoint);
+    return { originalEvent, screenPoint, imagePoint };
+  }
+
   // ── Private: MouseTracker factory ──────────────────────────────
 
   /**
@@ -504,6 +582,14 @@ export class FabricOverlay {
 
         if (this._mode === 'navigation') {
           // Should not happen (tracker is disabled), but just in case
+          return;
+        }
+
+        if (this._mode === 'customControl') {
+          // Block OSD and the page from every pointer event; the press/move/
+          // release handlers forward them to the custom control handler.
+          eventInfo.stopPropagation = true;
+          eventInfo.preventDefault = true;
           return;
         }
 
@@ -553,30 +639,48 @@ export class FabricOverlay {
 
       pressHandler: (event: OpenSeadragon.MouseTrackerEvent) => {
         if (this._forwarding || this._mode === 'navigation') return;
-        if (this._panGestureActive) return;
 
         const originalEvent = event.originalEvent as PointerEvent;
+        if (this._mode === 'customControl') {
+          this._customControlHandler?.onPointerDown?.(this._buildCustomControlEvent(originalEvent));
+          return;
+        }
+
+        if (this._panGestureActive) return;
         this._forwardToFabric(POINTER_DOWN, originalEvent);
       },
 
       moveHandler: (event: OpenSeadragon.MouseTrackerEvent) => {
         if (this._forwarding || this._mode === 'navigation') return;
-        if (this._panGestureActive) return;
 
         const originalEvent = event.originalEvent as PointerEvent;
+        if (this._mode === 'customControl') {
+          this._customControlHandler?.onPointerMove?.(this._buildCustomControlEvent(originalEvent));
+          return;
+        }
+
+        if (this._panGestureActive) return;
         this._forwardToFabric(POINTER_MOVE, originalEvent);
       },
 
       releaseHandler: (event: OpenSeadragon.MouseTrackerEvent) => {
         if (this._forwarding || this._mode === 'navigation') return;
-        if (this._panGestureActive) return;
 
         const originalEvent = event.originalEvent as PointerEvent;
+        if (this._mode === 'customControl') {
+          this._customControlHandler?.onPointerUp?.(this._buildCustomControlEvent(originalEvent));
+          return;
+        }
+
+        if (this._panGestureActive) return;
         this._forwardToFabric(POINTER_UP, originalEvent);
       },
 
       scrollHandler: (event: OpenSeadragon.MouseTrackerEvent) => {
-        if (this._mode !== 'annotation') return;
+        // Navigation mode lets OSD handle the wheel natively.
+        // Annotation and customControl both swallow page scroll and keep
+        // Ctrl/Cmd+scroll as a manual OSD zoom so users never lose zoom.
+        if (this._mode === 'navigation') return;
 
         const domEvent = event.originalEvent as WheelEvent;
 

--- a/packages/fabric-osd/tests/unit/controls/drag-value-control.test.ts
+++ b/packages/fabric-osd/tests/unit/controls/drag-value-control.test.ts
@@ -7,9 +7,9 @@ import type { CustomControlEvent } from '../../../src/overlay/fabric-overlay.js'
  * The originalEvent / imagePoint are unused by createDragValueControl, so we
  * supply minimal stand-ins.
  */
-function evt(x: number, y: number): CustomControlEvent {
+function evt(x: number, y: number, buttons = 1): CustomControlEvent {
   return {
-    originalEvent: { clientX: x, clientY: y } as unknown as PointerEvent,
+    originalEvent: { clientX: x, clientY: y, buttons } as unknown as PointerEvent,
     screenPoint: { x, y },
     imagePoint: { x, y },
   };
@@ -98,6 +98,47 @@ describe('createDragValueControl', () => {
 
     control.onPointerMove?.(evt(1000, 0));
     expect(value).toBeCloseTo(0.1); // unchanged
+  });
+
+  it('disarms when a move arrives with no button held (lost pointerup/cancel)', () => {
+    let value = 0;
+    const control = createDragValueControl({
+      getValue: () => value,
+      setValue: (v) => {
+        value = v;
+      },
+      sensitivity: 0.01,
+    });
+
+    control.onPointerDown?.(evt(0, 0));
+    control.onPointerMove?.(evt(10, 0)); // dragging, button held
+    expect(value).toBeCloseTo(0.1);
+
+    // A move with buttons === 0 means the press ended without a pointerup.
+    control.onPointerMove?.(evt(500, 0, 0));
+    expect(value).toBeCloseTo(0.1); // unchanged — disarmed
+
+    // Subsequent hover moves must not mutate the value either.
+    control.onPointerMove?.(evt(1000, 0, 1));
+    expect(value).toBeCloseTo(0.1);
+  });
+
+  it('skips redundant setValue calls while clamped at a boundary', () => {
+    let calls = 0;
+    const control = createDragValueControl({
+      getValue: () => 0,
+      setValue: () => {
+        calls += 1;
+      },
+      sensitivity: 0.01,
+      max: 1,
+    });
+
+    control.onPointerDown?.(evt(0, 0));
+    control.onPointerMove?.(evt(10000, 0)); // clamps to 1 → 1 write
+    control.onPointerMove?.(evt(20000, 0)); // still 1 → no write
+    control.onPointerMove?.(evt(30000, 0)); // still 1 → no write
+    expect(calls).toBe(1);
   });
 
   it('treats upward drag as increasing on the y-axis', () => {

--- a/packages/fabric-osd/tests/unit/controls/drag-value-control.test.ts
+++ b/packages/fabric-osd/tests/unit/controls/drag-value-control.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest';
+import { createDragValueControl } from '../../../src/controls/drag-value-control.js';
+import type { CustomControlEvent } from '../../../src/overlay/fabric-overlay.js';
+
+/**
+ * Builds a CustomControlEvent with the given element-relative screen point.
+ * The originalEvent / imagePoint are unused by createDragValueControl, so we
+ * supply minimal stand-ins.
+ */
+function evt(x: number, y: number): CustomControlEvent {
+  return {
+    originalEvent: { clientX: x, clientY: y } as unknown as PointerEvent,
+    screenPoint: { x, y },
+    imagePoint: { x, y },
+  };
+}
+
+describe('createDragValueControl', () => {
+  it('maps horizontal drag distance onto the value via sensitivity', () => {
+    let value = 0;
+    const control = createDragValueControl({
+      getValue: () => value,
+      setValue: (v) => {
+        value = v;
+      },
+      sensitivity: 0.01,
+    });
+
+    control.onPointerDown?.(evt(100, 50));
+    control.onPointerMove?.(evt(150, 50)); // +50px * 0.01 = +0.5
+    expect(value).toBeCloseTo(0.5);
+
+    control.onPointerMove?.(evt(60, 50)); // -40px from start * 0.01 = -0.4
+    expect(value).toBeCloseTo(-0.4);
+  });
+
+  it('captures the starting value at pointer-down', () => {
+    let value = 0.3;
+    const control = createDragValueControl({
+      getValue: () => value,
+      setValue: (v) => {
+        value = v;
+      },
+      sensitivity: 0.01,
+    });
+
+    control.onPointerDown?.(evt(0, 0));
+    control.onPointerMove?.(evt(20, 0)); // 0.3 + 20*0.01 = 0.5
+    expect(value).toBeCloseTo(0.5);
+  });
+
+  it('clamps to [min, max]', () => {
+    let value = 0;
+    const control = createDragValueControl({
+      getValue: () => value,
+      setValue: (v) => {
+        value = v;
+      },
+      sensitivity: 0.01,
+      min: -1,
+      max: 1,
+    });
+
+    control.onPointerDown?.(evt(0, 0));
+    control.onPointerMove?.(evt(10000, 0));
+    expect(value).toBe(1);
+    control.onPointerMove?.(evt(-10000, 0));
+    expect(value).toBe(-1);
+  });
+
+  it('ignores moves before a pointer-down', () => {
+    let calls = 0;
+    const control = createDragValueControl({
+      getValue: () => 0,
+      setValue: () => {
+        calls += 1;
+      },
+    });
+
+    control.onPointerMove?.(evt(50, 50));
+    expect(calls).toBe(0);
+  });
+
+  it('stops responding to moves after pointer-up', () => {
+    let value = 0;
+    const control = createDragValueControl({
+      getValue: () => value,
+      setValue: (v) => {
+        value = v;
+      },
+      sensitivity: 0.01,
+    });
+
+    control.onPointerDown?.(evt(0, 0));
+    control.onPointerMove?.(evt(10, 0));
+    expect(value).toBeCloseTo(0.1);
+    control.onPointerUp?.(evt(10, 0));
+
+    control.onPointerMove?.(evt(1000, 0));
+    expect(value).toBeCloseTo(0.1); // unchanged
+  });
+
+  it('treats upward drag as increasing on the y-axis', () => {
+    let value = 0;
+    const control = createDragValueControl({
+      getValue: () => value,
+      setValue: (v) => {
+        value = v;
+      },
+      axis: 'y',
+      sensitivity: 0.01,
+    });
+
+    control.onPointerDown?.(evt(0, 100));
+    control.onPointerMove?.(evt(0, 60)); // dragged up 40px → +0.4
+    expect(value).toBeCloseTo(0.4);
+  });
+});

--- a/packages/fabric-osd/tests/unit/controls/drag-value-control.test.ts
+++ b/packages/fabric-osd/tests/unit/controls/drag-value-control.test.ts
@@ -141,6 +141,44 @@ describe('createDragValueControl', () => {
     expect(calls).toBe(1);
   });
 
+  it('quantizes the value to the configured step (resolution of change)', () => {
+    let value = 0;
+    const control = createDragValueControl({
+      getValue: () => value,
+      setValue: (v) => {
+        value = v;
+      },
+      sensitivity: 0.01,
+      step: 0.025,
+    });
+
+    control.onPointerDown?.(evt(0, 0));
+
+    control.onPointerMove?.(evt(7, 0)); // raw 0.07 → nearest 0.025 = 0.075
+    expect(value).toBeCloseTo(0.075);
+
+    control.onPointerMove?.(evt(1, 0)); // raw 0.01 → nearest 0.025 = 0.0 (snaps back)
+    expect(value).toBeCloseTo(0);
+
+    control.onPointerMove?.(evt(4, 0)); // raw 0.04 → nearest 0.025 = 0.05
+    expect(value).toBeCloseTo(0.05);
+  });
+
+  it('does not emit until the drag crosses a step boundary', () => {
+    const writes: number[] = [];
+    const control = createDragValueControl({
+      getValue: () => 0,
+      setValue: (v) => writes.push(v),
+      sensitivity: 0.01,
+      step: 0.025,
+    });
+
+    control.onPointerDown?.(evt(0, 0));
+    control.onPointerMove?.(evt(1, 0)); // raw 0.01 → 0 (== start, no write)
+    control.onPointerMove?.(evt(2, 0)); // raw 0.02 → 0.025? round(0.8)=1 → 0.025
+    expect(writes).toEqual([0.025]);
+  });
+
   it('treats upward drag as increasing on the y-axis', () => {
     let value = 0;
     const control = createDragValueControl({

--- a/packages/fabric-osd/tests/unit/overlay/input-routing.test.ts
+++ b/packages/fabric-osd/tests/unit/overlay/input-routing.test.ts
@@ -60,6 +60,16 @@ function createMockOverlay(): { overlay: MockOverlay; state: MockState } {
         state.objectsEvented = true;
         state.osdMouseNavEnabled = false;
         break;
+
+      case 'customControl':
+        // Tracker intercepts so events reach the custom handler, but Fabric is
+        // fully inert and OSD mouse nav is disabled.
+        state.overlayTrackerTracking = true;
+        state.fabricSelection = false;
+        state.objectsSelectable = false;
+        state.objectsEvented = false;
+        state.osdMouseNavEnabled = false;
+        break;
     }
   }
 
@@ -133,6 +143,30 @@ describe('Input routing — setMode', () => {
     it('reports correct mode', () => {
       overlay.setMode('annotation');
       expect(overlay.getMode()).toBe('annotation');
+    });
+  });
+
+  describe('customControl mode', () => {
+    it('enables overlay tracker so events reach the custom handler', () => {
+      overlay.setMode('customControl');
+      expect(state.overlayTrackerTracking).toBe(true);
+    });
+
+    it('keeps Fabric inert (no selection, objects non-interactive)', () => {
+      overlay.setMode('customControl');
+      expect(state.fabricSelection).toBe(false);
+      expect(state.objectsSelectable).toBe(false);
+      expect(state.objectsEvented).toBe(false);
+    });
+
+    it('disables OSD mouse navigation', () => {
+      overlay.setMode('customControl');
+      expect(state.osdMouseNavEnabled).toBe(false);
+    });
+
+    it('reports correct mode', () => {
+      overlay.setMode('customControl');
+      expect(overlay.getMode()).toBe('customControl');
     });
   });
 

--- a/packages/fabric-osd/tests/unit/overlay/input-routing.test.ts
+++ b/packages/fabric-osd/tests/unit/overlay/input-routing.test.ts
@@ -23,6 +23,8 @@ interface MockState {
   objectsSelectable: boolean;
   /** Whether Fabric objects receive pointer events */
   objectsEvented: boolean;
+  /** Count of discardActiveObject() calls (a setMode side effect) */
+  discardActiveObjectCalls: number;
 }
 
 interface MockOverlay {
@@ -37,11 +39,16 @@ function createMockOverlay(): { overlay: MockOverlay; state: MockState } {
     osdMouseNavEnabled: true,
     objectsSelectable: false,
     objectsEvented: false,
+    discardActiveObjectCalls: 0,
   };
 
   let currentMode: OverlayMode = 'navigation';
 
   function setMode(mode: OverlayMode): void {
+    // Mirrors the real FabricOverlay.setMode no-op guard: re-applying the
+    // current mode must not re-run side effects (discardActiveObject, object
+    // walks) that could clobber an in-progress gesture.
+    if (mode === currentMode) return;
     currentMode = mode;
 
     switch (mode) {
@@ -51,6 +58,7 @@ function createMockOverlay(): { overlay: MockOverlay; state: MockState } {
         state.objectsSelectable = false;
         state.objectsEvented = false;
         state.osdMouseNavEnabled = true;
+        state.discardActiveObjectCalls += 1;
         break;
 
       case 'annotation':
@@ -69,6 +77,7 @@ function createMockOverlay(): { overlay: MockOverlay; state: MockState } {
         state.objectsSelectable = false;
         state.objectsEvented = false;
         state.osdMouseNavEnabled = false;
+        state.discardActiveObjectCalls += 1;
         break;
     }
   }
@@ -194,6 +203,17 @@ describe('Input routing — setMode', () => {
       expect(state.fabricSelection).toBe(true);
       expect(state.objectsSelectable).toBe(true);
       expect(state.objectsEvented).toBe(true);
+    });
+
+    it('does not re-run discardActiveObject side effect on redundant setMode', () => {
+      overlay.setMode('customControl');
+      const after = state.discardActiveObjectCalls;
+      expect(after).toBeGreaterThan(0);
+
+      // Re-applying the same mode must be a true no-op (guards an in-progress
+      // custom-control drag from being clobbered).
+      overlay.setMode('customControl');
+      expect(state.discardActiveObjectCalls).toBe(after);
     });
 
     it('handles repeated same-mode calls idempotently', () => {

--- a/packages/osdlabel/src/actions.ts
+++ b/packages/osdlabel/src/actions.ts
@@ -1,5 +1,5 @@
 import type { AnnotationId, ToolType } from '@osdlabel/annotation';
-import type { AnnotationState, ImageId, UIState } from '@osdlabel/viewer-api';
+import type { AnnotationState, ImageId, UIState, ViewerControlId } from '@osdlabel/viewer-api';
 import { DEFAULT_CELL_TRANSFORM } from '@osdlabel/viewer-api';
 import type {
   AnnotationContext,
@@ -37,6 +37,7 @@ export type AnnotationAction =
 
 export type UIAction =
   | { readonly type: 'SET_ACTIVE_TOOL'; readonly payload: ToolType | 'select' | null }
+  | { readonly type: 'SET_ACTIVE_VIEWER_CONTROL'; readonly payload: ViewerControlId | null }
   | { readonly type: 'SET_ACTIVE_CELL'; readonly payload: number }
   | { readonly type: 'SET_SELECTED_ANNOTATION'; readonly payload: AnnotationId | null }
   | {
@@ -142,6 +143,18 @@ export function applyUIAction(draft: UIState, action: UIAction): void {
   switch (action.type) {
     case 'SET_ACTIVE_TOOL':
       draft.activeTool = action.payload;
+      // One interaction owns the pointer at a time: selecting a tool exits any
+      // active viewer control.
+      if (action.payload !== null) {
+        draft.activeViewerControl = null;
+      }
+      break;
+    case 'SET_ACTIVE_VIEWER_CONTROL':
+      draft.activeViewerControl = action.payload;
+      // Activating a viewer control exits any active annotation tool.
+      if (action.payload !== null) {
+        draft.activeTool = null;
+      }
       break;
     case 'SET_ACTIVE_CELL':
       draft.activeCellIndex = action.payload;

--- a/packages/osdlabel/src/actions.ts
+++ b/packages/osdlabel/src/actions.ts
@@ -249,9 +249,12 @@ export function applyUIAction(draft: UIState, action: UIAction): void {
         ...DEFAULT_CELL_TRANSFORM,
       };
       const exposure = Math.max(Math.min(action.payload.value, 1), -1);
+      // Store faithfully — the caller (e.g. the drag control's `step`) owns the
+      // resolution of change. Round only to strip floating-point noise so the
+      // value stays clean for display and the `brightness()` filter.
       draft.cellTransforms[action.payload.cellIndex] = {
         ...current,
-        exposure: Math.round(exposure * 10) / 10,
+        exposure: Math.round(exposure * 1000) / 1000,
       };
       break;
     }

--- a/packages/osdlabel/src/index.ts
+++ b/packages/osdlabel/src/index.ts
@@ -22,6 +22,7 @@ export type {
   ImageId,
   ImageIdFields,
   UIState,
+  ViewerControlId,
   KeyboardShortcutMap,
   CellTransform,
   AnnotationState,
@@ -75,8 +76,20 @@ export type {
 } from '@osdlabel/fabric-annotations';
 
 // Fabric-OSD overlay (re-exported from @osdlabel/fabric-osd)
-export { FabricOverlay, computeViewportTransform, DecorationLayer } from '@osdlabel/fabric-osd';
-export type { OverlayOptions, OverlayMode, DomDecorationEntry } from '@osdlabel/fabric-osd';
+export {
+  FabricOverlay,
+  computeViewportTransform,
+  DecorationLayer,
+  createDragValueControl,
+} from '@osdlabel/fabric-osd';
+export type {
+  OverlayOptions,
+  OverlayMode,
+  DomDecorationEntry,
+  CustomControlEvent,
+  CustomControlHandler,
+  DragValueControlConfig,
+} from '@osdlabel/fabric-osd';
 
 // Decorations (re-exported from @osdlabel/decoration)
 export type {

--- a/packages/osdlabel/src/initial-state.ts
+++ b/packages/osdlabel/src/initial-state.ts
@@ -12,6 +12,7 @@ export function createInitialAnnotationState(): AnnotationState<OsdFields> {
 export function createInitialUIState(): UIState {
   return {
     activeTool: null,
+    activeViewerControl: null,
     activeCellIndex: 0,
     gridColumns: 1,
     gridRows: 1,

--- a/packages/osdlabel/tests/unit/actions.test.ts
+++ b/packages/osdlabel/tests/unit/actions.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import type { ToolType } from '@osdlabel/annotation';
+import type { ViewerControlId } from '@osdlabel/viewer-api';
+import { applyUIAction } from '../../src/actions.js';
+import { createInitialUIState } from '../../src/initial-state.js';
+
+const RECTANGLE: ToolType = 'rectangle';
+const EXPOSURE: ViewerControlId = 'exposure';
+
+describe('applyUIAction — tool / viewer-control mutual exclusivity', () => {
+  it('SET_ACTIVE_VIEWER_CONTROL clears an active tool', () => {
+    const state = createInitialUIState();
+    applyUIAction(state, { type: 'SET_ACTIVE_TOOL', payload: RECTANGLE });
+    expect(state.activeTool).toBe(RECTANGLE);
+
+    applyUIAction(state, { type: 'SET_ACTIVE_VIEWER_CONTROL', payload: EXPOSURE });
+    expect(state.activeViewerControl).toBe(EXPOSURE);
+    expect(state.activeTool).toBeNull();
+  });
+
+  it('SET_ACTIVE_TOOL clears an active viewer control', () => {
+    const state = createInitialUIState();
+    applyUIAction(state, { type: 'SET_ACTIVE_VIEWER_CONTROL', payload: EXPOSURE });
+    expect(state.activeViewerControl).toBe(EXPOSURE);
+
+    applyUIAction(state, { type: 'SET_ACTIVE_TOOL', payload: RECTANGLE });
+    expect(state.activeTool).toBe(RECTANGLE);
+    expect(state.activeViewerControl).toBeNull();
+  });
+
+  it('clearing the tool to null leaves the viewer control untouched', () => {
+    const state = createInitialUIState();
+    applyUIAction(state, { type: 'SET_ACTIVE_VIEWER_CONTROL', payload: EXPOSURE });
+
+    applyUIAction(state, { type: 'SET_ACTIVE_TOOL', payload: null });
+    expect(state.activeTool).toBeNull();
+    expect(state.activeViewerControl).toBe(EXPOSURE);
+  });
+
+  it('clearing the viewer control to null leaves the tool untouched', () => {
+    const state = createInitialUIState();
+    applyUIAction(state, { type: 'SET_ACTIVE_TOOL', payload: RECTANGLE });
+
+    applyUIAction(state, { type: 'SET_ACTIVE_VIEWER_CONTROL', payload: null });
+    expect(state.activeViewerControl).toBeNull();
+    expect(state.activeTool).toBe(RECTANGLE);
+  });
+
+  it('selecting the select tool also clears the viewer control', () => {
+    const state = createInitialUIState();
+    applyUIAction(state, { type: 'SET_ACTIVE_VIEWER_CONTROL', payload: EXPOSURE });
+
+    applyUIAction(state, { type: 'SET_ACTIVE_TOOL', payload: 'select' });
+    expect(state.activeTool).toBe('select');
+    expect(state.activeViewerControl).toBeNull();
+  });
+});

--- a/packages/react/src/components/ViewControls.tsx
+++ b/packages/react/src/components/ViewControls.tsx
@@ -234,6 +234,37 @@ export function ViewControls() {
           <path d="m19.07 4.93-1.41 1.41" />
         </svg>
       </button>
+      <button
+        type="button"
+        title="Drag to adjust exposure"
+        aria-label="Drag to adjust exposure"
+        aria-pressed={uiState.activeViewerControl === 'exposure'}
+        data-testid="view-exposure-drag"
+        disabled={!isActive}
+        onClick={() =>
+          actions.setActiveViewerControl(
+            uiState.activeViewerControl === 'exposure' ? null : 'exposure',
+          )
+        }
+        style={btnStyle(uiState.activeViewerControl === 'exposure')}
+      >
+        <svg
+          width="18"
+          height="18"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <circle cx="12" cy="12" r="3" />
+          <path d="M3 12h4" />
+          <path d="M17 12h4" />
+          <path d="m7 9-3 3 3 3" />
+          <path d="m17 9 3 3-3 3" />
+        </svg>
+      </button>
       {showReset && (
         <>
           {sep}

--- a/packages/react/src/hooks/useAnnotationTool.ts
+++ b/packages/react/src/hooks/useAnnotationTool.ts
@@ -4,8 +4,10 @@ import type { FabricOverlay } from '@osdlabel/fabric-osd';
 import type { AnnotationTool, AddAnnotationParams } from '@osdlabel/fabric-annotations';
 import type { AnnotationId, Point, ToolType } from '@osdlabel/annotation';
 import type { ImageId } from '@osdlabel/viewer-api';
+import { DEFAULT_CELL_TRANSFORM } from '@osdlabel/viewer-api';
 import {
   createAnnotationTool,
+  createDragValueControl,
   getScenePointFromEvent,
   processToolAddAnnotation,
   processToolUpdateAnnotation,
@@ -53,6 +55,8 @@ export function useAnnotationTool(
   contextStateRef.current = contextState;
   const constraintStatusRef = useRef(constraintStatus);
   constraintStatusRef.current = constraintStatus;
+  const uiStateRef = useRef(uiState);
+  uiStateRef.current = uiState;
 
   // Handle object:modified events
   useEffect(() => {
@@ -77,6 +81,32 @@ export function useAnnotationTool(
   // Main tool lifecycle effect
   useEffect(() => {
     if (!overlay || !imageId) return;
+
+    // A drag-driven viewer control takes precedence over annotation tools: the
+    // overlay enters customControl mode and forwards pointer events to the
+    // control's handler. This effect is the single authority over setMode, so
+    // no second effect can race it. getValue reads through a ref to avoid a
+    // stale closure across renders.
+    if (isActive && uiState.activeViewerControl === 'exposure') {
+      overlay.setCustomControlHandler(
+        createDragValueControl({
+          getValue: () =>
+            (
+              uiStateRef.current.cellTransforms[uiStateRef.current.activeCellIndex] ??
+              DEFAULT_CELL_TRANSFORM
+            ).exposure,
+          setValue: (value) => actions.setActiveImageExposure(value),
+          axis: 'x',
+          sensitivity: 0.01,
+          min: -1,
+          max: 1,
+        }),
+      );
+      overlay.setMode('customControl');
+      return () => {
+        overlay.setCustomControlHandler(null);
+      };
+    }
 
     if (!isActive || !uiState.activeTool) {
       overlay.setMode('navigation');
@@ -172,5 +202,14 @@ export function useAnnotationTool(
       overlay.canvas.off('mouse:up', handleUp);
       tool.deactivate();
     };
-  }, [overlay, imageId, isActive, uiState.activeTool, shortcuts, actions, activeToolKeyHandlerRef]);
+  }, [
+    overlay,
+    imageId,
+    isActive,
+    uiState.activeTool,
+    uiState.activeViewerControl,
+    shortcuts,
+    actions,
+    activeToolKeyHandlerRef,
+  ]);
 }

--- a/packages/react/src/hooks/useAnnotationTool.ts
+++ b/packages/react/src/hooks/useAnnotationTool.ts
@@ -96,7 +96,7 @@ export function useAnnotationTool(
               DEFAULT_CELL_TRANSFORM
             ).exposure,
           setValue: (value) => actions.setActiveImageExposure(value),
-          axis: 'x',
+          axis: 'y',
           sensitivity: 0.01,
           min: -1,
           max: 1,

--- a/packages/react/src/hooks/useAnnotationTool.ts
+++ b/packages/react/src/hooks/useAnnotationTool.ts
@@ -98,6 +98,7 @@ export function useAnnotationTool(
           setValue: (value) => actions.setActiveImageExposure(value),
           axis: 'y',
           sensitivity: 0.01,
+          step: 0.025,
           min: -1,
           max: 1,
         }),

--- a/packages/react/src/state/actions.ts
+++ b/packages/react/src/state/actions.ts
@@ -1,6 +1,6 @@
 import type { Dispatch } from 'react';
 import type { AnnotationId, ToolType } from '@osdlabel/annotation';
-import type { ImageId } from '@osdlabel/viewer-api';
+import type { ImageId, ViewerControlId } from '@osdlabel/viewer-api';
 import type {
   AnnotationContext,
   AnnotationContextId,
@@ -35,6 +35,10 @@ export function createActions(
 
   function setActiveTool(tool: ToolType | 'select' | null): void {
     dispatchUI({ type: 'SET_ACTIVE_TOOL', payload: tool });
+  }
+
+  function setActiveViewerControl(control: ViewerControlId | null): void {
+    dispatchUI({ type: 'SET_ACTIVE_VIEWER_CONTROL', payload: control });
   }
 
   function setActiveCell(cellIndex: number): void {
@@ -113,6 +117,7 @@ export function createActions(
     updateAnnotation,
     deleteAnnotation,
     setActiveTool,
+    setActiveViewerControl,
     setActiveCell,
     setSelectedAnnotation,
     assignImageToCell,

--- a/packages/solid/src/components/ViewControls.tsx
+++ b/packages/solid/src/components/ViewControls.tsx
@@ -307,6 +307,50 @@ export const ViewControls: Component = () => {
         </svg>
       </button>
 
+      <button
+        type="button"
+        title="Drag to adjust exposure"
+        aria-label="Drag to adjust exposure"
+        aria-pressed={uiState.activeViewerControl === 'exposure'}
+        data-testid="view-exposure-drag"
+        disabled={!isActive()}
+        onClick={() =>
+          actions.setActiveViewerControl(
+            uiState.activeViewerControl === 'exposure' ? null : 'exposure',
+          )
+        }
+        style={{
+          width: '32px',
+          height: '32px',
+          'background-color': uiState.activeViewerControl === 'exposure' ? '#2196F3' : '#333',
+          border: 'none',
+          'border-radius': '4px',
+          color: 'white',
+          cursor: isActive() ? 'pointer' : 'default',
+          opacity: isActive() ? '1' : '0.5',
+          display: 'flex',
+          'align-items': 'center',
+          'justify-content': 'center',
+        }}
+      >
+        <svg
+          width="18"
+          height="18"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <circle cx="12" cy="12" r="3" />
+          <path d="M3 12h4" />
+          <path d="M17 12h4" />
+          <path d="m7 9-3 3 3 3" />
+          <path d="m17 9 3 3-3 3" />
+        </svg>
+      </button>
+
       <Show
         when={
           cellTransform().rotation !== 0 ||

--- a/packages/solid/src/hooks/useAnnotationTool.ts
+++ b/packages/solid/src/hooks/useAnnotationTool.ts
@@ -4,8 +4,10 @@ import type { FabricOverlay } from '@osdlabel/fabric-osd';
 import type { AnnotationTool, AddAnnotationParams } from '@osdlabel/fabric-annotations';
 import type { AnnotationId, Point, ToolType } from '@osdlabel/annotation';
 import type { ImageId } from '@osdlabel/viewer-api';
+import { DEFAULT_CELL_TRANSFORM } from '@osdlabel/viewer-api';
 import {
   createAnnotationTool,
+  createDragValueControl,
   getScenePointFromEvent,
   processToolAddAnnotation,
   processToolUpdateAnnotation,
@@ -73,10 +75,34 @@ export function useAnnotationTool(
   createEffect(() => {
     const ov = overlay();
     const active = isActive();
+    const viewerControl = uiState.activeViewerControl;
     const type = uiState.activeTool;
     const imgId = imageId();
 
     if (!ov || !imgId) {
+      return;
+    }
+
+    // A drag-driven viewer control takes precedence over annotation tools:
+    // the overlay enters customControl mode and forwards pointer events to the
+    // control's handler. This is the single authority over setMode, so there is
+    // no second effect that could race it.
+    if (active && viewerControl === 'exposure') {
+      ov.setCustomControlHandler(
+        createDragValueControl({
+          getValue: () =>
+            (uiState.cellTransforms[uiState.activeCellIndex] ?? DEFAULT_CELL_TRANSFORM).exposure,
+          setValue: (value) => actions.setActiveImageExposure(value),
+          axis: 'x',
+          sensitivity: 0.01,
+          min: -1,
+          max: 1,
+        }),
+      );
+      ov.setMode('customControl');
+      onCleanup(() => {
+        ov.setCustomControlHandler(null);
+      });
       return;
     }
 

--- a/packages/solid/src/hooks/useAnnotationTool.ts
+++ b/packages/solid/src/hooks/useAnnotationTool.ts
@@ -93,7 +93,7 @@ export function useAnnotationTool(
           getValue: () =>
             (uiState.cellTransforms[uiState.activeCellIndex] ?? DEFAULT_CELL_TRANSFORM).exposure,
           setValue: (value) => actions.setActiveImageExposure(value),
-          axis: 'x',
+          axis: 'y',
           sensitivity: 0.01,
           min: -1,
           max: 1,

--- a/packages/solid/src/hooks/useAnnotationTool.ts
+++ b/packages/solid/src/hooks/useAnnotationTool.ts
@@ -95,6 +95,7 @@ export function useAnnotationTool(
           setValue: (value) => actions.setActiveImageExposure(value),
           axis: 'y',
           sensitivity: 0.01,
+          step: 0.025,
           min: -1,
           max: 1,
         }),

--- a/packages/solid/src/state/actions.ts
+++ b/packages/solid/src/state/actions.ts
@@ -1,6 +1,6 @@
 import { type SetStoreFunction, produce } from 'solid-js/store';
 import type { AnnotationId, ToolType } from '@osdlabel/annotation';
-import type { AnnotationState, ImageId, UIState } from '@osdlabel/viewer-api';
+import type { AnnotationState, ImageId, UIState, ViewerControlId } from '@osdlabel/viewer-api';
 import type {
   AnnotationContext,
   AnnotationContextId,
@@ -56,6 +56,14 @@ export function createActions(
   function setActiveTool(tool: ToolType | 'select' | null): void {
     setUIState(
       produce((draft) => applyUIAction(draft, { type: 'SET_ACTIVE_TOOL', payload: tool })),
+    );
+  }
+
+  function setActiveViewerControl(control: ViewerControlId | null): void {
+    setUIState(
+      produce((draft) =>
+        applyUIAction(draft, { type: 'SET_ACTIVE_VIEWER_CONTROL', payload: control }),
+      ),
     );
   }
 
@@ -191,6 +199,7 @@ export function createActions(
     updateAnnotation,
     deleteAnnotation,
     setActiveTool,
+    setActiveViewerControl,
     setActiveCell,
     setSelectedAnnotation,
     assignImageToCell,

--- a/packages/viewer-api/src/types.ts
+++ b/packages/viewer-api/src/types.ts
@@ -40,9 +40,21 @@ export const DEFAULT_CELL_TRANSFORM: CellTransform = {
 // with SolidJS's `SetStoreFunction` path-based API. Data model types above
 // (Annotation, Geometry, etc.) remain fully `readonly`.
 
+/**
+ * Identifies a drag-driven viewer control. When one is active the overlay
+ * enters `customControl` mode and forwards pointer events to that control's
+ * handler instead of to OSD or the Fabric annotation layer.
+ */
+export type ViewerControlId = 'exposure';
+
 /** UI state */
 export interface UIState {
   activeTool: ToolType | 'select' | null;
+  /**
+   * The active drag-driven viewer control, if any. Mutually exclusive with
+   * `activeTool`: at most one interaction owns the pointer at a time.
+   */
+  activeViewerControl: ViewerControlId | null;
   activeCellIndex: number;
   gridColumns: number;
   gridRows: number;


### PR DESCRIPTION
Introduce a third FabricOverlay interaction mode, `customControl`, where
neither OpenSeadragon nor the Fabric annotation layer reacts to the mouse;
pointer events are forwarded to a registered handler instead. This enables
drag-based viewer functions, with continuous drag-to-adjust exposure as the
first use case.

- FabricOverlay: `customControl` mode, `CustomControlHandler` contract,
  `setCustomControlHandler()`, and a setMode no-op guard so redundant
  re-applies cannot clobber an in-progress gesture. Ctrl/Cmd+scroll still
  zooms while in the mode.
- Add framework-agnostic `createDragValueControl()` helper mapping drag
  distance onto a clamped numeric value.
- Add `UIState.activeViewerControl` (`ViewerControlId`), mutually exclusive
  with `activeTool`; the single mode-authority effect in both the Solid and
  React `useAnnotationTool` hooks resolves mode by precedence
  (customControl > annotation > navigation).
- ViewControls (Solid + React): drag-to-adjust-exposure toggle button.
- Tests: unit tests for the drag helper, customControl routing coverage in
  the mode-routing test, and an E2E drag-exposure test.

https://claude.ai/code/session_01JRRmpaz3BfRuny1H3FMeYF