### PR TITLE
chore(release): add changeset + fix geometry lockstep group

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -10,6 +10,7 @@
       "@osdlabel/decoration",
       "@osdlabel/fabric-annotations",
       "@osdlabel/fabric-osd",
+      "@osdlabel/geometry",
       "@osdlabel/osd-helper",
       "@osdlabel/react",
       "@osdlabel/solid",

--- a/.changeset/geometry-conversion-vertex-editing.md
+++ b/.changeset/geometry-conversion-vertex-editing.md
@@ -1,0 +1,12 @@
+---
+"osdlabel": minor
+"@osdlabel/solid": minor
+"@osdlabel/react": minor
+"@osdlabel/geometry": minor
+---
+
+Add circle→rectangle conversion and interactive polygon/polyline vertex editing.
+
+- Convert a selected circle to its axis-aligned bounding rectangle via a contextual, constraint-aware "Convert to Rect" toolbar button, backed by the pure `circleToBoundingRectangle` helper.
+- Edit polygon/polyline vertices: a configurable long-press enters a sticky edit mode with per-vertex move handles and edge-midpoint insertion handles; Delete/Backspace removes a vertex (min 3 polygon / 2 polyline). Reachable from the Select, Polyline, and Free-draw tools; long-press timing/tolerance are Annotator-level options.
+- New `@osdlabel/geometry` package holds the geometry math and conversions; `@osdlabel/decoration` re-exports the math so the public API is unchanged.


### PR DESCRIPTION
## Why

The geometry-conversion + vertex-editing PR (#130) merged **without a changeset**, so the release workflow skipped the version-PR path and went straight to `publish`, which failed on the brand-new `@osdlabel/geometry` package.

This PR fixes the release tooling. It does **not** itself publish the new package (see note below).

## Changes

- **Add `@osdlabel/geometry` to the `fixed` lockstep group** in `.changeset/config.json`. It was missing, so on the next release it would have desynced from the other `@osdlabel/*` packages (and `pnpm run check-versions` would eventually fail).
- **Add a `minor` changeset** describing the circle→rectangle conversion + polygon/polyline vertex editing features and the new geometry package, so CI opens a proper **"Version Packages"** PR (bumping all packages 0.4.0 → 0.5.0).

`pnpm changeset status` confirms every fixed-group package (now including `@osdlabel/geometry`) bumps minor together.

## ⚠️ Still required: first publish of `@osdlabel/geometry`

The publish workflow uses npm **trusted publishing (OIDC)** with `--provenance` and no `NODE_AUTH_TOKEN`. OIDC can only publish a package that **already exists on npm** with a trusted publisher configured — so the very first publish of `@osdlabel/geometry` can't happen through this workflow.

A one-time bootstrap is needed (from a machine with npm credentials), e.g.:

```sh
pnpm --filter @osdlabel/geometry build
cd packages/geometry && npm publish --access public
```

Then add the GitHub Actions trusted publisher for the package on npmjs.com. After that, normal OIDC releases (via the Version Packages PR) will publish it like every other package.

Merging this PR is safe on its own — it only changes release metadata.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VLQKoLHRua4H8ArZPhLM7L)_