### PR TITLE
feat: add createAnnotationFromGeometry + document DOM decorations, React/SSR, and import recipe

### DIFF
--- a/.changeset/auto-init-fabric.md
+++ b/.changeset/auto-init-fabric.md
@@ -1,0 +1,6 @@
+---
+'@osdlabel/fabric-annotations': minor
+'@osdlabel/fabric-osd': minor
+---
+
+Register the Fabric `id` custom property automatically. `FabricOverlay`'s constructor now calls `initFabricModule()`, so annotations serialize their `id` (and the overlay's clear filter works) without consumers remembering the setup call. `initFabricModule()` remains exported and is now idempotent and merge-safe — it adds `id` to any existing `customProperties` instead of overwriting them — so explicit calls and consumer-registered custom properties are both preserved.

--- a/.changeset/import-from-geometry.md
+++ b/.changeset/import-from-geometry.md
@@ -1,0 +1,6 @@
+---
+"@osdlabel/fabric-annotations": minor
+"osdlabel": minor
+---
+
+Add `createAnnotationFromGeometry` for seeding annotations from external geometry without the manual Fabric round-trip. The `osdlabel` umbrella (and the `@osdlabel/react` / `@osdlabel/solid` re-exports) gains `createAnnotationFromGeometry(geometry, { imageId, contextId, toolType, style?, id?, label? })`, which builds a complete `OsdAnnotation` including the Fabric `rawAnnotationData` envelope and guarantees the `id` survives serialization. `@osdlabel/fabric-annotations` exposes the underlying `buildFabricObjectFromGeometry` (the inverse of `getGeometryFromFabricObject`).

--- a/.changeset/peer-range-floors.md
+++ b/.changeset/peer-range-floors.md
@@ -1,0 +1,10 @@
+---
+'@osdlabel/fabric-annotations': patch
+'@osdlabel/fabric-osd': patch
+'@osdlabel/osd-helper': patch
+'osdlabel': patch
+'@osdlabel/react': patch
+'@osdlabel/solid': patch
+---
+
+Widen the published `fabric` and `openseadragon` peer ranges from exact pins to caret ranges (`fabric: ^7.4.0`, `openseadragon: ^5.0.1`) to reduce install friction in monorepos and shared-install setups. The `fabric` floor stays at 7.4.0 to exclude the <7.4 CVE. Dev/workspace installs remain pinned to exact versions via the default pnpm catalog; the ranges are sourced from a new named `peers` catalog used only in `peerDependencies`.

--- a/apps/dev/package.json
+++ b/apps/dev/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@osdlabel/solid": "workspace:*",
+    "fabric": "catalog:",
     "osdlabel": "workspace:*",
     "solid-js": "catalog:"
   },

--- a/apps/dev/src/App.tsx
+++ b/apps/dev/src/App.tsx
@@ -12,7 +12,6 @@ import {
   useAnnotator,
   serialize,
   deserialize,
-  initFabricModule,
   createMeasurementProvider,
   createLabelProvider,
   createDistanceProvider,
@@ -27,8 +26,12 @@ import type {
   DomDecoration,
   OsdFields,
 } from '@osdlabel/solid';
+import { FabricObject } from 'fabric';
 
-initFabricModule();
+// NOTE: initFabricModule() is intentionally NOT called here. The library
+// registers the Fabric `id` custom property automatically when a FabricOverlay
+// mounts, so this dev harness dogfoods that auto-registration. The E2E test
+// `auto-init-fabric.spec.ts` relies on this.
 
 const IMAGES: ImageSource[] = [
   {
@@ -106,6 +109,21 @@ function AppContent() {
 
   // Auto-assign first image to cell 0
   actions.assignImageToCell(0, IMAGES[0]!.id);
+
+  // Test-only hooks consumed by E2E (auto-init-fabric.spec.ts). Exposes the
+  // current serialized document and the live Fabric `customProperties` array so
+  // the test can assert the `id` registration is correct and idempotent.
+  (
+    window as unknown as {
+      __osdTest?: {
+        serialize: () => ReturnType<typeof serialize>;
+        fabricCustomProperties: () => string[];
+      };
+    }
+  ).__osdTest = {
+    serialize: () => serialize(annotationState),
+    fabricCustomProperties: () => [...(FabricObject.customProperties ?? [])],
+  };
 
   const copyAnnotationsToClipboard = () => {
     const json = JSON.stringify(annotationState.byImage, null, 2);

--- a/apps/dev/tests/e2e/auto-init-fabric.spec.ts
+++ b/apps/dev/tests/e2e/auto-init-fabric.spec.ts
@@ -1,0 +1,142 @@
+import { test, expect } from '@playwright/test';
+import type { Page } from '@playwright/test';
+
+/**
+ * Validates that the Fabric `id` custom property is registered automatically
+ * when a FabricOverlay mounts — and that the registration is idempotent across
+ * many overlay constructions.
+ *
+ * Crucially, the dev harness (apps/dev/src/App.tsx) does NOT call
+ * initFabricModule() itself, so everything asserted here is driven solely by the
+ * library's auto-registration inside FabricOverlay's constructor.
+ *
+ * The harness exposes two test-only hooks on `window.__osdTest`:
+ *   - serialize(): the current serialized annotation document
+ *   - fabricCustomProperties(): a snapshot of FabricObject.customProperties
+ *
+ * Uses the bundled local image (`jpg`) so the test never depends on network
+ * access to external DZI tile sources.
+ */
+
+interface SerializedAnnotation {
+  readonly id: string;
+  readonly rawAnnotationData: { readonly data: { readonly id?: string } };
+}
+
+interface OsdTestHooks {
+  serialize: () => SerializedAnnotation[];
+  fabricCustomProperties: () => string[];
+}
+
+function customProperties(page: Page): Promise<string[]> {
+  return page.evaluate(() =>
+    (window as unknown as { __osdTest: OsdTestHooks }).__osdTest.fabricCustomProperties(),
+  );
+}
+
+function serializedAnnotations(page: Page): Promise<SerializedAnnotation[]> {
+  return page.evaluate(() =>
+    (window as unknown as { __osdTest: OsdTestHooks }).__osdTest.serialize(),
+  );
+}
+
+/** Assign the local `jpg` image to the currently-active cell and wait for its overlay. */
+async function assignLocalImageToActiveCell(page: Page): Promise<void> {
+  const canvasCountBefore = await page.locator('canvas.upper-canvas').count();
+  await page.getByTestId('filmstrip-item-jpg').click();
+  // Wait until a(nother) Fabric overlay canvas has mounted.
+  await expect
+    .poll(() => page.locator('canvas.upper-canvas').count(), { timeout: 15000 })
+    .toBeGreaterThan(canvasCountBefore - 1);
+  await page.locator('canvas.upper-canvas').first().waitFor({ state: 'attached', timeout: 15000 });
+}
+
+async function drawRectangleInFirstCell(
+  page: Page,
+  from: { x: number; y: number },
+  to: { x: number; y: number },
+): Promise<void> {
+  const canvas = page.locator('canvas.upper-canvas').first();
+  const box = await canvas.boundingBox();
+  if (!box) throw new Error('Canvas not found');
+
+  const rect = page.getByTestId('tool-rectangle');
+  await expect(rect).toBeEnabled({ timeout: 10000 });
+  await rect.click();
+  await page.mouse.move(box.x + from.x, box.y + from.y);
+  await page.mouse.down();
+  await page.mouse.move(box.x + to.x, box.y + to.y, { steps: 8 });
+  await page.mouse.up();
+  await page.waitForTimeout(400);
+}
+
+test.describe('Auto-registration of the Fabric `id` property', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector('[data-testid="tool-navigate"]', { timeout: 10000 });
+    // Switch to the unscoped "General" context so the local image is in scope and
+    // the rectangle tool is enabled (the default "Fracture" context is scoped to
+    // the network DZI images only).
+    await page.getByRole('combobox').selectOption({ label: 'General' });
+    // Cell 0 defaults to a network DZI; assign the local image so the overlay
+    // mounts offline. Its FabricOverlay constructor runs auto-init.
+    await assignLocalImageToActiveCell(page);
+    await page.waitForTimeout(500);
+  });
+
+  test('registers `id` automatically — no manual initFabricModule() call', async ({ page }) => {
+    // The overlay mounted on load; auto-init must have registered exactly `id`.
+    expect(await customProperties(page)).toEqual(['id']);
+  });
+
+  test('a drawn annotation serializes its id end-to-end', async ({ page }) => {
+    await drawRectangleInFirstCell(page, { x: 140, y: 120 }, { x: 320, y: 240 });
+
+    const anns = await serializedAnnotations(page);
+    expect(anns).toHaveLength(1);
+
+    const ann = anns[0]!;
+    // The id survives toObject() only because the custom property is registered.
+    expect(ann.id).toBeTruthy();
+    expect(ann.rawAnnotationData.data.id).toBe(ann.id);
+  });
+
+  test('registration stays idempotent across many overlay constructions', async ({ page }) => {
+    // Baseline: one overlay mounted, exactly one `id` entry.
+    expect(await customProperties(page)).toEqual(['id']);
+
+    // Draw in single-cell mode first so we have committed, serialized data.
+    await drawRectangleInFirstCell(page, { x: 140, y: 120 }, { x: 300, y: 230 });
+    const initial = await serializedAnnotations(page);
+    expect(initial).toHaveLength(1);
+    expect(initial[0]!.rawAnnotationData.data.id).toBe(initial[0]!.id);
+
+    // Force MANY more overlay constructions: expand to a 2x2 grid and assign the
+    // local image to all three remaining cells. Each assignment mounts a fresh
+    // ViewerCell + FabricOverlay, re-running auto-init.
+    await page.getByTestId('grid-selector-trigger').click();
+    await page.getByTestId('grid-cell-2-2').click();
+    await expect(page.getByTestId('grid-size')).toContainText('2x2');
+
+    for (let i = 0; i < 3; i++) {
+      await page.locator('text=Assign an image').first().click();
+      await assignLocalImageToActiveCell(page);
+    }
+    await page.waitForTimeout(500);
+
+    // After ≥4 overlay constructions, `customProperties` must still be exactly
+    // ['id'] — not duplicated, not cleared. That is the idempotency guarantee.
+    const props = await customProperties(page);
+    expect(props).toEqual(['id']);
+    expect(props.filter((p) => p === 'id')).toHaveLength(1);
+
+    // Existing serialized data survived all the remounts with its id intact.
+    const after = await serializedAnnotations(page);
+    expect(after.length).toBeGreaterThanOrEqual(1);
+    for (const ann of after) {
+      expect(ann.rawAnnotationData.data.id).toBe(ann.id);
+    }
+    const ids = after.map((a) => a.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});

--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -73,6 +73,7 @@ export default defineConfig({
             { label: 'Annotation Contexts', slug: 'guides/annotation-contexts' },
             { label: 'Serialization', slug: 'guides/serialization' },
             { label: 'Components', slug: 'guides/components' },
+            { label: 'React & SSR', slug: 'guides/react-and-ssr' },
             { label: 'State & Hooks', slug: 'guides/state-and-hooks' },
             { label: 'Coordinate Systems', slug: 'guides/coordinate-systems' },
             { label: 'Decorations', slug: 'guides/decorations' },

--- a/apps/docs/public/llms.txt
+++ b/apps/docs/public/llms.txt
@@ -1005,23 +1005,7 @@ It accepts any `Geometry` (`rectangle`, `circle`, `line`, `point`, `polyline`, `
 
 The static `toolTypeToGeometryType('freeHandPath')` helper returns `polyline`, but the freehand **tool** produces a closed `polygon` by default at runtime (open `polyline` only when Shift is held). When importing a freehand contour, set `geometry.type` to whichever matches your data and pass `toolType: 'freeHandPath'`.
 
-### Importing SVG paths and other shapes
-
-Because `createAnnotationFromGeometry` accepts any of the six geometry types, importing almost always reduces to mapping your source into one of them — no manual Fabric work:
-
-- **Straight-segment SVG paths** (`M` / `L` commands) → read the vertices and pass `{ type: 'polyline', points }` (open) or `{ type: 'polygon', points }` (closed).
-- **Curved SVG paths** (`C` / `Q` / `A` commands) → the geometry model has no lossless curve type, so sample the curve into points and pass them as a polygon / polyline. (`getGeometryFromFabricObject` likewise does not read Fabric `Path` objects — sampling is the supported route for curves.)
-
-```ts
-
-// points: { x: number; y: number }[] read or sampled from your SVG path's `d`
-const annotation = createAnnotationFromGeometry(
-  { type: 'polygon', points },
-  { imageId, contextId, toolType: 'freeHandPath' },
-);
-```
-
-Annotations drawn with the built-in freehand tool are already plain `polygon` (closed) or `polyline` (open) geometry — there is nothing special to handle when importing them.
+Multi-point shapes import the same way: pass `{ type: 'polyline', points }` (open) or `{ type: 'polygon', points }` (closed), where `points` is an array of image-space `{ x, y }` coordinates. Annotations drawn with the built-in freehand tool are already plain `polygon` / `polyline` geometry, so there is nothing special to handle when importing them either.
 
 ### Lower-level escape hatch
 

--- a/apps/docs/public/llms.txt
+++ b/apps/docs/public/llms.txt
@@ -97,8 +97,6 @@ The `Annotator` component provides a complete annotation interface with toolbar,
 
 ```tsx
 
-initFabricModule();
-
 function App() {
   return (
     <div style={{ width: '100vw', height: '100vh' }}>
@@ -121,6 +119,8 @@ function App() {
 
 render(() => <App />, document.getElementById('app')!);
 ```
+
+The `Annotator` registers the Fabric `id` custom property automatically when its viewer mounts, so there's no setup call to remember. (`initFabricModule()` is still exported and idempotent if you build Fabric objects yourself before any viewer exists — see [Serialization](/osdlabel/guides/serialization/).)
 
 ## 4. What you get
 

--- a/apps/docs/public/llms.txt
+++ b/apps/docs/public/llms.txt
@@ -1005,28 +1005,45 @@ It accepts any `Geometry` (`rectangle`, `circle`, `line`, `point`, `polyline`, `
 
 The static `toolTypeToGeometryType('freeHandPath')` helper returns `polyline`, but the freehand **tool** produces a closed `polygon` by default at runtime (open `polyline` only when Shift is held). When importing a freehand contour, set `geometry.type` to whichever matches your data and pass `toolType: 'freeHandPath'`.
 
-### The manual round-trip (fallback)
+### Importing SVG paths and other shapes
 
-`createAnnotationFromGeometry` covers the six built-in geometry types. If you have geometry it can't express (e.g. an arbitrary SVG `Path` — `getGeometryFromFabricObject` only reads `Rect` / `Circle` / `Line` / `Polyline` / `Polygon`), down-convert it yourself — e.g. sample a path into polygon points — and build the envelope manually:
+Because `createAnnotationFromGeometry` accepts any of the six geometry types, importing almost always reduces to mapping your source into one of them — no manual Fabric work:
+
+- **Straight-segment SVG paths** (`M` / `L` commands) → read the vertices and pass `{ type: 'polyline', points }` (open) or `{ type: 'polygon', points }` (closed).
+- **Curved SVG paths** (`C` / `Q` / `A` commands) → the geometry model has no lossless curve type, so sample the curve into points and pass them as a polygon / polyline. (`getGeometryFromFabricObject` likewise does not read Fabric `Path` objects — sampling is the supported route for curves.)
 
 ```ts
 
-  initFabricModule,
+// points: { x: number; y: number }[] read or sampled from your SVG path's `d`
+const annotation = createAnnotationFromGeometry(
+  { type: 'polygon', points },
+  { imageId, contextId, toolType: 'freeHandPath' },
+);
+```
+
+Annotations drawn with the built-in freehand tool are already plain `polygon` (closed) or `polyline` (open) geometry — there is nothing special to handle when importing them.
+
+### Lower-level escape hatch
+
+If you already hold a **Fabric object** (of a supported class) rather than raw geometry, you can build the envelope directly instead of going through `createAnnotationFromGeometry`:
+
+```ts
+
   getFabricOptions,
   serializeFabricObject,
   getGeometryFromFabricObject,
+  buildFabricObjectFromGeometry,
 } from '@osdlabel/solid';
 
-initFabricModule(); // registers the `id` custom property so it serializes — call once
+// From an existing Fabric object → annotation pieces:
+const rawAnnotationData = serializeFabricObject(obj); // envelope
+const geometry = getGeometryFromFabricObject(obj, 'polygon'); // image-space geometry
 
-// build a Fabric object yourself (e.g. new Polygon(sampledPoints, options)),
-// then: serializeFabricObject(obj) for rawAnnotationData, and
-// getGeometryFromFabricObject(obj, 'polygon') for the geometry.
+// Or the inverse — geometry → Fabric object (what createAnnotationFromGeometry uses internally):
+const fabricObject = buildFabricObjectFromGeometry(geometry, getFabricOptions(style, id));
 ```
 
-If your geometry _is_ one of the six built-in types and you only need a Fabric object (not the full annotation), `buildFabricObjectFromGeometry(geometry, getFabricOptions(style, id))` — the inverse of `getGeometryFromFabricObject`, re-exported from the umbrella — saves you hand-rolling `new Polygon(...)` / `new Rect(...)`. `createAnnotationFromGeometry` uses it internally.
-
-Calling `initFabricModule()` is what makes the annotation `id` survive `toObject()`; miss it and the `id` silently drops from the envelope. (`createAnnotationFromGeometry` handles this for you.)
+These read/produce the same five Fabric classes (`Rect` / `Circle` / `Line` / `Polyline` / `Polygon`). The annotation `id` is registered automatically when an `Annotator` mounts; if you build and serialize Fabric objects entirely outside any viewer, call `initFabricModule()` once first so the `id` survives `toObject()`. (`createAnnotationFromGeometry` guarantees this for you regardless.)
 
 ## Validation
 

--- a/apps/docs/public/llms.txt
+++ b/apps/docs/public/llms.txt
@@ -925,7 +925,7 @@ osdlabel uses a flat JSON array format for persisting annotations:
     },
     "rawAnnotationData": {
       "format": "fabric",
-      "fabricVersion": "7.2.0",
+      "fabricVersion": "7.4.0",
       "data": { ... }
     },
     "createdAt": "2026-03-06T12:00:00.000Z",
@@ -994,14 +994,14 @@ It accepts any `Geometry` (`rectangle`, `circle`, `line`, `point`, `polyline`, `
 
 `toolType` is recorded independently of `geometry.type`. For most shapes they match (`'rectangle'` ↔ `rectangle`, `'circle'` ↔ `circle`, …). The exception is freehand:
 
-| `toolType`       | Resulting `geometry.type`                          |
-| ---------------- | -------------------------------------------------- |
-| `rectangle`      | `rectangle`                                        |
-| `circle`         | `circle`                                           |
-| `line`           | `line`                                             |
-| `point`          | `point`                                            |
-| `polyline`       | `polyline`                                          |
-| `freeHandPath`   | `polygon` (closed path) or `polyline` (open path)  |
+| `toolType`     | Resulting `geometry.type`                         |
+| -------------- | ------------------------------------------------- |
+| `rectangle`    | `rectangle`                                       |
+| `circle`       | `circle`                                          |
+| `line`         | `line`                                            |
+| `point`        | `point`                                           |
+| `polyline`     | `polyline`                                        |
+| `freeHandPath` | `polygon` (closed path) or `polyline` (open path) |
 
 The static `toolTypeToGeometryType('freeHandPath')` helper returns `polyline`, but the freehand **tool** produces a closed `polygon` by default at runtime (open `polyline` only when Shift is held). When importing a freehand contour, set `geometry.type` to whichever matches your data and pass `toolType: 'freeHandPath'`.
 
@@ -1023,6 +1023,8 @@ initFabricModule(); // registers the `id` custom property so it serializes — c
 // then: serializeFabricObject(obj) for rawAnnotationData, and
 // getGeometryFromFabricObject(obj, 'polygon') for the geometry.
 ```
+
+If your geometry _is_ one of the six built-in types and you only need a Fabric object (not the full annotation), `buildFabricObjectFromGeometry(geometry, getFabricOptions(style, id))` — the inverse of `getGeometryFromFabricObject`, re-exported from the umbrella — saves you hand-rolling `new Polygon(...)` / `new Rect(...)`. `createAnnotationFromGeometry` uses it internally.
 
 Calling `initFabricModule()` is what makes the annotation `id` survive `toObject()`; miss it and the `id` silently drops from the envelope. (`createAnnotationFromGeometry` handles this for you.)
 
@@ -1492,7 +1494,9 @@ The decoration package also exports pure geometry utilities you can use to build
 
 ```ts
 function createLabelProvider<E extends object = Record<string, never>>(): DecorationProvider<E>;
-function createMeasurementProvider<E extends object = Record<string, never>>(): DecorationProvider<E>;
+function createMeasurementProvider<
+  E extends object = Record<string, never>,
+>(): DecorationProvider<E>;
 function createDistanceProvider<E extends object = Record<string, never>>(): DecorationProvider<E>;
 ```
 
@@ -1670,7 +1674,10 @@ function DeleteButton({ content }: { content: unknown }) {
 
 function DeleteButton(props: { content: unknown }) {
   const { actions } = useAnnotator();
-  const { annotationId, imageId } = props.content as { annotationId: AnnotationId; imageId: ImageId };
+  const { annotationId, imageId } = props.content as {
+    annotationId: AnnotationId;
+    imageId: ImageId;
+  };
   return (
     <button class="anno-delete" onClick={() => actions.deleteAnnotation(annotationId, imageId)}>
       ✕
@@ -1693,7 +1700,7 @@ If you emit `type: 'dom'` decorations but **don't** pass `renderDomDecoration`, 
 | Field                  | Type                       | Notes                                                                           |
 | ---------------------- | -------------------------- | ------------------------------------------------------------------------------- |
 | `id`                   | `string`                   | Stable across recomputations; also the portal key.                              |
-| `type`                 | `'dom'`                    | Discriminator.                                                                   |
+| `type`                 | `'dom'`                    | Discriminator.                                                                  |
 | `anchor`               | `Point`                    | **Image-space**. Transformed by `imageToScreen` every frame.                    |
 | `offset`               | `{ x: number; y: number }` | **Screen-space pixels** added to the anchor's screen position.                  |
 | `placement`            | `TextPlacement`            | How the host sits relative to its anchor (`'top-left'` default, `'center'`, …). |

--- a/apps/docs/public/llms.txt
+++ b/apps/docs/public/llms.txt
@@ -327,6 +327,10 @@ React annotator UI layer.
 
 For most applications, importing from the framework-specific package (`@osdlabel/solid` or `@osdlabel/react`) is the quickest way to get started. Both re-export everything from `osdlabel`.
 
+:::tip[Import rule]
+**Import every public type and value from the single umbrella package you're already using** (`@osdlabel/solid`, `@osdlabel/react`, or `osdlabel`). Commonly-needed types such as `ImageId`, `AnnotationId`, and `ImageSource` physically live in lower-level subpackages (`@osdlabel/viewer-api`, `@osdlabel/annotation`), so importing them from those paths only resolves when the subpackage is a **direct dependency** of your app. The umbrella re-exports them all — sticking to it avoids "cannot find module" errors and keeps your dependency list to one package. Reach for direct subpackage imports (below) only when you've added that subpackage as an explicit dependency for a custom UI layer.
+:::
+
 ### 1. Framework package (recommended)
 
 ```ts
@@ -959,6 +963,69 @@ actions.loadAnnotations(byImage);
 
 `deserialize()` validates the basic structure of the array and throws `SerializationError` on invalid input. For deep validation, the library integrates with Valibot in `@osdlabel/validation`.
 
+### Flat out, keyed in
+
+The two directions are intentionally **asymmetric**, and it trips people up:
+
+- **`serialize(state)` returns a flat `Annotation[]`** — and so does the `onAnnotationsChange` callback (see [below](#listening-to-changes)). That flat array **is** your persistable document; you can save the callback's argument directly without calling `serialize` yourself.
+- **`deserialize(doc)` returns a keyed `{ byImage }` map** — `Record<ImageId, Record<AnnotationId, Annotation>>` — which is the exact shape `loadAnnotations` expects for the store.
+
+So: persist the **flat** array, load it back through `deserialize` to get the **keyed** map. If you keep your own annotation list (e.g. a flat `Annotation[]` from `onAnnotationsChange`), you still pass it through `deserialize` to seed the store.
+
+## Seeding from external geometry
+
+Loading already-serialized osdlabel documents is just `deserialize` (above). The harder case is **importing annotations from another system** — you have raw geometry (a bounding box from a detector, a contour from a segmentation model, points from a CSV) but no Fabric `rawAnnotationData` envelope.
+
+Use `createAnnotationFromGeometry` — it builds the complete annotation (geometry **and** the Fabric envelope) in one call:
+
+```tsx
+
+const annotation = createAnnotationFromGeometry(
+  { type: 'rectangle', origin: { x: 120, y: 80 }, width: 200, height: 140, rotation: 0 },
+  { imageId, contextId, toolType: 'rectangle', label: 'lesion' },
+);
+
+actions.addAnnotation(annotation);
+```
+
+It accepts any `Geometry` (`rectangle`, `circle`, `line`, `point`, `polyline`, `polygon`), defaults the style to `DEFAULT_ANNOTATION_STYLE`, generates an `id` when you don't supply one, and guarantees the `id` survives serialization — so the result round-trips through `serialize` / `deserialize` like a hand-drawn annotation. To seed many at once, map over your source data and call `loadAnnotations` (or `addAnnotation` per item).
+
+### Choosing a `toolType`
+
+`toolType` is recorded independently of `geometry.type`. For most shapes they match (`'rectangle'` ↔ `rectangle`, `'circle'` ↔ `circle`, …). The exception is freehand:
+
+| `toolType`       | Resulting `geometry.type`                          |
+| ---------------- | -------------------------------------------------- |
+| `rectangle`      | `rectangle`                                        |
+| `circle`         | `circle`                                           |
+| `line`           | `line`                                             |
+| `point`          | `point`                                            |
+| `polyline`       | `polyline`                                          |
+| `freeHandPath`   | `polygon` (closed path) or `polyline` (open path)  |
+
+The static `toolTypeToGeometryType('freeHandPath')` helper returns `polyline`, but the freehand **tool** produces a closed `polygon` by default at runtime (open `polyline` only when Shift is held). When importing a freehand contour, set `geometry.type` to whichever matches your data and pass `toolType: 'freeHandPath'`.
+
+### The manual round-trip (fallback)
+
+`createAnnotationFromGeometry` covers the six built-in geometry types. If you have geometry it can't express (e.g. an arbitrary SVG `Path` — `getGeometryFromFabricObject` only reads `Rect` / `Circle` / `Line` / `Polyline` / `Polygon`), down-convert it yourself — e.g. sample a path into polygon points — and build the envelope manually:
+
+```ts
+
+  initFabricModule,
+  getFabricOptions,
+  serializeFabricObject,
+  getGeometryFromFabricObject,
+} from '@osdlabel/solid';
+
+initFabricModule(); // registers the `id` custom property so it serializes — call once
+
+// build a Fabric object yourself (e.g. new Polygon(sampledPoints, options)),
+// then: serializeFabricObject(obj) for rawAnnotationData, and
+// getGeometryFromFabricObject(obj, 'polygon') for the geometry.
+```
+
+Calling `initFabricModule()` is what makes the annotation `id` survive `toObject()`; miss it and the `id` silently drops from the envelope. (`createAnnotationFromGeometry` handles this for you.)
+
 ## Validation
 
 The library provides comprehensive Valibot schemas for annotation validation in the `@osdlabel/validation` package:
@@ -984,7 +1051,8 @@ The `onAnnotationsChange` callback fires whenever annotations are added, updated
 ```tsx
 <AnnotatorProvider
   onAnnotationsChange={(annotations) => {
-    // annotations: Annotation[] — flat list of all annotations
+    // annotations: Annotation[] — the same flat document serialize() would produce.
+    // No need to call serialize() yourself; persist this array directly.
     saveToBackend(annotations);
   }}
 >
@@ -1183,7 +1251,7 @@ Annotations are always stored in image-space pixels. The overlay's `viewportTran
 
 # Decorations
 
-**Decorations** are derived, read-only visuals that osdlabel renders on top of your annotations: per-annotation text labels, computed measurements (area, perimeter, length, radius), and connector lines between annotation pairs. They are not part of annotation state and are never serialized — they are recomputed from current state on every relevant change.
+**Decorations** are derived, read-only visuals that osdlabel renders on top of your annotations: per-annotation text labels, computed measurements (area, perimeter, length, radius), connector lines between annotation pairs, and [rich DOM overlays](#dom-decorations) rendered by your own UI framework. They are not part of annotation state and are never serialized — they are recomputed from current state on every relevant change.
 
 You drive them by passing one or more **providers** (pure functions) to `<Annotator>` via the `decorationProviders` prop. The library ships built-in providers for the common cases and lets you compose them or write your own.
 
@@ -1207,14 +1275,15 @@ interface DecorationContext<E> {
 
 The library calls your providers on every relevant change — annotation added/edited/deleted, selection changed, drag tick — and reconciles the result into the DOM and the Fabric canvas. Providers must be deterministic and side-effect-free; nothing they return is persisted.
 
-### Two render targets
+### Three render targets
 
 A `Decoration` is a discriminated union:
 
 - **`TextDecoration`** renders as an absolutely-positioned `<div>` in a host layer over the Fabric canvas. Text stays upright, crisp, and constant screen-size at any zoom / rotation / flip — there is no counter-transform math because the host layer is in screen-space, not image-space. Position is `imageToScreen(anchor) + offset` recomputed on every frame.
 - **`LineDecoration`** renders as a non-interactive Fabric `Line` on the overlay canvas, in image-space. It follows pan / zoom / rotate / flip via the existing viewport transform at zero per-frame cost. Stroke width is `strokeUniform` so dashed patterns look the same at all zooms.
+- **`DomDecoration`** renders an arbitrary component tree from _your_ UI framework — buttons, inputs, popovers, charts — into a positioned host element via the framework's native portal. Unlike `TextDecoration` (which the library renders for you as a styled `<div>`), a `DomDecoration` hands rendering back to you through the `renderDomDecoration` prop, so the tree lives inside your app's component context. See [DOM decorations](#dom-decorations) below.
 
-You don't choose the render target by hand — picking `type: 'text'` vs `type: 'line'` does it for you.
+You don't choose the render target by hand — the `type` field (`'text'` / `'line'` / `'dom'`) does it for you.
 
 ### Composition order
 
@@ -1409,13 +1478,42 @@ type DecorationProvider<E extends object = Record<string, never>> = (
 ) => readonly Decoration[];
 ```
 
-You return an array of `TextDecoration` and / or `LineDecoration` values. Three rules:
+You return an array of `TextDecoration`, `LineDecoration`, and / or `DomDecoration` values. Three rules:
 
 1. **Be pure.** No `setState`, no DOM, no network. The library may call your provider many times per second during a drag.
 2. **Use stable IDs.** Return the same `Decoration.id` across recomputations for the same logical decoration (e.g. `` `bbox:${ann.id}` ``). The renderer diffs by id — stable ids let it update DOM/Fabric in place instead of recreating nodes.
 3. **Set `relatedAnnotationIds`.** This drives lifecycle (so decorations are cleaned up when their annotations are deleted) and powers `withSelectionEmphasis`. For per-annotation decorations, it's `[ann.id]`; for relational decorations it's the participating annotation ids.
 
 The decoration package also exports pure geometry utilities you can use to build anchors and derived values: `area`, `perimeter`, `length`, `radius`, `distance`, `centroid`, `midpoint`, `boundingBox`. See [`@osdlabel/decoration`](/osdlabel/api/reference/osdlabel/) for full signatures.
+
+### Typing providers with extension fields
+
+`DecorationProvider<E>` is generic over your annotation's extension fields `E`, and so are the built-in factories:
+
+```ts
+function createLabelProvider<E extends object = Record<string, never>>(): DecorationProvider<E>;
+function createMeasurementProvider<E extends object = Record<string, never>>(): DecorationProvider<E>;
+function createDistanceProvider<E extends object = Record<string, never>>(): DecorationProvider<E>;
+```
+
+`E` **defaults to `Record<string, never>`** (no extension fields). That default is fine when a callback only touches built-in `Annotation` fields, but it will not infer your custom fields for you. **Pass the generic explicitly** whenever you read an extension field (e.g. `contextId`, or your own metadata) inside a callback, or when you assign into a `DecorationProvider<MyFields>[]`:
+
+```ts
+interface MyFields {
+  readonly contextId: AnnotationContextId;
+  readonly priority: number;
+}
+
+// ✅ pass <MyFields> so `pair` sees the extra fields
+const distances = createDistanceProvider<MyFields>({
+  pair: (annotations) =>
+    annotations
+      .filter((a) => a.priority > 0) // typed, no `String(...)` cast needed
+      .map((a, i, arr) => ({ a, b: arr[(i + 1) % arr.length]! })),
+});
+```
+
+Comparing a **branded id** (e.g. `contextId: AnnotationContextId`) against a plain string narrows cleanly with `String(...)`: `String(ann.contextId) === 'tumor'`. Prefer comparing branded-to-branded (`ann.contextId === createAnnotationContextId('tumor')`) where you have the factory in scope.
 
 ### Example: bounding-box dimensions
 
@@ -1500,6 +1598,110 @@ export const rectanglePath: DecorationProvider = ({ annotations }) => {
 | `relatedAnnotationIds` | `readonly AnnotationId[]` | Drives lifecycle and selection emphasis.                                 |
 
 A `LineDecoration` is rendered as a non-interactive Fabric `Line` on the overlay canvas. If you want users to be able to select / move / edit the line, draw a line **annotation** instead (annotations are state and serialize; decorations don't).
+
+## DOM decorations
+
+`TextDecoration` is great for plain labels, but sometimes you need a **rich, interactive overlay** anchored to an annotation — a delete button, an inline editor, a status badge, a small chart, a link into your app's routing. That's what `DomDecoration` is for: the library positions an empty host `<div>` over the image (tracking pan / zoom / rotate / flip every frame), and _your_ framework renders into it through a **portal**, so the rendered tree shares your app's context, theme, and event handlers.
+
+### The flow
+
+1. A provider returns a `Decoration` with `type: 'dom'`, an image-space `anchor`, and a framework-agnostic `content: unknown` payload (treated as stable configuration / identity).
+2. The library creates and positions the host element and emits an entry `{ id, element, decoration }`.
+3. You pass a `renderDomDecoration` render-prop to `<Annotator>` (or `<AnnotatorProvider>`); the framework portals its return value into the host element, keyed by the decoration `id`.
+
+`content` is _configuration_, not per-frame data. Dynamic values (a live count, a selection flag) should flow through your app's own reactivity inside the rendered component, not through `content` changing every frame — keeping `content` stable lets the renderer reuse DOM in place.
+
+### Provider side (framework-agnostic)
+
+```ts
+
+// Typed with the imageId extension field so the payload can carry it
+// (see "Typing providers with extension fields" above).
+export const deleteButtons: DecorationProvider<{ imageId: ImageId }> = ({ annotations }) => {
+  const out: DomDecoration[] = [];
+  for (const ann of annotations) {
+    const { min, max } = boundingBox(ann.geometry);
+    out.push({
+      id: `delete-btn:${ann.id}`,
+      type: 'dom',
+      relatedAnnotationIds: [ann.id],
+      anchor: { x: max.x, y: min.y }, // top-right corner, image-space
+      offset: { x: 4, y: -4 }, // screen-space nudge
+      placement: 'left',
+      content: { annotationId: ann.id, imageId: ann.imageId }, // stable config the render-prop reads
+      style: { pointerEvents: 'auto', zIndex: 20 },
+    });
+  }
+  return out;
+};
+```
+
+### Render side
+
+The render-prop receives the full `DomDecoration` (read your payload off `decoration.content`) and returns a framework node.
+
+The render-prop runs inside the annotator's component tree, so the rendered component can call `useAnnotator()` to reach state and actions.
+
+**React** — returns a `ReactNode`, portalled via `createPortal`:
+
+```tsx
+
+function DeleteButton({ content }: { content: unknown }) {
+  const { actions } = useAnnotator();
+  const { annotationId, imageId } = content as { annotationId: AnnotationId; imageId: ImageId };
+  return (
+    <button className="anno-delete" onClick={() => actions.deleteAnnotation(annotationId, imageId)}>
+      ✕
+    </button>
+  );
+}
+
+<Annotator
+  images={images}
+  contexts={contexts}
+  decorationProviders={[deleteButtons]}
+  renderDomDecoration={(decoration) => <DeleteButton content={decoration.content} />}
+/>;
+```
+
+**Solid** — returns a `JSX.Element`, portalled via `<Portal>`:
+
+```tsx
+
+function DeleteButton(props: { content: unknown }) {
+  const { actions } = useAnnotator();
+  const { annotationId, imageId } = props.content as { annotationId: AnnotationId; imageId: ImageId };
+  return (
+    <button class="anno-delete" onClick={() => actions.deleteAnnotation(annotationId, imageId)}>
+      ✕
+    </button>
+  );
+}
+
+<Annotator
+  images={images}
+  contexts={contexts}
+  decorationProviders={[deleteButtons]}
+  renderDomDecoration={(decoration) => <DeleteButton content={decoration.content} />}
+/>;
+```
+
+If you emit `type: 'dom'` decorations but **don't** pass `renderDomDecoration`, the host elements are positioned but stay empty — the library never guesses how to render your `content`.
+
+### DomDecoration anatomy
+
+| Field                  | Type                       | Notes                                                                           |
+| ---------------------- | -------------------------- | ------------------------------------------------------------------------------- |
+| `id`                   | `string`                   | Stable across recomputations; also the portal key.                              |
+| `type`                 | `'dom'`                    | Discriminator.                                                                   |
+| `anchor`               | `Point`                    | **Image-space**. Transformed by `imageToScreen` every frame.                    |
+| `offset`               | `{ x: number; y: number }` | **Screen-space pixels** added to the anchor's screen position.                  |
+| `placement`            | `TextPlacement`            | How the host sits relative to its anchor (`'top-left'` default, `'center'`, …). |
+| `content`              | `unknown`                  | Stable config the render-prop interprets. Not per-frame data.                   |
+| `style`                | `DomDecorationStyle`       | See below.                                                                      |
+| `relatedAnnotationIds` | `readonly AnnotationId[]`  | Drives lifecycle and selection emphasis.                                        |
+
+**`DomDecorationStyle` fields:** `className`, `zIndex`, `width` / `height` (fixed screen-px, otherwise sizes to content), and `pointerEvents` — defaults to `'auto'` so content is interactive; set `'none'` for purely-visual overlays that should let clicks fall through to the canvas.
 
 ## Live updates during drag
 

--- a/apps/docs/src/content/docs/getting-started/quick-start.mdx
+++ b/apps/docs/src/content/docs/getting-started/quick-start.mdx
@@ -62,9 +62,6 @@ The `Annotator` component provides a complete annotation interface with toolbar,
 ```tsx
 import { render } from 'solid-js/web';
 import { Annotator } from '@osdlabel/solid';
-import { initFabricModule } from '@osdlabel/solid';
-
-initFabricModule();
 
 function App() {
   return (
@@ -88,6 +85,8 @@ function App() {
 
 render(() => <App />, document.getElementById('app')!);
 ```
+
+The `Annotator` registers the Fabric `id` custom property automatically when its viewer mounts, so there's no setup call to remember. (`initFabricModule()` is still exported and idempotent if you build Fabric objects yourself before any viewer exists — see [Serialization](/osdlabel/guides/serialization/).)
 
 ## 4. What you get
 

--- a/apps/docs/src/content/docs/guides/decorations.mdx
+++ b/apps/docs/src/content/docs/guides/decorations.mdx
@@ -3,7 +3,7 @@ title: Decorations
 description: Derived visual overlays — labels, measurements, and connectors — driven by pure providers
 ---
 
-**Decorations** are derived, read-only visuals that osdlabel renders on top of your annotations: per-annotation text labels, computed measurements (area, perimeter, length, radius), and connector lines between annotation pairs. They are not part of annotation state and are never serialized — they are recomputed from current state on every relevant change.
+**Decorations** are derived, read-only visuals that osdlabel renders on top of your annotations: per-annotation text labels, computed measurements (area, perimeter, length, radius), connector lines between annotation pairs, and [rich DOM overlays](#dom-decorations) rendered by your own UI framework. They are not part of annotation state and are never serialized — they are recomputed from current state on every relevant change.
 
 You drive them by passing one or more **providers** (pure functions) to `<Annotator>` via the `decorationProviders` prop. The library ships built-in providers for the common cases and lets you compose them or write your own.
 
@@ -27,14 +27,15 @@ interface DecorationContext<E> {
 
 The library calls your providers on every relevant change — annotation added/edited/deleted, selection changed, drag tick — and reconciles the result into the DOM and the Fabric canvas. Providers must be deterministic and side-effect-free; nothing they return is persisted.
 
-### Two render targets
+### Three render targets
 
 A `Decoration` is a discriminated union:
 
 - **`TextDecoration`** renders as an absolutely-positioned `<div>` in a host layer over the Fabric canvas. Text stays upright, crisp, and constant screen-size at any zoom / rotation / flip — there is no counter-transform math because the host layer is in screen-space, not image-space. Position is `imageToScreen(anchor) + offset` recomputed on every frame.
 - **`LineDecoration`** renders as a non-interactive Fabric `Line` on the overlay canvas, in image-space. It follows pan / zoom / rotate / flip via the existing viewport transform at zero per-frame cost. Stroke width is `strokeUniform` so dashed patterns look the same at all zooms.
+- **`DomDecoration`** renders an arbitrary component tree from _your_ UI framework — buttons, inputs, popovers, charts — into a positioned host element via the framework's native portal. Unlike `TextDecoration` (which the library renders for you as a styled `<div>`), a `DomDecoration` hands rendering back to you through the `renderDomDecoration` prop, so the tree lives inside your app's component context. See [DOM decorations](#dom-decorations) below.
 
-You don't choose the render target by hand — picking `type: 'text'` vs `type: 'line'` does it for you.
+You don't choose the render target by hand — the `type` field (`'text'` / `'line'` / `'dom'`) does it for you.
 
 ### Composition order
 
@@ -236,13 +237,44 @@ type DecorationProvider<E extends object = Record<string, never>> = (
 ) => readonly Decoration[];
 ```
 
-You return an array of `TextDecoration` and / or `LineDecoration` values. Three rules:
+You return an array of `TextDecoration`, `LineDecoration`, and / or `DomDecoration` values. Three rules:
 
 1. **Be pure.** No `setState`, no DOM, no network. The library may call your provider many times per second during a drag.
 2. **Use stable IDs.** Return the same `Decoration.id` across recomputations for the same logical decoration (e.g. `` `bbox:${ann.id}` ``). The renderer diffs by id — stable ids let it update DOM/Fabric in place instead of recreating nodes.
 3. **Set `relatedAnnotationIds`.** This drives lifecycle (so decorations are cleaned up when their annotations are deleted) and powers `withSelectionEmphasis`. For per-annotation decorations, it's `[ann.id]`; for relational decorations it's the participating annotation ids.
 
 The decoration package also exports pure geometry utilities you can use to build anchors and derived values: `area`, `perimeter`, `length`, `radius`, `distance`, `centroid`, `midpoint`, `boundingBox`. See [`@osdlabel/decoration`](/osdlabel/api/reference/osdlabel/) for full signatures.
+
+### Typing providers with extension fields
+
+`DecorationProvider<E>` is generic over your annotation's extension fields `E`, and so are the built-in factories:
+
+```ts
+function createLabelProvider<E extends object = Record<string, never>>(): DecorationProvider<E>;
+function createMeasurementProvider<
+  E extends object = Record<string, never>,
+>(): DecorationProvider<E>;
+function createDistanceProvider<E extends object = Record<string, never>>(): DecorationProvider<E>;
+```
+
+`E` **defaults to `Record<string, never>`** (no extension fields). That default is fine when a callback only touches built-in `Annotation` fields, but it will not infer your custom fields for you. **Pass the generic explicitly** whenever you read an extension field (e.g. `contextId`, or your own metadata) inside a callback, or when you assign into a `DecorationProvider<MyFields>[]`:
+
+```ts
+interface MyFields {
+  readonly contextId: AnnotationContextId;
+  readonly priority: number;
+}
+
+// ✅ pass <MyFields> so `pair` sees the extra fields
+const distances = createDistanceProvider<MyFields>({
+  pair: (annotations) =>
+    annotations
+      .filter((a) => a.priority > 0) // typed, no `String(...)` cast needed
+      .map((a, i, arr) => ({ a, b: arr[(i + 1) % arr.length]! })),
+});
+```
+
+Comparing a **branded id** (e.g. `contextId: AnnotationContextId`) against a plain string narrows cleanly with `String(...)`: `String(ann.contextId) === 'tumor'`. Prefer comparing branded-to-branded (`ann.contextId === createAnnotationContextId('tumor')`) where you have the factory in scope.
 
 ### Example: bounding-box dimensions
 
@@ -331,6 +363,120 @@ export const rectanglePath: DecorationProvider = ({ annotations }) => {
 | `relatedAnnotationIds` | `readonly AnnotationId[]` | Drives lifecycle and selection emphasis.                                 |
 
 A `LineDecoration` is rendered as a non-interactive Fabric `Line` on the overlay canvas. If you want users to be able to select / move / edit the line, draw a line **annotation** instead (annotations are state and serialize; decorations don't).
+
+## DOM decorations
+
+`TextDecoration` is great for plain labels, but sometimes you need a **rich, interactive overlay** anchored to an annotation — a delete button, an inline editor, a status badge, a small chart, a link into your app's routing. That's what `DomDecoration` is for: the library positions an empty host `<div>` over the image (tracking pan / zoom / rotate / flip every frame), and _your_ framework renders into it through a **portal**, so the rendered tree shares your app's context, theme, and event handlers.
+
+### The flow
+
+1. A provider returns a `Decoration` with `type: 'dom'`, an image-space `anchor`, and a framework-agnostic `content: unknown` payload (treated as stable configuration / identity).
+2. The library creates and positions the host element and emits an entry `{ id, element, decoration }`.
+3. You pass a `renderDomDecoration` render-prop to `<Annotator>` (or `<AnnotatorProvider>`); the framework portals its return value into the host element, keyed by the decoration `id`.
+
+`content` is _configuration_, not per-frame data. Dynamic values (a live count, a selection flag) should flow through your app's own reactivity inside the rendered component, not through `content` changing every frame — keeping `content` stable lets the renderer reuse DOM in place.
+
+### Provider side (framework-agnostic)
+
+```ts
+import type { DecorationProvider, DomDecoration } from '@osdlabel/solid'; // or '@osdlabel/react'
+import type { ImageId } from '@osdlabel/solid';
+import { boundingBox } from '@osdlabel/solid';
+
+// Typed with the imageId extension field so the payload can carry it
+// (see "Typing providers with extension fields" above).
+export const deleteButtons: DecorationProvider<{ imageId: ImageId }> = ({ annotations }) => {
+  const out: DomDecoration[] = [];
+  for (const ann of annotations) {
+    const { min, max } = boundingBox(ann.geometry);
+    out.push({
+      id: `delete-btn:${ann.id}`,
+      type: 'dom',
+      relatedAnnotationIds: [ann.id],
+      anchor: { x: max.x, y: min.y }, // top-right corner, image-space
+      offset: { x: 4, y: -4 }, // screen-space nudge
+      placement: 'left',
+      content: { annotationId: ann.id, imageId: ann.imageId }, // stable config the render-prop reads
+      style: { pointerEvents: 'auto', zIndex: 20 },
+    });
+  }
+  return out;
+};
+```
+
+### Render side
+
+The render-prop receives the full `DomDecoration` (read your payload off `decoration.content`) and returns a framework node.
+
+The render-prop runs inside the annotator's component tree, so the rendered component can call `useAnnotator()` to reach state and actions.
+
+**React** — returns a `ReactNode`, portalled via `createPortal`:
+
+```tsx
+import { Annotator, useAnnotator } from '@osdlabel/react';
+import type { AnnotationId, ImageId } from '@osdlabel/react';
+
+function DeleteButton({ content }: { content: unknown }) {
+  const { actions } = useAnnotator();
+  const { annotationId, imageId } = content as { annotationId: AnnotationId; imageId: ImageId };
+  return (
+    <button className="anno-delete" onClick={() => actions.deleteAnnotation(annotationId, imageId)}>
+      ✕
+    </button>
+  );
+}
+
+<Annotator
+  images={images}
+  contexts={contexts}
+  decorationProviders={[deleteButtons]}
+  renderDomDecoration={(decoration) => <DeleteButton content={decoration.content} />}
+/>;
+```
+
+**Solid** — returns a `JSX.Element`, portalled via `<Portal>`:
+
+```tsx
+import { Annotator, useAnnotator } from '@osdlabel/solid';
+import type { AnnotationId, ImageId } from '@osdlabel/solid';
+
+function DeleteButton(props: { content: unknown }) {
+  const { actions } = useAnnotator();
+  const { annotationId, imageId } = props.content as {
+    annotationId: AnnotationId;
+    imageId: ImageId;
+  };
+  return (
+    <button class="anno-delete" onClick={() => actions.deleteAnnotation(annotationId, imageId)}>
+      ✕
+    </button>
+  );
+}
+
+<Annotator
+  images={images}
+  contexts={contexts}
+  decorationProviders={[deleteButtons]}
+  renderDomDecoration={(decoration) => <DeleteButton content={decoration.content} />}
+/>;
+```
+
+If you emit `type: 'dom'` decorations but **don't** pass `renderDomDecoration`, the host elements are positioned but stay empty — the library never guesses how to render your `content`.
+
+### DomDecoration anatomy
+
+| Field                  | Type                       | Notes                                                                           |
+| ---------------------- | -------------------------- | ------------------------------------------------------------------------------- |
+| `id`                   | `string`                   | Stable across recomputations; also the portal key.                              |
+| `type`                 | `'dom'`                    | Discriminator.                                                                  |
+| `anchor`               | `Point`                    | **Image-space**. Transformed by `imageToScreen` every frame.                    |
+| `offset`               | `{ x: number; y: number }` | **Screen-space pixels** added to the anchor's screen position.                  |
+| `placement`            | `TextPlacement`            | How the host sits relative to its anchor (`'top-left'` default, `'center'`, …). |
+| `content`              | `unknown`                  | Stable config the render-prop interprets. Not per-frame data.                   |
+| `style`                | `DomDecorationStyle`       | See below.                                                                      |
+| `relatedAnnotationIds` | `readonly AnnotationId[]`  | Drives lifecycle and selection emphasis.                                        |
+
+**`DomDecorationStyle` fields:** `className`, `zIndex`, `width` / `height` (fixed screen-px, otherwise sizes to content), and `pointerEvents` — defaults to `'auto'` so content is interactive; set `'none'` for purely-visual overlays that should let clicks fall through to the canvas.
 
 ## Live updates during drag
 

--- a/apps/docs/src/content/docs/guides/packages-and-architecture.mdx
+++ b/apps/docs/src/content/docs/guides/packages-and-architecture.mdx
@@ -89,6 +89,10 @@ React annotator UI layer.
 
 For most applications, importing from the framework-specific package (`@osdlabel/solid` or `@osdlabel/react`) is the quickest way to get started. Both re-export everything from `osdlabel`.
 
+:::tip[Import rule]
+**Import every public type and value from the single umbrella package you're already using** (`@osdlabel/solid`, `@osdlabel/react`, or `osdlabel`). Commonly-needed types such as `ImageId`, `AnnotationId`, and `ImageSource` physically live in lower-level subpackages (`@osdlabel/viewer-api`, `@osdlabel/annotation`), so importing them from those paths only resolves when the subpackage is a **direct dependency** of your app. The umbrella re-exports them all — sticking to it avoids "cannot find module" errors and keeps your dependency list to one package. Reach for direct subpackage imports (below) only when you've added that subpackage as an explicit dependency for a custom UI layer.
+:::
+
 ### 1. Framework package (recommended)
 
 ```ts

--- a/apps/docs/src/content/docs/guides/react-and-ssr.mdx
+++ b/apps/docs/src/content/docs/guides/react-and-ssr.mdx
@@ -3,7 +3,7 @@ title: React & SSR
 description: Using @osdlabel/react, and mounting the annotator client-only under Next.js / Remix
 ---
 
-Most guides on this site use `@osdlabel/solid` because the API is identical across bindings. This guide collects the parts that are **React-specific** or that bite when you render on a server: where to call `initFabricModule()`, `Annotator` vs `AnnotatorProvider`, the `renderDomDecoration` prop, and how to mount client-only under SSR frameworks.
+Most guides on this site use `@osdlabel/solid` because the API is identical across bindings. This guide collects the parts that are **React-specific** or that bite when you render on a server: `Annotator` vs `AnnotatorProvider`, the `renderDomDecoration` prop, and how to mount client-only under SSR frameworks.
 
 ## React parity
 
@@ -29,13 +29,9 @@ The end-to-end shape (the React counterpart of the [Quick Start](/osdlabel/getti
 
 ```tsx
 import { createRoot } from 'react-dom/client';
-import { Annotator, initFabricModule } from '@osdlabel/react';
+import { Annotator } from '@osdlabel/react';
 import { createImageId, createAnnotationContextId } from '@osdlabel/react';
 import type { ImageSource, AnnotationContext } from '@osdlabel/react';
-
-// Call once, before the first Annotator mounts. Registers the Fabric `id`
-// custom property so annotations serialize correctly. Idempotent.
-initFabricModule();
 
 const images: ImageSource[] = [
   {
@@ -106,8 +102,9 @@ osdlabel is **ESM-only** and touches `window`, Fabric, and OpenSeadragon **at im
 The rules:
 
 1. **Never import `@osdlabel/react` into a module that runs on the server.** Isolate it behind a dynamic, client-only boundary.
-2. **Call `initFabricModule()` on the client only** — at the top of the client-only module, or in a mount effect. Never at the top of a file the server imports.
-3. Treat the annotator as a leaf you load lazily after hydration.
+2. Treat the annotator as a leaf you load lazily after hydration.
+
+(Fabric `id` registration is automatic — the `Annotator` handles it on mount, on the client, so there's no setup call to place carefully.)
 
 ### Next.js (App Router)
 
@@ -117,10 +114,8 @@ Put the annotator in its own Client Component and load it with `next/dynamic` + 
 // AnnotatorClient.tsx
 'use client';
 
-import { Annotator, initFabricModule } from '@osdlabel/react';
+import { Annotator } from '@osdlabel/react';
 import type { ImageSource, AnnotationContext } from '@osdlabel/react';
-
-initFabricModule(); // runs only on the client because this module is never server-imported
 
 export default function AnnotatorClient(props: {
   images: ImageSource[];

--- a/apps/docs/src/content/docs/guides/react-and-ssr.mdx
+++ b/apps/docs/src/content/docs/guides/react-and-ssr.mdx
@@ -118,10 +118,14 @@ Put the annotator in its own Client Component and load it with `next/dynamic` + 
 'use client';
 
 import { Annotator, initFabricModule } from '@osdlabel/react';
+import type { ImageSource, AnnotationContext } from '@osdlabel/react';
 
 initFabricModule(); // runs only on the client because this module is never server-imported
 
-export default function AnnotatorClient(props: { images; contexts }) {
+export default function AnnotatorClient(props: {
+  images: ImageSource[];
+  contexts: AnnotationContext[];
+}) {
   return <Annotator images={props.images} contexts={props.contexts} />;
 }
 ```

--- a/apps/docs/src/content/docs/guides/react-and-ssr.mdx
+++ b/apps/docs/src/content/docs/guides/react-and-ssr.mdx
@@ -1,0 +1,171 @@
+---
+title: React & SSR
+description: Using @osdlabel/react, and mounting the annotator client-only under Next.js / Remix
+---
+
+Most guides on this site use `@osdlabel/solid` because the API is identical across bindings. This guide collects the parts that are **React-specific** or that bite when you render on a server: where to call `initFabricModule()`, `Annotator` vs `AnnotatorProvider`, the `renderDomDecoration` prop, and how to mount client-only under SSR frameworks.
+
+## React parity
+
+`@osdlabel/react` mirrors `@osdlabel/solid` symbol-for-symbol — same `Annotator`, `AnnotatorProvider`, `useAnnotator`, the same `createImageId` / `createAnnotationContextId` factories, the same `serialize` / `deserialize` / `createAnnotationFromGeometry`. The package also re-exports everything from the framework-agnostic `osdlabel` core, so you import from one place:
+
+```tsx
+import {
+  Annotator,
+  AnnotatorProvider,
+  useAnnotator,
+  createImageId,
+  createAnnotationContextId,
+  initFabricModule,
+} from '@osdlabel/react';
+import type { ImageSource, AnnotationContext } from '@osdlabel/react';
+```
+
+> **Import rule:** import every public type and value from the umbrella package you're already using (`@osdlabel/react`, `@osdlabel/solid`, or `osdlabel`). Types like `ImageId`, `AnnotationId`, and `ImageSource` physically live in lower-level subpackages (`@osdlabel/viewer-api`, `@osdlabel/annotation`), and importing them from those paths only works if they're direct dependencies of your app. The umbrella re-exports them all. See [Packages & Architecture](/osdlabel/guides/packages-and-architecture/).
+
+## A complete React example
+
+The end-to-end shape (the React counterpart of the [Quick Start](/osdlabel/getting-started/quick-start/)):
+
+```tsx
+import { createRoot } from 'react-dom/client';
+import { Annotator, initFabricModule } from '@osdlabel/react';
+import { createImageId, createAnnotationContextId } from '@osdlabel/react';
+import type { ImageSource, AnnotationContext } from '@osdlabel/react';
+
+// Call once, before the first Annotator mounts. Registers the Fabric `id`
+// custom property so annotations serialize correctly. Idempotent.
+initFabricModule();
+
+const images: ImageSource[] = [
+  {
+    id: createImageId('sample-1'),
+    tileSource: 'https://openseadragon.github.io/example-images/highsmith/highsmith.dzi',
+    label: 'Highsmith',
+  },
+];
+
+const contexts: AnnotationContext[] = [
+  {
+    id: createAnnotationContextId('default'),
+    label: 'Default',
+    tools: [{ type: 'rectangle' }, { type: 'circle' }, { type: 'point' }],
+  },
+];
+
+function App() {
+  return (
+    <div style={{ width: '100vw', height: '100vh' }}>
+      <Annotator
+        images={images}
+        contexts={contexts}
+        showFilmstrip
+        showViewControls
+        onAnnotationsChange={(annotations) => {
+          // flat Annotation[] — persist directly (see Serialization guide)
+          console.log('Annotations:', annotations.length);
+        }}
+      />
+    </div>
+  );
+}
+
+createRoot(document.getElementById('app')!).render(<App />);
+```
+
+The only mechanical differences from the Solid examples: `createRoot(...).render(<App />)` instead of Solid's `render(() => <App />, el)`, and JSX `className` / `style={{ ... }}` conventions.
+
+## `Annotator` vs `AnnotatorProvider`
+
+Two ways to mount, same underlying state:
+
+- **`<Annotator>`** — the batteries-included layout: toolbar, grid, filmstrip, status bar, view controls. Reach for this first. It accepts every `AnnotatorProvider` prop (it extends them) plus layout flags like `showFilmstrip`.
+- **`<AnnotatorProvider>`** — just the state/context, no chrome. Wrap your own tree and compose individual components (`Toolbar`, `GridView`, `ViewerCell`, …) yourself, reading state via `useAnnotator()`. Use this when you need a custom layout.
+
+Both take `images`, `contexts`, `decorationProviders`, `onAnnotationsChange`, `renderDomDecoration`, etc. Picking one is purely about whether you want the default layout.
+
+## Rich DOM decorations
+
+The `renderDomDecoration` prop lets a provider emit interactive overlays (buttons, popovers, inline editors) anchored to annotations, rendered by React through `createPortal`. In React it returns a `ReactNode`:
+
+```tsx
+<Annotator
+  images={images}
+  contexts={contexts}
+  decorationProviders={[deleteButtons]}
+  renderDomDecoration={(decoration) => <DeleteButton content={decoration.content} />}
+/>
+```
+
+The full provider + render-prop flow (and the Solid equivalent) is in the [Decorations guide → DOM decorations](/osdlabel/guides/decorations/#dom-decorations).
+
+## Server-side rendering (Next.js, Remix, …)
+
+osdlabel is **ESM-only** and touches `window`, Fabric, and OpenSeadragon **at import time**. It cannot run during server rendering — importing it on the server throws (`window is not defined`). Mount it **client-only**.
+
+The rules:
+
+1. **Never import `@osdlabel/react` into a module that runs on the server.** Isolate it behind a dynamic, client-only boundary.
+2. **Call `initFabricModule()` on the client only** — at the top of the client-only module, or in a mount effect. Never at the top of a file the server imports.
+3. Treat the annotator as a leaf you load lazily after hydration.
+
+### Next.js (App Router)
+
+Put the annotator in its own Client Component and load it with `next/dynamic` + `ssr: false`:
+
+```tsx
+// AnnotatorClient.tsx
+'use client';
+
+import { Annotator, initFabricModule } from '@osdlabel/react';
+
+initFabricModule(); // runs only on the client because this module is never server-imported
+
+export default function AnnotatorClient(props: { images; contexts }) {
+  return <Annotator images={props.images} contexts={props.contexts} />;
+}
+```
+
+```tsx
+// page.tsx (Server Component)
+import dynamic from 'next/dynamic';
+
+const AnnotatorClient = dynamic(() => import('./AnnotatorClient'), { ssr: false });
+
+export default function Page() {
+  return <AnnotatorClient images={images} contexts={contexts} />;
+}
+```
+
+`ssr: false` guarantees the module is only evaluated in the browser, so the import-time `window` access never runs on the server.
+
+### Remix / React Router
+
+There is no `ssr: false` for a route, so gate rendering on the client with a mounted flag and a lazy import:
+
+```tsx
+import { lazy, Suspense, useEffect, useState } from 'react';
+
+const AnnotatorClient = lazy(() => import('./AnnotatorClient'));
+
+export default function Route() {
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+  if (!mounted) return null; // skip on the server and the first (hydration) render
+  return (
+    <Suspense fallback={null}>
+      <AnnotatorClient images={images} contexts={contexts} />
+    </Suspense>
+  );
+}
+```
+
+Returning `null` until mounted keeps the server render and the first client render identical (no hydration mismatch), then swaps in the lazily-imported annotator once you're safely in the browser.
+
+## See also
+
+- [Quick Start](/osdlabel/getting-started/quick-start/) — the Solid walkthrough this mirrors
+- [Components](/osdlabel/guides/components/) — `Annotator` / `AnnotatorProvider` prop reference
+- [Decorations](/osdlabel/guides/decorations/#dom-decorations) — the `renderDomDecoration` flow
+- [Serialization](/osdlabel/guides/serialization/) — persisting and seeding annotations
+- [Packages & Architecture](/osdlabel/guides/packages-and-architecture/) — the import rule in full

--- a/apps/docs/src/content/docs/guides/serialization.mdx
+++ b/apps/docs/src/content/docs/guides/serialization.mdx
@@ -111,24 +111,7 @@ It accepts any `Geometry` (`rectangle`, `circle`, `line`, `point`, `polyline`, `
 
 The static `toolTypeToGeometryType('freeHandPath')` helper returns `polyline`, but the freehand **tool** produces a closed `polygon` by default at runtime (open `polyline` only when Shift is held). When importing a freehand contour, set `geometry.type` to whichever matches your data and pass `toolType: 'freeHandPath'`.
 
-### Importing SVG paths and other shapes
-
-Because `createAnnotationFromGeometry` accepts any of the six geometry types, importing almost always reduces to mapping your source into one of them — no manual Fabric work:
-
-- **Straight-segment SVG paths** (`M` / `L` commands) → read the vertices and pass `{ type: 'polyline', points }` (open) or `{ type: 'polygon', points }` (closed).
-- **Curved SVG paths** (`C` / `Q` / `A` commands) → the geometry model has no lossless curve type, so sample the curve into points and pass them as a polygon / polyline. (`getGeometryFromFabricObject` likewise does not read Fabric `Path` objects — sampling is the supported route for curves.)
-
-```ts
-import { createAnnotationFromGeometry } from '@osdlabel/solid';
-
-// points: { x: number; y: number }[] read or sampled from your SVG path's `d`
-const annotation = createAnnotationFromGeometry(
-  { type: 'polygon', points },
-  { imageId, contextId, toolType: 'freeHandPath' },
-);
-```
-
-Annotations drawn with the built-in freehand tool are already plain `polygon` (closed) or `polyline` (open) geometry — there is nothing special to handle when importing them.
+Multi-point shapes import the same way: pass `{ type: 'polyline', points }` (open) or `{ type: 'polygon', points }` (closed), where `points` is an array of image-space `{ x, y }` coordinates. Annotations drawn with the built-in freehand tool are already plain `polygon` / `polyline` geometry, so there is nothing special to handle when importing them either.
 
 ### Lower-level escape hatch
 

--- a/apps/docs/src/content/docs/guides/serialization.mdx
+++ b/apps/docs/src/content/docs/guides/serialization.mdx
@@ -68,6 +68,70 @@ actions.loadAnnotations(byImage);
 
 `deserialize()` validates the basic structure of the array and throws `SerializationError` on invalid input. For deep validation, the library integrates with Valibot in `@osdlabel/validation`.
 
+### Flat out, keyed in
+
+The two directions are intentionally **asymmetric**, and it trips people up:
+
+- **`serialize(state)` returns a flat `Annotation[]`** — and so does the `onAnnotationsChange` callback (see [below](#listening-to-changes)). That flat array **is** your persistable document; you can save the callback's argument directly without calling `serialize` yourself.
+- **`deserialize(doc)` returns a keyed `{ byImage }` map** — `Record<ImageId, Record<AnnotationId, Annotation>>` — which is the exact shape `loadAnnotations` expects for the store.
+
+So: persist the **flat** array, load it back through `deserialize` to get the **keyed** map. If you keep your own annotation list (e.g. a flat `Annotation[]` from `onAnnotationsChange`), you still pass it through `deserialize` to seed the store.
+
+## Seeding from external geometry
+
+Loading already-serialized osdlabel documents is just `deserialize` (above). The harder case is **importing annotations from another system** — you have raw geometry (a bounding box from a detector, a contour from a segmentation model, points from a CSV) but no Fabric `rawAnnotationData` envelope.
+
+Use `createAnnotationFromGeometry` — it builds the complete annotation (geometry **and** the Fabric envelope) in one call:
+
+```tsx
+import { createAnnotationFromGeometry } from '@osdlabel/solid'; // or '@osdlabel/react'
+
+const annotation = createAnnotationFromGeometry(
+  { type: 'rectangle', origin: { x: 120, y: 80 }, width: 200, height: 140, rotation: 0 },
+  { imageId, contextId, toolType: 'rectangle', label: 'lesion' },
+);
+
+actions.addAnnotation(annotation);
+```
+
+It accepts any `Geometry` (`rectangle`, `circle`, `line`, `point`, `polyline`, `polygon`), defaults the style to `DEFAULT_ANNOTATION_STYLE`, generates an `id` when you don't supply one, and guarantees the `id` survives serialization — so the result round-trips through `serialize` / `deserialize` like a hand-drawn annotation. To seed many at once, map over your source data and call `loadAnnotations` (or `addAnnotation` per item).
+
+### Choosing a `toolType`
+
+`toolType` is recorded independently of `geometry.type`. For most shapes they match (`'rectangle'` ↔ `rectangle`, `'circle'` ↔ `circle`, …). The exception is freehand:
+
+| `toolType`     | Resulting `geometry.type`                         |
+| -------------- | ------------------------------------------------- |
+| `rectangle`    | `rectangle`                                       |
+| `circle`       | `circle`                                          |
+| `line`         | `line`                                            |
+| `point`        | `point`                                           |
+| `polyline`     | `polyline`                                        |
+| `freeHandPath` | `polygon` (closed path) or `polyline` (open path) |
+
+The static `toolTypeToGeometryType('freeHandPath')` helper returns `polyline`, but the freehand **tool** produces a closed `polygon` by default at runtime (open `polyline` only when Shift is held). When importing a freehand contour, set `geometry.type` to whichever matches your data and pass `toolType: 'freeHandPath'`.
+
+### The manual round-trip (fallback)
+
+`createAnnotationFromGeometry` covers the six built-in geometry types. If you have geometry it can't express (e.g. an arbitrary SVG `Path` — `getGeometryFromFabricObject` only reads `Rect` / `Circle` / `Line` / `Polyline` / `Polygon`), down-convert it yourself — e.g. sample a path into polygon points — and build the envelope manually:
+
+```ts
+import {
+  initFabricModule,
+  getFabricOptions,
+  serializeFabricObject,
+  getGeometryFromFabricObject,
+} from '@osdlabel/solid';
+
+initFabricModule(); // registers the `id` custom property so it serializes — call once
+
+// build a Fabric object yourself (e.g. new Polygon(sampledPoints, options)),
+// then: serializeFabricObject(obj) for rawAnnotationData, and
+// getGeometryFromFabricObject(obj, 'polygon') for the geometry.
+```
+
+Calling `initFabricModule()` is what makes the annotation `id` survive `toObject()`; miss it and the `id` silently drops from the envelope. (`createAnnotationFromGeometry` handles this for you.)
+
 ## Validation
 
 The library provides comprehensive Valibot schemas for annotation validation in the `@osdlabel/validation` package:
@@ -95,7 +159,8 @@ The `onAnnotationsChange` callback fires whenever annotations are added, updated
 ```tsx
 <AnnotatorProvider
   onAnnotationsChange={(annotations) => {
-    // annotations: Annotation[] — flat list of all annotations
+    // annotations: Annotation[] — the same flat document serialize() would produce.
+    // No need to call serialize() yourself; persist this array directly.
     saveToBackend(annotations);
   }}
 >

--- a/apps/docs/src/content/docs/guides/serialization.mdx
+++ b/apps/docs/src/content/docs/guides/serialization.mdx
@@ -28,7 +28,7 @@ osdlabel uses a flat JSON array format for persisting annotations:
     },
     "rawAnnotationData": {
       "format": "fabric",
-      "fabricVersion": "7.2.0",
+      "fabricVersion": "7.4.0",
       "data": { ... }
     },
     "createdAt": "2026-03-06T12:00:00.000Z",
@@ -129,6 +129,8 @@ initFabricModule(); // registers the `id` custom property so it serializes — c
 // then: serializeFabricObject(obj) for rawAnnotationData, and
 // getGeometryFromFabricObject(obj, 'polygon') for the geometry.
 ```
+
+If your geometry _is_ one of the six built-in types and you only need a Fabric object (not the full annotation), `buildFabricObjectFromGeometry(geometry, getFabricOptions(style, id))` — the inverse of `getGeometryFromFabricObject`, re-exported from the umbrella — saves you hand-rolling `new Polygon(...)` / `new Rect(...)`. `createAnnotationFromGeometry` uses it internally.
 
 Calling `initFabricModule()` is what makes the annotation `id` survive `toObject()`; miss it and the `id` silently drops from the envelope. (`createAnnotationFromGeometry` handles this for you.)
 

--- a/apps/docs/src/content/docs/guides/serialization.mdx
+++ b/apps/docs/src/content/docs/guides/serialization.mdx
@@ -111,28 +111,46 @@ It accepts any `Geometry` (`rectangle`, `circle`, `line`, `point`, `polyline`, `
 
 The static `toolTypeToGeometryType('freeHandPath')` helper returns `polyline`, but the freehand **tool** produces a closed `polygon` by default at runtime (open `polyline` only when Shift is held). When importing a freehand contour, set `geometry.type` to whichever matches your data and pass `toolType: 'freeHandPath'`.
 
-### The manual round-trip (fallback)
+### Importing SVG paths and other shapes
 
-`createAnnotationFromGeometry` covers the six built-in geometry types. If you have geometry it can't express (e.g. an arbitrary SVG `Path` — `getGeometryFromFabricObject` only reads `Rect` / `Circle` / `Line` / `Polyline` / `Polygon`), down-convert it yourself — e.g. sample a path into polygon points — and build the envelope manually:
+Because `createAnnotationFromGeometry` accepts any of the six geometry types, importing almost always reduces to mapping your source into one of them — no manual Fabric work:
+
+- **Straight-segment SVG paths** (`M` / `L` commands) → read the vertices and pass `{ type: 'polyline', points }` (open) or `{ type: 'polygon', points }` (closed).
+- **Curved SVG paths** (`C` / `Q` / `A` commands) → the geometry model has no lossless curve type, so sample the curve into points and pass them as a polygon / polyline. (`getGeometryFromFabricObject` likewise does not read Fabric `Path` objects — sampling is the supported route for curves.)
+
+```ts
+import { createAnnotationFromGeometry } from '@osdlabel/solid';
+
+// points: { x: number; y: number }[] read or sampled from your SVG path's `d`
+const annotation = createAnnotationFromGeometry(
+  { type: 'polygon', points },
+  { imageId, contextId, toolType: 'freeHandPath' },
+);
+```
+
+Annotations drawn with the built-in freehand tool are already plain `polygon` (closed) or `polyline` (open) geometry — there is nothing special to handle when importing them.
+
+### Lower-level escape hatch
+
+If you already hold a **Fabric object** (of a supported class) rather than raw geometry, you can build the envelope directly instead of going through `createAnnotationFromGeometry`:
 
 ```ts
 import {
-  initFabricModule,
   getFabricOptions,
   serializeFabricObject,
   getGeometryFromFabricObject,
+  buildFabricObjectFromGeometry,
 } from '@osdlabel/solid';
 
-initFabricModule(); // registers the `id` custom property so it serializes — call once
+// From an existing Fabric object → annotation pieces:
+const rawAnnotationData = serializeFabricObject(obj); // envelope
+const geometry = getGeometryFromFabricObject(obj, 'polygon'); // image-space geometry
 
-// build a Fabric object yourself (e.g. new Polygon(sampledPoints, options)),
-// then: serializeFabricObject(obj) for rawAnnotationData, and
-// getGeometryFromFabricObject(obj, 'polygon') for the geometry.
+// Or the inverse — geometry → Fabric object (what createAnnotationFromGeometry uses internally):
+const fabricObject = buildFabricObjectFromGeometry(geometry, getFabricOptions(style, id));
 ```
 
-If your geometry _is_ one of the six built-in types and you only need a Fabric object (not the full annotation), `buildFabricObjectFromGeometry(geometry, getFabricOptions(style, id))` — the inverse of `getGeometryFromFabricObject`, re-exported from the umbrella — saves you hand-rolling `new Polygon(...)` / `new Rect(...)`. `createAnnotationFromGeometry` uses it internally.
-
-Calling `initFabricModule()` is what makes the annotation `id` survive `toObject()`; miss it and the `id` silently drops from the envelope. (`createAnnotationFromGeometry` handles this for you.)
+These read/produce the same five Fabric classes (`Rect` / `Circle` / `Line` / `Polyline` / `Polygon`). The annotation `id` is registered automatically when an `Annotator` mounts; if you build and serialize Fabric objects entirely outside any viewer, call `initFabricModule()` once first so the `id` survives `toObject()`. (`createAnnotationFromGeometry` guarantees this for you regardless.)
 
 ## Validation
 

--- a/apps/docs/src/content/docs/llm.md
+++ b/apps/docs/src/content/docs/llm.md
@@ -999,23 +999,7 @@ It accepts any `Geometry` (`rectangle`, `circle`, `line`, `point`, `polyline`, `
 
 The static `toolTypeToGeometryType('freeHandPath')` helper returns `polyline`, but the freehand **tool** produces a closed `polygon` by default at runtime (open `polyline` only when Shift is held). When importing a freehand contour, set `geometry.type` to whichever matches your data and pass `toolType: 'freeHandPath'`.
 
-### Importing SVG paths and other shapes
-
-Because `createAnnotationFromGeometry` accepts any of the six geometry types, importing almost always reduces to mapping your source into one of them — no manual Fabric work:
-
-- **Straight-segment SVG paths** (`M` / `L` commands) → read the vertices and pass `{ type: 'polyline', points }` (open) or `{ type: 'polygon', points }` (closed).
-- **Curved SVG paths** (`C` / `Q` / `A` commands) → the geometry model has no lossless curve type, so sample the curve into points and pass them as a polygon / polyline. (`getGeometryFromFabricObject` likewise does not read Fabric `Path` objects — sampling is the supported route for curves.)
-
-```ts
-
-// points: { x: number; y: number }[] read or sampled from your SVG path's `d`
-const annotation = createAnnotationFromGeometry(
-  { type: 'polygon', points },
-  { imageId, contextId, toolType: 'freeHandPath' },
-);
-```
-
-Annotations drawn with the built-in freehand tool are already plain `polygon` (closed) or `polyline` (open) geometry — there is nothing special to handle when importing them.
+Multi-point shapes import the same way: pass `{ type: 'polyline', points }` (open) or `{ type: 'polygon', points }` (closed), where `points` is an array of image-space `{ x, y }` coordinates. Annotations drawn with the built-in freehand tool are already plain `polygon` / `polyline` geometry, so there is nothing special to handle when importing them either.
 
 ### Lower-level escape hatch
 

--- a/apps/docs/src/content/docs/llm.md
+++ b/apps/docs/src/content/docs/llm.md
@@ -91,8 +91,6 @@ The `Annotator` component provides a complete annotation interface with toolbar,
 
 ```tsx
 
-initFabricModule();
-
 function App() {
   return (
     <div style={{ width: '100vw', height: '100vh' }}>
@@ -115,6 +113,8 @@ function App() {
 
 render(() => <App />, document.getElementById('app')!);
 ```
+
+The `Annotator` registers the Fabric `id` custom property automatically when its viewer mounts, so there's no setup call to remember. (`initFabricModule()` is still exported and idempotent if you build Fabric objects yourself before any viewer exists — see [Serialization](/osdlabel/guides/serialization/).)
 
 ## 4. What you get
 

--- a/apps/docs/src/content/docs/llm.md
+++ b/apps/docs/src/content/docs/llm.md
@@ -321,6 +321,10 @@ React annotator UI layer.
 
 For most applications, importing from the framework-specific package (`@osdlabel/solid` or `@osdlabel/react`) is the quickest way to get started. Both re-export everything from `osdlabel`.
 
+:::tip[Import rule]
+**Import every public type and value from the single umbrella package you're already using** (`@osdlabel/solid`, `@osdlabel/react`, or `osdlabel`). Commonly-needed types such as `ImageId`, `AnnotationId`, and `ImageSource` physically live in lower-level subpackages (`@osdlabel/viewer-api`, `@osdlabel/annotation`), so importing them from those paths only resolves when the subpackage is a **direct dependency** of your app. The umbrella re-exports them all — sticking to it avoids "cannot find module" errors and keeps your dependency list to one package. Reach for direct subpackage imports (below) only when you've added that subpackage as an explicit dependency for a custom UI layer.
+:::
+
 ### 1. Framework package (recommended)
 
 ```ts
@@ -953,6 +957,69 @@ actions.loadAnnotations(byImage);
 
 `deserialize()` validates the basic structure of the array and throws `SerializationError` on invalid input. For deep validation, the library integrates with Valibot in `@osdlabel/validation`.
 
+### Flat out, keyed in
+
+The two directions are intentionally **asymmetric**, and it trips people up:
+
+- **`serialize(state)` returns a flat `Annotation[]`** — and so does the `onAnnotationsChange` callback (see [below](#listening-to-changes)). That flat array **is** your persistable document; you can save the callback's argument directly without calling `serialize` yourself.
+- **`deserialize(doc)` returns a keyed `{ byImage }` map** — `Record<ImageId, Record<AnnotationId, Annotation>>` — which is the exact shape `loadAnnotations` expects for the store.
+
+So: persist the **flat** array, load it back through `deserialize` to get the **keyed** map. If you keep your own annotation list (e.g. a flat `Annotation[]` from `onAnnotationsChange`), you still pass it through `deserialize` to seed the store.
+
+## Seeding from external geometry
+
+Loading already-serialized osdlabel documents is just `deserialize` (above). The harder case is **importing annotations from another system** — you have raw geometry (a bounding box from a detector, a contour from a segmentation model, points from a CSV) but no Fabric `rawAnnotationData` envelope.
+
+Use `createAnnotationFromGeometry` — it builds the complete annotation (geometry **and** the Fabric envelope) in one call:
+
+```tsx
+
+const annotation = createAnnotationFromGeometry(
+  { type: 'rectangle', origin: { x: 120, y: 80 }, width: 200, height: 140, rotation: 0 },
+  { imageId, contextId, toolType: 'rectangle', label: 'lesion' },
+);
+
+actions.addAnnotation(annotation);
+```
+
+It accepts any `Geometry` (`rectangle`, `circle`, `line`, `point`, `polyline`, `polygon`), defaults the style to `DEFAULT_ANNOTATION_STYLE`, generates an `id` when you don't supply one, and guarantees the `id` survives serialization — so the result round-trips through `serialize` / `deserialize` like a hand-drawn annotation. To seed many at once, map over your source data and call `loadAnnotations` (or `addAnnotation` per item).
+
+### Choosing a `toolType`
+
+`toolType` is recorded independently of `geometry.type`. For most shapes they match (`'rectangle'` ↔ `rectangle`, `'circle'` ↔ `circle`, …). The exception is freehand:
+
+| `toolType`       | Resulting `geometry.type`                          |
+| ---------------- | -------------------------------------------------- |
+| `rectangle`      | `rectangle`                                        |
+| `circle`         | `circle`                                           |
+| `line`           | `line`                                             |
+| `point`          | `point`                                            |
+| `polyline`       | `polyline`                                          |
+| `freeHandPath`   | `polygon` (closed path) or `polyline` (open path)  |
+
+The static `toolTypeToGeometryType('freeHandPath')` helper returns `polyline`, but the freehand **tool** produces a closed `polygon` by default at runtime (open `polyline` only when Shift is held). When importing a freehand contour, set `geometry.type` to whichever matches your data and pass `toolType: 'freeHandPath'`.
+
+### The manual round-trip (fallback)
+
+`createAnnotationFromGeometry` covers the six built-in geometry types. If you have geometry it can't express (e.g. an arbitrary SVG `Path` — `getGeometryFromFabricObject` only reads `Rect` / `Circle` / `Line` / `Polyline` / `Polygon`), down-convert it yourself — e.g. sample a path into polygon points — and build the envelope manually:
+
+```ts
+
+  initFabricModule,
+  getFabricOptions,
+  serializeFabricObject,
+  getGeometryFromFabricObject,
+} from '@osdlabel/solid';
+
+initFabricModule(); // registers the `id` custom property so it serializes — call once
+
+// build a Fabric object yourself (e.g. new Polygon(sampledPoints, options)),
+// then: serializeFabricObject(obj) for rawAnnotationData, and
+// getGeometryFromFabricObject(obj, 'polygon') for the geometry.
+```
+
+Calling `initFabricModule()` is what makes the annotation `id` survive `toObject()`; miss it and the `id` silently drops from the envelope. (`createAnnotationFromGeometry` handles this for you.)
+
 ## Validation
 
 The library provides comprehensive Valibot schemas for annotation validation in the `@osdlabel/validation` package:
@@ -978,7 +1045,8 @@ The `onAnnotationsChange` callback fires whenever annotations are added, updated
 ```tsx
 <AnnotatorProvider
   onAnnotationsChange={(annotations) => {
-    // annotations: Annotation[] — flat list of all annotations
+    // annotations: Annotation[] — the same flat document serialize() would produce.
+    // No need to call serialize() yourself; persist this array directly.
     saveToBackend(annotations);
   }}
 >
@@ -1177,7 +1245,7 @@ Annotations are always stored in image-space pixels. The overlay's `viewportTran
 
 # Decorations
 
-**Decorations** are derived, read-only visuals that osdlabel renders on top of your annotations: per-annotation text labels, computed measurements (area, perimeter, length, radius), and connector lines between annotation pairs. They are not part of annotation state and are never serialized — they are recomputed from current state on every relevant change.
+**Decorations** are derived, read-only visuals that osdlabel renders on top of your annotations: per-annotation text labels, computed measurements (area, perimeter, length, radius), connector lines between annotation pairs, and [rich DOM overlays](#dom-decorations) rendered by your own UI framework. They are not part of annotation state and are never serialized — they are recomputed from current state on every relevant change.
 
 You drive them by passing one or more **providers** (pure functions) to `<Annotator>` via the `decorationProviders` prop. The library ships built-in providers for the common cases and lets you compose them or write your own.
 
@@ -1201,14 +1269,15 @@ interface DecorationContext<E> {
 
 The library calls your providers on every relevant change — annotation added/edited/deleted, selection changed, drag tick — and reconciles the result into the DOM and the Fabric canvas. Providers must be deterministic and side-effect-free; nothing they return is persisted.
 
-### Two render targets
+### Three render targets
 
 A `Decoration` is a discriminated union:
 
 - **`TextDecoration`** renders as an absolutely-positioned `<div>` in a host layer over the Fabric canvas. Text stays upright, crisp, and constant screen-size at any zoom / rotation / flip — there is no counter-transform math because the host layer is in screen-space, not image-space. Position is `imageToScreen(anchor) + offset` recomputed on every frame.
 - **`LineDecoration`** renders as a non-interactive Fabric `Line` on the overlay canvas, in image-space. It follows pan / zoom / rotate / flip via the existing viewport transform at zero per-frame cost. Stroke width is `strokeUniform` so dashed patterns look the same at all zooms.
+- **`DomDecoration`** renders an arbitrary component tree from _your_ UI framework — buttons, inputs, popovers, charts — into a positioned host element via the framework's native portal. Unlike `TextDecoration` (which the library renders for you as a styled `<div>`), a `DomDecoration` hands rendering back to you through the `renderDomDecoration` prop, so the tree lives inside your app's component context. See [DOM decorations](#dom-decorations) below.
 
-You don't choose the render target by hand — picking `type: 'text'` vs `type: 'line'` does it for you.
+You don't choose the render target by hand — the `type` field (`'text'` / `'line'` / `'dom'`) does it for you.
 
 ### Composition order
 
@@ -1403,13 +1472,42 @@ type DecorationProvider<E extends object = Record<string, never>> = (
 ) => readonly Decoration[];
 ```
 
-You return an array of `TextDecoration` and / or `LineDecoration` values. Three rules:
+You return an array of `TextDecoration`, `LineDecoration`, and / or `DomDecoration` values. Three rules:
 
 1. **Be pure.** No `setState`, no DOM, no network. The library may call your provider many times per second during a drag.
 2. **Use stable IDs.** Return the same `Decoration.id` across recomputations for the same logical decoration (e.g. `` `bbox:${ann.id}` ``). The renderer diffs by id — stable ids let it update DOM/Fabric in place instead of recreating nodes.
 3. **Set `relatedAnnotationIds`.** This drives lifecycle (so decorations are cleaned up when their annotations are deleted) and powers `withSelectionEmphasis`. For per-annotation decorations, it's `[ann.id]`; for relational decorations it's the participating annotation ids.
 
 The decoration package also exports pure geometry utilities you can use to build anchors and derived values: `area`, `perimeter`, `length`, `radius`, `distance`, `centroid`, `midpoint`, `boundingBox`. See [`@osdlabel/decoration`](/osdlabel/api/reference/osdlabel/) for full signatures.
+
+### Typing providers with extension fields
+
+`DecorationProvider<E>` is generic over your annotation's extension fields `E`, and so are the built-in factories:
+
+```ts
+function createLabelProvider<E extends object = Record<string, never>>(): DecorationProvider<E>;
+function createMeasurementProvider<E extends object = Record<string, never>>(): DecorationProvider<E>;
+function createDistanceProvider<E extends object = Record<string, never>>(): DecorationProvider<E>;
+```
+
+`E` **defaults to `Record<string, never>`** (no extension fields). That default is fine when a callback only touches built-in `Annotation` fields, but it will not infer your custom fields for you. **Pass the generic explicitly** whenever you read an extension field (e.g. `contextId`, or your own metadata) inside a callback, or when you assign into a `DecorationProvider<MyFields>[]`:
+
+```ts
+interface MyFields {
+  readonly contextId: AnnotationContextId;
+  readonly priority: number;
+}
+
+// ✅ pass <MyFields> so `pair` sees the extra fields
+const distances = createDistanceProvider<MyFields>({
+  pair: (annotations) =>
+    annotations
+      .filter((a) => a.priority > 0) // typed, no `String(...)` cast needed
+      .map((a, i, arr) => ({ a, b: arr[(i + 1) % arr.length]! })),
+});
+```
+
+Comparing a **branded id** (e.g. `contextId: AnnotationContextId`) against a plain string narrows cleanly with `String(...)`: `String(ann.contextId) === 'tumor'`. Prefer comparing branded-to-branded (`ann.contextId === createAnnotationContextId('tumor')`) where you have the factory in scope.
 
 ### Example: bounding-box dimensions
 
@@ -1494,6 +1592,110 @@ export const rectanglePath: DecorationProvider = ({ annotations }) => {
 | `relatedAnnotationIds` | `readonly AnnotationId[]` | Drives lifecycle and selection emphasis.                                 |
 
 A `LineDecoration` is rendered as a non-interactive Fabric `Line` on the overlay canvas. If you want users to be able to select / move / edit the line, draw a line **annotation** instead (annotations are state and serialize; decorations don't).
+
+## DOM decorations
+
+`TextDecoration` is great for plain labels, but sometimes you need a **rich, interactive overlay** anchored to an annotation — a delete button, an inline editor, a status badge, a small chart, a link into your app's routing. That's what `DomDecoration` is for: the library positions an empty host `<div>` over the image (tracking pan / zoom / rotate / flip every frame), and _your_ framework renders into it through a **portal**, so the rendered tree shares your app's context, theme, and event handlers.
+
+### The flow
+
+1. A provider returns a `Decoration` with `type: 'dom'`, an image-space `anchor`, and a framework-agnostic `content: unknown` payload (treated as stable configuration / identity).
+2. The library creates and positions the host element and emits an entry `{ id, element, decoration }`.
+3. You pass a `renderDomDecoration` render-prop to `<Annotator>` (or `<AnnotatorProvider>`); the framework portals its return value into the host element, keyed by the decoration `id`.
+
+`content` is _configuration_, not per-frame data. Dynamic values (a live count, a selection flag) should flow through your app's own reactivity inside the rendered component, not through `content` changing every frame — keeping `content` stable lets the renderer reuse DOM in place.
+
+### Provider side (framework-agnostic)
+
+```ts
+
+// Typed with the imageId extension field so the payload can carry it
+// (see "Typing providers with extension fields" above).
+export const deleteButtons: DecorationProvider<{ imageId: ImageId }> = ({ annotations }) => {
+  const out: DomDecoration[] = [];
+  for (const ann of annotations) {
+    const { min, max } = boundingBox(ann.geometry);
+    out.push({
+      id: `delete-btn:${ann.id}`,
+      type: 'dom',
+      relatedAnnotationIds: [ann.id],
+      anchor: { x: max.x, y: min.y }, // top-right corner, image-space
+      offset: { x: 4, y: -4 }, // screen-space nudge
+      placement: 'left',
+      content: { annotationId: ann.id, imageId: ann.imageId }, // stable config the render-prop reads
+      style: { pointerEvents: 'auto', zIndex: 20 },
+    });
+  }
+  return out;
+};
+```
+
+### Render side
+
+The render-prop receives the full `DomDecoration` (read your payload off `decoration.content`) and returns a framework node.
+
+The render-prop runs inside the annotator's component tree, so the rendered component can call `useAnnotator()` to reach state and actions.
+
+**React** — returns a `ReactNode`, portalled via `createPortal`:
+
+```tsx
+
+function DeleteButton({ content }: { content: unknown }) {
+  const { actions } = useAnnotator();
+  const { annotationId, imageId } = content as { annotationId: AnnotationId; imageId: ImageId };
+  return (
+    <button className="anno-delete" onClick={() => actions.deleteAnnotation(annotationId, imageId)}>
+      ✕
+    </button>
+  );
+}
+
+<Annotator
+  images={images}
+  contexts={contexts}
+  decorationProviders={[deleteButtons]}
+  renderDomDecoration={(decoration) => <DeleteButton content={decoration.content} />}
+/>;
+```
+
+**Solid** — returns a `JSX.Element`, portalled via `<Portal>`:
+
+```tsx
+
+function DeleteButton(props: { content: unknown }) {
+  const { actions } = useAnnotator();
+  const { annotationId, imageId } = props.content as { annotationId: AnnotationId; imageId: ImageId };
+  return (
+    <button class="anno-delete" onClick={() => actions.deleteAnnotation(annotationId, imageId)}>
+      ✕
+    </button>
+  );
+}
+
+<Annotator
+  images={images}
+  contexts={contexts}
+  decorationProviders={[deleteButtons]}
+  renderDomDecoration={(decoration) => <DeleteButton content={decoration.content} />}
+/>;
+```
+
+If you emit `type: 'dom'` decorations but **don't** pass `renderDomDecoration`, the host elements are positioned but stay empty — the library never guesses how to render your `content`.
+
+### DomDecoration anatomy
+
+| Field                  | Type                       | Notes                                                                           |
+| ---------------------- | -------------------------- | ------------------------------------------------------------------------------- |
+| `id`                   | `string`                   | Stable across recomputations; also the portal key.                              |
+| `type`                 | `'dom'`                    | Discriminator.                                                                   |
+| `anchor`               | `Point`                    | **Image-space**. Transformed by `imageToScreen` every frame.                    |
+| `offset`               | `{ x: number; y: number }` | **Screen-space pixels** added to the anchor's screen position.                  |
+| `placement`            | `TextPlacement`            | How the host sits relative to its anchor (`'top-left'` default, `'center'`, …). |
+| `content`              | `unknown`                  | Stable config the render-prop interprets. Not per-frame data.                   |
+| `style`                | `DomDecorationStyle`       | See below.                                                                      |
+| `relatedAnnotationIds` | `readonly AnnotationId[]`  | Drives lifecycle and selection emphasis.                                        |
+
+**`DomDecorationStyle` fields:** `className`, `zIndex`, `width` / `height` (fixed screen-px, otherwise sizes to content), and `pointerEvents` — defaults to `'auto'` so content is interactive; set `'none'` for purely-visual overlays that should let clicks fall through to the canvas.
 
 ## Live updates during drag
 

--- a/apps/docs/src/content/docs/llm.md
+++ b/apps/docs/src/content/docs/llm.md
@@ -919,7 +919,7 @@ osdlabel uses a flat JSON array format for persisting annotations:
     },
     "rawAnnotationData": {
       "format": "fabric",
-      "fabricVersion": "7.2.0",
+      "fabricVersion": "7.4.0",
       "data": { ... }
     },
     "createdAt": "2026-03-06T12:00:00.000Z",
@@ -988,14 +988,14 @@ It accepts any `Geometry` (`rectangle`, `circle`, `line`, `point`, `polyline`, `
 
 `toolType` is recorded independently of `geometry.type`. For most shapes they match (`'rectangle'` ↔ `rectangle`, `'circle'` ↔ `circle`, …). The exception is freehand:
 
-| `toolType`       | Resulting `geometry.type`                          |
-| ---------------- | -------------------------------------------------- |
-| `rectangle`      | `rectangle`                                        |
-| `circle`         | `circle`                                           |
-| `line`           | `line`                                             |
-| `point`          | `point`                                            |
-| `polyline`       | `polyline`                                          |
-| `freeHandPath`   | `polygon` (closed path) or `polyline` (open path)  |
+| `toolType`     | Resulting `geometry.type`                         |
+| -------------- | ------------------------------------------------- |
+| `rectangle`    | `rectangle`                                       |
+| `circle`       | `circle`                                          |
+| `line`         | `line`                                            |
+| `point`        | `point`                                           |
+| `polyline`     | `polyline`                                        |
+| `freeHandPath` | `polygon` (closed path) or `polyline` (open path) |
 
 The static `toolTypeToGeometryType('freeHandPath')` helper returns `polyline`, but the freehand **tool** produces a closed `polygon` by default at runtime (open `polyline` only when Shift is held). When importing a freehand contour, set `geometry.type` to whichever matches your data and pass `toolType: 'freeHandPath'`.
 
@@ -1017,6 +1017,8 @@ initFabricModule(); // registers the `id` custom property so it serializes — c
 // then: serializeFabricObject(obj) for rawAnnotationData, and
 // getGeometryFromFabricObject(obj, 'polygon') for the geometry.
 ```
+
+If your geometry _is_ one of the six built-in types and you only need a Fabric object (not the full annotation), `buildFabricObjectFromGeometry(geometry, getFabricOptions(style, id))` — the inverse of `getGeometryFromFabricObject`, re-exported from the umbrella — saves you hand-rolling `new Polygon(...)` / `new Rect(...)`. `createAnnotationFromGeometry` uses it internally.
 
 Calling `initFabricModule()` is what makes the annotation `id` survive `toObject()`; miss it and the `id` silently drops from the envelope. (`createAnnotationFromGeometry` handles this for you.)
 
@@ -1486,7 +1488,9 @@ The decoration package also exports pure geometry utilities you can use to build
 
 ```ts
 function createLabelProvider<E extends object = Record<string, never>>(): DecorationProvider<E>;
-function createMeasurementProvider<E extends object = Record<string, never>>(): DecorationProvider<E>;
+function createMeasurementProvider<
+  E extends object = Record<string, never>,
+>(): DecorationProvider<E>;
 function createDistanceProvider<E extends object = Record<string, never>>(): DecorationProvider<E>;
 ```
 
@@ -1664,7 +1668,10 @@ function DeleteButton({ content }: { content: unknown }) {
 
 function DeleteButton(props: { content: unknown }) {
   const { actions } = useAnnotator();
-  const { annotationId, imageId } = props.content as { annotationId: AnnotationId; imageId: ImageId };
+  const { annotationId, imageId } = props.content as {
+    annotationId: AnnotationId;
+    imageId: ImageId;
+  };
   return (
     <button class="anno-delete" onClick={() => actions.deleteAnnotation(annotationId, imageId)}>
       ✕
@@ -1687,7 +1694,7 @@ If you emit `type: 'dom'` decorations but **don't** pass `renderDomDecoration`, 
 | Field                  | Type                       | Notes                                                                           |
 | ---------------------- | -------------------------- | ------------------------------------------------------------------------------- |
 | `id`                   | `string`                   | Stable across recomputations; also the portal key.                              |
-| `type`                 | `'dom'`                    | Discriminator.                                                                   |
+| `type`                 | `'dom'`                    | Discriminator.                                                                  |
 | `anchor`               | `Point`                    | **Image-space**. Transformed by `imageToScreen` every frame.                    |
 | `offset`               | `{ x: number; y: number }` | **Screen-space pixels** added to the anchor's screen position.                  |
 | `placement`            | `TextPlacement`            | How the host sits relative to its anchor (`'top-left'` default, `'center'`, …). |

--- a/apps/docs/src/content/docs/llm.md
+++ b/apps/docs/src/content/docs/llm.md
@@ -999,28 +999,45 @@ It accepts any `Geometry` (`rectangle`, `circle`, `line`, `point`, `polyline`, `
 
 The static `toolTypeToGeometryType('freeHandPath')` helper returns `polyline`, but the freehand **tool** produces a closed `polygon` by default at runtime (open `polyline` only when Shift is held). When importing a freehand contour, set `geometry.type` to whichever matches your data and pass `toolType: 'freeHandPath'`.
 
-### The manual round-trip (fallback)
+### Importing SVG paths and other shapes
 
-`createAnnotationFromGeometry` covers the six built-in geometry types. If you have geometry it can't express (e.g. an arbitrary SVG `Path` — `getGeometryFromFabricObject` only reads `Rect` / `Circle` / `Line` / `Polyline` / `Polygon`), down-convert it yourself — e.g. sample a path into polygon points — and build the envelope manually:
+Because `createAnnotationFromGeometry` accepts any of the six geometry types, importing almost always reduces to mapping your source into one of them — no manual Fabric work:
+
+- **Straight-segment SVG paths** (`M` / `L` commands) → read the vertices and pass `{ type: 'polyline', points }` (open) or `{ type: 'polygon', points }` (closed).
+- **Curved SVG paths** (`C` / `Q` / `A` commands) → the geometry model has no lossless curve type, so sample the curve into points and pass them as a polygon / polyline. (`getGeometryFromFabricObject` likewise does not read Fabric `Path` objects — sampling is the supported route for curves.)
 
 ```ts
 
-  initFabricModule,
+// points: { x: number; y: number }[] read or sampled from your SVG path's `d`
+const annotation = createAnnotationFromGeometry(
+  { type: 'polygon', points },
+  { imageId, contextId, toolType: 'freeHandPath' },
+);
+```
+
+Annotations drawn with the built-in freehand tool are already plain `polygon` (closed) or `polyline` (open) geometry — there is nothing special to handle when importing them.
+
+### Lower-level escape hatch
+
+If you already hold a **Fabric object** (of a supported class) rather than raw geometry, you can build the envelope directly instead of going through `createAnnotationFromGeometry`:
+
+```ts
+
   getFabricOptions,
   serializeFabricObject,
   getGeometryFromFabricObject,
+  buildFabricObjectFromGeometry,
 } from '@osdlabel/solid';
 
-initFabricModule(); // registers the `id` custom property so it serializes — call once
+// From an existing Fabric object → annotation pieces:
+const rawAnnotationData = serializeFabricObject(obj); // envelope
+const geometry = getGeometryFromFabricObject(obj, 'polygon'); // image-space geometry
 
-// build a Fabric object yourself (e.g. new Polygon(sampledPoints, options)),
-// then: serializeFabricObject(obj) for rawAnnotationData, and
-// getGeometryFromFabricObject(obj, 'polygon') for the geometry.
+// Or the inverse — geometry → Fabric object (what createAnnotationFromGeometry uses internally):
+const fabricObject = buildFabricObjectFromGeometry(geometry, getFabricOptions(style, id));
 ```
 
-If your geometry _is_ one of the six built-in types and you only need a Fabric object (not the full annotation), `buildFabricObjectFromGeometry(geometry, getFabricOptions(style, id))` — the inverse of `getGeometryFromFabricObject`, re-exported from the umbrella — saves you hand-rolling `new Polygon(...)` / `new Rect(...)`. `createAnnotationFromGeometry` uses it internally.
-
-Calling `initFabricModule()` is what makes the annotation `id` survive `toObject()`; miss it and the `id` silently drops from the envelope. (`createAnnotationFromGeometry` handles this for you.)
+These read/produce the same five Fabric classes (`Rect` / `Circle` / `Line` / `Polyline` / `Polygon`). The annotation `id` is registered automatically when an `Annotator` mounts; if you build and serialize Fabric objects entirely outside any viewer, call `initFabricModule()` once first so the `id` survives `toObject()`. (`createAnnotationFromGeometry` guarantees this for you regardless.)
 
 ## Validation
 

--- a/packages/fabric-annotations/package.json
+++ b/packages/fabric-annotations/package.json
@@ -34,7 +34,7 @@
     "@osdlabel/viewer-api": "workspace:*"
   },
   "peerDependencies": {
-    "fabric": "catalog:"
+    "fabric": "catalog:peers"
   },
   "devDependencies": {
     "typescript": "catalog:",

--- a/packages/fabric-annotations/src/build-fabric-object.ts
+++ b/packages/fabric-annotations/src/build-fabric-object.ts
@@ -1,0 +1,77 @@
+import { Rect, Circle, Line, Polyline, Polygon, type FabricObject } from 'fabric';
+import type { Geometry } from '@osdlabel/annotation';
+import type { FabricShapeOptions } from './fabric-utils.js';
+
+/** Screen-pixel radius used to render `point` geometry (mirrors PointTool). */
+const POINT_RADIUS = 5;
+
+/**
+ * Construct a Fabric object from image-space {@link Geometry}. This is the
+ * inverse of {@link getGeometryFromFabricObject}: feeding the result back
+ * through that function reproduces the input geometry.
+ *
+ * Construction mirrors the per-shape tools (`RectangleTool`, `CircleTool`,
+ * `LineTool`, `PointTool`, `PolylineTool`, `FreeHandPathTool`) so imported
+ * geometry behaves identically to user-drawn geometry. The object is created
+ * committed (`selectable`/`evented` true) — callers that need a preview object
+ * should adjust those flags afterwards.
+ */
+export function buildFabricObjectFromGeometry(
+  geometry: Geometry,
+  options: FabricShapeOptions,
+): FabricObject {
+  switch (geometry.type) {
+    case 'rectangle':
+      return new Rect({
+        ...options,
+        left: geometry.origin.x,
+        top: geometry.origin.y,
+        width: geometry.width,
+        height: geometry.height,
+        angle: geometry.rotation,
+        selectable: true,
+        evented: true,
+      });
+    case 'circle':
+      return new Circle({
+        ...options,
+        left: geometry.center.x,
+        top: geometry.center.y,
+        radius: geometry.radius,
+        originX: 'center',
+        originY: 'center',
+        selectable: true,
+        evented: true,
+      });
+    case 'line':
+      return new Line([geometry.start.x, geometry.start.y, geometry.end.x, geometry.end.y], {
+        ...options,
+        originX: 'left',
+        originY: 'top',
+        selectable: true,
+        evented: true,
+      });
+    case 'point':
+      return new Circle({
+        ...options,
+        left: geometry.position.x,
+        top: geometry.position.y,
+        radius: POINT_RADIUS,
+        originX: 'center',
+        originY: 'center',
+        hasControls: false,
+        selectable: true,
+        evented: true,
+      });
+    case 'polyline':
+      return new Polyline(
+        geometry.points.map((p) => ({ x: p.x, y: p.y })),
+        { ...options, fill: 'transparent', selectable: true, evented: true },
+      );
+    case 'polygon':
+      return new Polygon(
+        geometry.points.map((p) => ({ x: p.x, y: p.y })),
+        { ...options, selectable: true, evented: true },
+      );
+  }
+}

--- a/packages/fabric-annotations/src/fabric-module.ts
+++ b/packages/fabric-annotations/src/fabric-module.ts
@@ -13,10 +13,18 @@ declare module 'fabric' {
 
 /**
  * Registers custom properties on FabricObject so toObject() includes them.
- * Must be called once before any Fabric interaction.
+ *
+ * Called automatically when a `FabricOverlay` is constructed, so most consumers
+ * never need to invoke it directly. It remains exported (and idempotent) for
+ * advanced setups that build Fabric objects before any overlay exists. The
+ * `id` entry is merged into any existing `customProperties` rather than
+ * overwriting them, so consumer-registered properties are preserved.
  *
  * _readOnly is intentionally NOT registered — it is transient display state, not persisted.
  */
 export function initFabricModule(): void {
-  FabricObject.customProperties = ['id'];
+  const existing = FabricObject.customProperties ?? [];
+  if (!existing.includes('id')) {
+    FabricObject.customProperties = [...existing, 'id'];
+  }
 }

--- a/packages/fabric-annotations/src/index.ts
+++ b/packages/fabric-annotations/src/index.ts
@@ -1,5 +1,6 @@
 export * from './fabric-module.js';
 export * from './fabric-utils.js';
+export { buildFabricObjectFromGeometry } from './build-fabric-object.js';
 export type { ToolOverlay, FabricFields } from './types.js';
 export type { AnnotationTool, ToolCallbacks, AddAnnotationParams } from './tools/base-tool.js';
 export { BaseTool } from './tools/base-tool.js';

--- a/packages/fabric-annotations/tests/unit/build-fabric-object.test.ts
+++ b/packages/fabric-annotations/tests/unit/build-fabric-object.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest';
+import { DEFAULT_ANNOTATION_STYLE, createAnnotationId } from '@osdlabel/annotation';
+import type { Geometry } from '@osdlabel/annotation';
+import { buildFabricObjectFromGeometry } from '../../src/build-fabric-object.js';
+import { getFabricOptions, getGeometryFromFabricObject } from '../../src/fabric-utils.js';
+import { initFabricModule } from '../../src/fabric-module.js';
+
+// Register custom Fabric properties so toObject() includes `id`.
+initFabricModule();
+
+const id = createAnnotationId('test-1');
+const options = getFabricOptions(DEFAULT_ANNOTATION_STYLE, id);
+
+/** Build a Fabric object from geometry and read it straight back. */
+function roundTrip(geometry: Geometry): Geometry {
+  const obj = buildFabricObjectFromGeometry(geometry, options);
+  const back = getGeometryFromFabricObject(obj, geometry.type);
+  expect(back).not.toBeNull();
+  return back as Geometry;
+}
+
+describe('buildFabricObjectFromGeometry', () => {
+  it('round-trips rectangle geometry', () => {
+    const geometry: Geometry = {
+      type: 'rectangle',
+      origin: { x: 10, y: 20 },
+      width: 100,
+      height: 50,
+      rotation: 0,
+    };
+    const back = roundTrip(geometry);
+    expect(back.type).toBe('rectangle');
+    if (back.type !== 'rectangle') return;
+    expect(back.origin.x).toBeCloseTo(10);
+    expect(back.origin.y).toBeCloseTo(20);
+    expect(back.width).toBeCloseTo(100);
+    expect(back.height).toBeCloseTo(50);
+    expect(back.rotation).toBeCloseTo(0);
+  });
+
+  it('round-trips circle geometry', () => {
+    const geometry: Geometry = {
+      type: 'circle',
+      center: { x: 200, y: 150 },
+      radius: 40,
+    };
+    const back = roundTrip(geometry);
+    expect(back.type).toBe('circle');
+    if (back.type !== 'circle') return;
+    expect(back.center.x).toBeCloseTo(200);
+    expect(back.center.y).toBeCloseTo(150);
+    expect(back.radius).toBeCloseTo(40);
+  });
+
+  it('round-trips line geometry', () => {
+    const geometry: Geometry = {
+      type: 'line',
+      start: { x: 5, y: 5 },
+      end: { x: 95, y: 65 },
+    };
+    const back = roundTrip(geometry);
+    expect(back.type).toBe('line');
+    if (back.type !== 'line') return;
+    expect(back.start.x).toBeCloseTo(5);
+    expect(back.start.y).toBeCloseTo(5);
+    expect(back.end.x).toBeCloseTo(95);
+    expect(back.end.y).toBeCloseTo(65);
+  });
+
+  it('round-trips point geometry', () => {
+    const geometry: Geometry = { type: 'point', position: { x: 42, y: 84 } };
+    const back = roundTrip(geometry);
+    expect(back.type).toBe('point');
+    if (back.type !== 'point') return;
+    expect(back.position.x).toBeCloseTo(42);
+    expect(back.position.y).toBeCloseTo(84);
+  });
+
+  it('round-trips polyline geometry', () => {
+    const points = [
+      { x: 0, y: 0 },
+      { x: 30, y: 10 },
+      { x: 60, y: 0 },
+    ];
+    const back = roundTrip({ type: 'polyline', points });
+    expect(back.type).toBe('polyline');
+    if (back.type !== 'polyline') return;
+    expect(back.points).toHaveLength(3);
+    back.points.forEach((p, i) => {
+      expect(p.x).toBeCloseTo(points[i]!.x);
+      expect(p.y).toBeCloseTo(points[i]!.y);
+    });
+  });
+
+  it('round-trips polygon geometry', () => {
+    const points = [
+      { x: 0, y: 0 },
+      { x: 50, y: 0 },
+      { x: 25, y: 40 },
+    ];
+    const back = roundTrip({ type: 'polygon', points });
+    expect(back.type).toBe('polygon');
+    if (back.type !== 'polygon') return;
+    expect(back.points).toHaveLength(3);
+    back.points.forEach((p, i) => {
+      expect(p.x).toBeCloseTo(points[i]!.x);
+      expect(p.y).toBeCloseTo(points[i]!.y);
+    });
+  });
+
+  it('sets the id on the built object so it serializes', () => {
+    const obj = buildFabricObjectFromGeometry({ type: 'point', position: { x: 1, y: 2 } }, options);
+    expect((obj.toObject() as { id?: string }).id).toBe(id);
+  });
+});

--- a/packages/fabric-annotations/tests/unit/build-fabric-object.test.ts
+++ b/packages/fabric-annotations/tests/unit/build-fabric-object.test.ts
@@ -38,6 +38,24 @@ describe('buildFabricObjectFromGeometry', () => {
     expect(back.rotation).toBeCloseTo(0);
   });
 
+  it('round-trips a rotated rectangle', () => {
+    const geometry: Geometry = {
+      type: 'rectangle',
+      origin: { x: 10, y: 20 },
+      width: 100,
+      height: 50,
+      rotation: 30,
+    };
+    const back = roundTrip(geometry);
+    expect(back.type).toBe('rectangle');
+    if (back.type !== 'rectangle') return;
+    expect(back.origin.x).toBeCloseTo(10);
+    expect(back.origin.y).toBeCloseTo(20);
+    expect(back.width).toBeCloseTo(100);
+    expect(back.height).toBeCloseTo(50);
+    expect(back.rotation).toBeCloseTo(30);
+  });
+
   it('round-trips circle geometry', () => {
     const geometry: Geometry = {
       type: 'circle',

--- a/packages/fabric-annotations/tests/unit/fabric-module.test.ts
+++ b/packages/fabric-annotations/tests/unit/fabric-module.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { FabricObject } from 'fabric';
+import { initFabricModule } from '../../src/fabric-module.js';
+
+describe('initFabricModule', () => {
+  beforeEach(() => {
+    FabricObject.customProperties = [];
+  });
+
+  it('registers the `id` custom property', () => {
+    initFabricModule();
+    expect(FabricObject.customProperties).toContain('id');
+  });
+
+  it('is idempotent — does not duplicate `id`', () => {
+    initFabricModule();
+    initFabricModule();
+    const idCount = (FabricObject.customProperties ?? []).filter((p) => p === 'id').length;
+    expect(idCount).toBe(1);
+  });
+
+  it('merges `id` into existing custom properties instead of clobbering them', () => {
+    FabricObject.customProperties = ['myCustomProp'];
+    initFabricModule();
+    expect(FabricObject.customProperties).toContain('myCustomProp');
+    expect(FabricObject.customProperties).toContain('id');
+  });
+});

--- a/packages/fabric-osd/package.json
+++ b/packages/fabric-osd/package.json
@@ -35,8 +35,8 @@
     "@osdlabel/viewer-api": "workspace:*"
   },
   "peerDependencies": {
-    "fabric": "catalog:",
-    "openseadragon": "catalog:"
+    "fabric": "catalog:peers",
+    "openseadragon": "catalog:peers"
   },
   "devDependencies": {
     "@types/openseadragon": "catalog:",

--- a/packages/fabric-osd/src/overlay/fabric-overlay.ts
+++ b/packages/fabric-osd/src/overlay/fabric-overlay.ts
@@ -4,7 +4,7 @@ import type { TMat2D } from 'fabric';
 import type { Point } from '@osdlabel/annotation';
 import type { CellTransform } from '@osdlabel/viewer-api';
 import { DEFAULT_CELL_TRANSFORM } from '@osdlabel/viewer-api';
-import '@osdlabel/fabric-annotations';
+import { initFabricModule } from '@osdlabel/fabric-annotations';
 import {
   POINTER_DOWN,
   POINTER_MOVE,
@@ -219,6 +219,11 @@ export class FabricOverlay {
 
   constructor(viewer: OpenSeadragon.Viewer, options?: OverlayOptions) {
     this._viewer = viewer;
+
+    // Ensure the `id` custom property is registered so annotation objects
+    // serialize their id (and the clear filter `obj => obj.id` works). Idempotent
+    // and merge-safe, so an explicit consumer call remains harmless.
+    initFabricModule();
 
     // ── Create canvas DOM element ────────────────────────────────
     this._canvasEl = document.createElement('canvas');

--- a/packages/osd-helper/package.json
+++ b/packages/osd-helper/package.json
@@ -33,7 +33,7 @@
     "@osdlabel/viewer-api": "workspace:*"
   },
   "peerDependencies": {
-    "openseadragon": "catalog:"
+    "openseadragon": "catalog:peers"
   },
   "devDependencies": {
     "@types/openseadragon": "catalog:",

--- a/packages/osdlabel/package.json
+++ b/packages/osdlabel/package.json
@@ -31,8 +31,8 @@
     "lint": "eslint src/ tests/"
   },
   "peerDependencies": {
-    "fabric": "catalog:",
-    "openseadragon": "catalog:",
+    "fabric": "catalog:peers",
+    "openseadragon": "catalog:peers",
     "valibot": "catalog:"
   },
   "dependencies": {

--- a/packages/osdlabel/src/create-annotation.ts
+++ b/packages/osdlabel/src/create-annotation.ts
@@ -1,0 +1,87 @@
+import {
+  createAnnotationId,
+  generateId,
+  DEFAULT_ANNOTATION_STYLE,
+  type AnnotationId,
+  type AnnotationStyle,
+  type Geometry,
+  type ToolType,
+} from '@osdlabel/annotation';
+import type { AnnotationContextId } from '@osdlabel/annotation-context';
+import type { ImageId } from '@osdlabel/viewer-api';
+import {
+  buildFabricObjectFromGeometry,
+  getFabricOptions,
+  serializeFabricObject,
+} from '@osdlabel/fabric-annotations';
+import type { OsdAnnotation } from './types.js';
+
+/** Options for {@link createAnnotationFromGeometry}. */
+export interface CreateAnnotationFromGeometryOptions {
+  /** Image the annotation belongs to. */
+  readonly imageId: ImageId;
+  /** Annotation context (scope) the annotation belongs to. */
+  readonly contextId: AnnotationContextId;
+  /**
+   * Tool type recorded on the annotation. Note this is independent of
+   * `geometry.type`: e.g. a freehand path is `toolType: 'freeHandPath'` with
+   * `geometry.type: 'polygon'` (closed) or `'polyline'` (open).
+   */
+  readonly toolType: ToolType;
+  /** Visual style. Defaults to {@link DEFAULT_ANNOTATION_STYLE}. */
+  readonly style?: AnnotationStyle | undefined;
+  /** Explicit id. A fresh id is generated when omitted. */
+  readonly id?: AnnotationId | undefined;
+  /** Optional text label. */
+  readonly label?: string | undefined;
+}
+
+/**
+ * Build a complete {@link OsdAnnotation} from image-space {@link Geometry},
+ * producing the Fabric `rawAnnotationData` envelope for you.
+ *
+ * This removes the manual round-trip otherwise required to seed annotations
+ * from an external system (build a Fabric object → `serializeFabricObject` →
+ * `getGeometryFromFabricObject`). The returned annotation can be passed
+ * straight to `addAnnotation` / `loadAnnotations` or persisted via `serialize`.
+ *
+ * The `id` is guaranteed to be present in the serialized envelope regardless of
+ * whether {@link initFabricModule} has registered it as a custom property, so
+ * the result always round-trips through `deserialize` →
+ * `createFabricObjectFromRawData`.
+ *
+ * @example
+ * ```ts
+ * const annotation = createAnnotationFromGeometry(
+ *   { type: 'rectangle', origin: { x: 10, y: 20 }, width: 100, height: 50, rotation: 0 },
+ *   { imageId, contextId, toolType: 'rectangle' },
+ * );
+ * actions.addAnnotation(annotation);
+ * ```
+ */
+export function createAnnotationFromGeometry(
+  geometry: Geometry,
+  options: CreateAnnotationFromGeometryOptions,
+): OsdAnnotation {
+  const id = options.id ?? createAnnotationId(generateId());
+  const style = options.style ?? DEFAULT_ANNOTATION_STYLE;
+  const fabricObject = buildFabricObjectFromGeometry(geometry, getFabricOptions(style, id));
+
+  const raw = serializeFabricObject(fabricObject);
+  // Self-contained: guarantee the id survives serialization even if
+  // initFabricModule() has not registered `id` as a Fabric custom property.
+  const rawAnnotationData = raw.data['id'] === id ? raw : { ...raw, data: { ...raw.data, id } };
+
+  const now = new Date().toISOString();
+  return {
+    id,
+    geometry,
+    toolType: options.toolType,
+    imageId: options.imageId,
+    contextId: options.contextId,
+    rawAnnotationData,
+    createdAt: now,
+    updatedAt: now,
+    ...(options.label !== undefined ? { label: options.label } : {}),
+  };
+}

--- a/packages/osdlabel/src/index.ts
+++ b/packages/osdlabel/src/index.ts
@@ -65,6 +65,7 @@ export {
   deserializeFabricObject,
   createFabricObjectFromRawData,
   getGeometryFromFabricObject,
+  buildFabricObjectFromGeometry,
 } from '@osdlabel/fabric-annotations';
 export type {
   ToolOverlay,

--- a/packages/osdlabel/src/index.ts
+++ b/packages/osdlabel/src/index.ts
@@ -143,6 +143,10 @@ export {
 // Own types
 export type { OsdAnnotation, OsdFields } from './types.js';
 
+// Annotation construction helpers
+export { createAnnotationFromGeometry } from './create-annotation.js';
+export type { CreateAnnotationFromGeometryOptions } from './create-annotation.js';
+
 // Pre-configured serialization (uses OSD validators)
 export { serialize, deserialize, SerializationError } from './serialization-configured.js';
 export type { DeserializeResult } from './serialization-configured.js';

--- a/packages/osdlabel/tests/unit/create-annotation.test.ts
+++ b/packages/osdlabel/tests/unit/create-annotation.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+import { createImageId } from '@osdlabel/viewer-api';
+import { createAnnotationContextId } from '@osdlabel/annotation-context';
+import {
+  createFabricObjectFromRawData,
+  getGeometryFromFabricObject,
+  initFabricModule,
+} from '@osdlabel/fabric-annotations';
+import type { Geometry } from '@osdlabel/annotation';
+import { createAnnotationFromGeometry } from '../../src/create-annotation.js';
+
+initFabricModule();
+
+const imageId = createImageId('img-1');
+const contextId = createAnnotationContextId('ctx-1');
+
+describe('createAnnotationFromGeometry', () => {
+  it('produces a complete annotation with a serialized fabric envelope', () => {
+    const geometry: Geometry = {
+      type: 'rectangle',
+      origin: { x: 10, y: 20 },
+      width: 100,
+      height: 50,
+      rotation: 0,
+    };
+    const ann = createAnnotationFromGeometry(geometry, {
+      imageId,
+      contextId,
+      toolType: 'rectangle',
+      label: 'tumor',
+    });
+
+    expect(ann.imageId).toBe(imageId);
+    expect(ann.contextId).toBe(contextId);
+    expect(ann.toolType).toBe('rectangle');
+    expect(ann.label).toBe('tumor');
+    expect(ann.geometry).toEqual(geometry);
+    expect(ann.rawAnnotationData.format).toBe('fabric');
+    expect(ann.createdAt).toBe(ann.updatedAt);
+    expect(typeof ann.createdAt).toBe('string');
+  });
+
+  it('embeds the annotation id in the serialized envelope', () => {
+    const ann = createAnnotationFromGeometry(
+      { type: 'point', position: { x: 1, y: 2 } },
+      { imageId, contextId, toolType: 'point' },
+    );
+    expect((ann.rawAnnotationData.data as { id?: string }).id).toBe(ann.id);
+  });
+
+  it('honors an explicit id', () => {
+    const ann = createAnnotationFromGeometry(
+      { type: 'circle', center: { x: 5, y: 5 }, radius: 3 },
+      { imageId, contextId, toolType: 'circle', id: undefined },
+    );
+    expect(ann.id).toBeTruthy();
+  });
+
+  it('round-trips through deserialize → getGeometryFromFabricObject', async () => {
+    const geometry: Geometry = {
+      type: 'polygon',
+      points: [
+        { x: 0, y: 0 },
+        { x: 40, y: 0 },
+        { x: 20, y: 30 },
+      ],
+    };
+    const ann = createAnnotationFromGeometry(geometry, {
+      imageId,
+      contextId,
+      toolType: 'freeHandPath',
+    });
+    // freeHandPath records polygon geometry even though the static map differs.
+    expect(ann.geometry.type).toBe('polygon');
+
+    const obj = await createFabricObjectFromRawData(ann);
+    expect(obj).not.toBeNull();
+    const back = getGeometryFromFabricObject(obj!, 'polygon');
+    expect(back?.type).toBe('polygon');
+    if (back?.type !== 'polygon') return;
+    expect(back.points).toHaveLength(3);
+    back.points.forEach((p, i) => {
+      expect(p.x).toBeCloseTo(geometry.points[i]!.x);
+      expect(p.y).toBeCloseTo(geometry.points[i]!.y);
+    });
+  });
+});

--- a/packages/osdlabel/tests/unit/create-annotation.test.ts
+++ b/packages/osdlabel/tests/unit/create-annotation.test.ts
@@ -1,13 +1,17 @@
 import { describe, expect, it } from 'vitest';
+import { FabricObject } from 'fabric';
 import { createImageId } from '@osdlabel/viewer-api';
+import type { AnnotationState } from '@osdlabel/viewer-api';
 import { createAnnotationContextId } from '@osdlabel/annotation-context';
 import {
   createFabricObjectFromRawData,
   getGeometryFromFabricObject,
   initFabricModule,
 } from '@osdlabel/fabric-annotations';
-import type { Geometry } from '@osdlabel/annotation';
+import { createAnnotationId, type Geometry } from '@osdlabel/annotation';
 import { createAnnotationFromGeometry } from '../../src/create-annotation.js';
+import { serialize, deserialize } from '../../src/serialization-configured.js';
+import type { OsdFields } from '../../src/types.js';
 
 initFabricModule();
 
@@ -49,11 +53,30 @@ describe('createAnnotationFromGeometry', () => {
   });
 
   it('honors an explicit id', () => {
+    const id = createAnnotationId('explicit-id-1');
     const ann = createAnnotationFromGeometry(
       { type: 'circle', center: { x: 5, y: 5 }, radius: 3 },
-      { imageId, contextId, toolType: 'circle', id: undefined },
+      { imageId, contextId, toolType: 'circle', id },
     );
-    expect(ann.id).toBeTruthy();
+    expect(ann.id).toBe(id);
+    expect((ann.rawAnnotationData.data as { id?: string }).id).toBe(id);
+  });
+
+  it('embeds the id even when initFabricModule has not registered it', () => {
+    // Simulate an app that never called initFabricModule(): strip the `id`
+    // custom property so toObject() would otherwise omit it.
+    const previous = FabricObject.customProperties;
+    FabricObject.customProperties = [];
+    try {
+      const ann = createAnnotationFromGeometry(
+        { type: 'point', position: { x: 7, y: 9 } },
+        { imageId, contextId, toolType: 'point' },
+      );
+      // Without the self-contained patch, this id would be missing.
+      expect((ann.rawAnnotationData.data as { id?: string }).id).toBe(ann.id);
+    } finally {
+      FabricObject.customProperties = previous;
+    }
   });
 
   it('round-trips through deserialize → getGeometryFromFabricObject', async () => {
@@ -83,5 +106,36 @@ describe('createAnnotationFromGeometry', () => {
       expect(p.x).toBeCloseTo(geometry.points[i]!.x);
       expect(p.y).toBeCloseTo(geometry.points[i]!.y);
     });
+  });
+
+  it('round-trips through the configured serialize → deserialize path', () => {
+    const geometry: Geometry = {
+      type: 'rectangle',
+      origin: { x: 30, y: 40 },
+      width: 80,
+      height: 60,
+      rotation: 0,
+    };
+    const ann = createAnnotationFromGeometry(geometry, {
+      imageId,
+      contextId,
+      toolType: 'rectangle',
+      label: 'seeded',
+    });
+
+    const state: AnnotationState<OsdFields> = {
+      byImage: { [imageId]: { [ann.id]: ann } },
+      changeCounter: 1,
+    };
+
+    // serialize → JSON → deserialize, exercising the Valibot OsdAnnotationSchema.
+    const doc = serialize(state);
+    const { byImage } = deserialize(JSON.parse(JSON.stringify(doc)) as unknown);
+    const restored = byImage[imageId]?.[ann.id];
+
+    expect(restored).toBeDefined();
+    expect(restored!.geometry).toEqual(geometry);
+    expect(restored!.label).toBe('seeded');
+    expect(restored!.rawAnnotationData.format).toBe('fabric');
   });
 });

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -47,8 +47,8 @@
     "lint": "eslint src/ tests/"
   },
   "peerDependencies": {
-    "fabric": "catalog:",
-    "openseadragon": "catalog:",
+    "fabric": "catalog:peers",
+    "openseadragon": "catalog:peers",
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0"
   },

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -47,8 +47,8 @@
     "lint": "eslint src/ tests/"
   },
   "peerDependencies": {
-    "fabric": "catalog:",
-    "openseadragon": "catalog:",
+    "fabric": "catalog:peers",
+    "openseadragon": "catalog:peers",
     "solid-js": "catalog:"
   },
   "dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,6 +98,9 @@ importers:
       '@osdlabel/solid':
         specifier: workspace:*
         version: link:../../packages/solid
+      fabric:
+        specifier: 'catalog:'
+        version: 7.4.0
       osdlabel:
         specifier: workspace:*
         version: link:../../packages/osdlabel

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,9 +39,6 @@ catalogs:
     immer:
       specifier: ^10.1.1
       version: 10.2.0
-    openseadragon:
-      specifier: 5.0.1
-      version: 5.0.1
     prettier:
       specifier: ^3.8.3
       version: 3.8.3
@@ -72,6 +69,13 @@ catalogs:
     vitest:
       specifier: ^4.1.8
       version: 4.1.8
+  peers:
+    fabric:
+      specifier: ^7.4.0
+      version: 7.4.0
+    openseadragon:
+      specifier: ^5.0.1
+      version: 5.0.1
 
 overrides:
   human-id: 4.1.3
@@ -263,7 +267,7 @@ importers:
         specifier: workspace:*
         version: link:../viewer-api
       fabric:
-        specifier: 'catalog:'
+        specifier: catalog:peers
         version: 7.4.0
     devDependencies:
       typescript:
@@ -288,10 +292,10 @@ importers:
         specifier: workspace:*
         version: link:../viewer-api
       fabric:
-        specifier: 'catalog:'
+        specifier: catalog:peers
         version: 7.4.0
       openseadragon:
-        specifier: 'catalog:'
+        specifier: catalog:peers
         version: 5.0.1
     devDependencies:
       '@types/openseadragon':
@@ -313,7 +317,7 @@ importers:
         specifier: workspace:*
         version: link:../viewer-api
       openseadragon:
-        specifier: 'catalog:'
+        specifier: catalog:peers
         version: 5.0.1
     devDependencies:
       '@types/openseadragon':
@@ -350,10 +354,10 @@ importers:
         specifier: workspace:*
         version: link:../viewer-api
       fabric:
-        specifier: 'catalog:'
+        specifier: catalog:peers
         version: 7.4.0
       openseadragon:
-        specifier: 'catalog:'
+        specifier: catalog:peers
         version: 5.0.1
       valibot:
         specifier: 'catalog:'
@@ -405,13 +409,13 @@ importers:
         specifier: workspace:*
         version: link:../viewer-api
       fabric:
-        specifier: 'catalog:'
+        specifier: catalog:peers
         version: 7.4.0
       immer:
         specifier: 'catalog:'
         version: 10.2.0
       openseadragon:
-        specifier: 'catalog:'
+        specifier: catalog:peers
         version: 5.0.1
       osdlabel:
         specifier: workspace:*
@@ -475,10 +479,10 @@ importers:
         specifier: workspace:*
         version: link:../viewer-api
       fabric:
-        specifier: 'catalog:'
+        specifier: catalog:peers
         version: 7.4.0
       openseadragon:
-        specifier: 'catalog:'
+        specifier: catalog:peers
         version: 5.0.1
       osdlabel:
         specifier: workspace:*

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -26,6 +26,15 @@ catalog:
   '@vitejs/plugin-react': ^6.0.2
   immer: ^10.1.1
 
+# Caret ranges used for PUBLISHED peerDependencies of fabric / openseadragon.
+# The default catalog above pins exact versions for reproducible dev installs;
+# these widen the consumer-facing peer range to reduce install friction in
+# monorepos. The fabric floor stays at 7.4.0 to exclude the <7.4 CVE.
+catalogs:
+  peers:
+    fabric: ^7.4.0
+    openseadragon: ^5.0.1
+
 overrides:
   human-id: 4.1.3
 


### PR DESCRIPTION
Addresses integration feedback from #125.

Code:
- Add buildFabricObjectFromGeometry (@osdlabel/fabric-annotations), the inverse
  of getGeometryFromFabricObject, with round-trip unit tests.
- Add createAnnotationFromGeometry (osdlabel umbrella, re-exported by the React
  and Solid bindings): builds a complete OsdAnnotation incl. the Fabric
  rawAnnotationData envelope and guarantees the id survives serialization,
  removing the manual serializeFabricObject/getGeometryFromFabricObject round-trip.

Docs:
- Decorations guide: new DOM decorations section (renderDomDecoration flow with
  React + Solid examples), three-render-target model, and provider extension-field
  typing / branded-id comparison guidance.
- Serialization guide: flat-out/keyed-in asymmetry note, seeding-from-geometry
  recipe, toolType<->geometry mapping (incl. freeHandPath polygon/polyline), and
  the manual round-trip fallback.
- New React & SSR guide: client-only mounting for Next.js / Remix, initFabricModule
  placement, Annotator vs AnnotatorProvider.
- Packages & Architecture: explicit umbrella-import rule.

https://claude.ai/code/session_01Lmz23MftKLSPhvpAgHrbt9