### PR TITLE
docs: bring READMEs up to date with features shipped since June

### DIFF
--- a/.changeset/readme-refresh-view-controls.md
+++ b/.changeset/readme-refresh-view-controls.md
@@ -1,0 +1,20 @@
+---
+'osdlabel': patch
+'@osdlabel/annotation': patch
+'@osdlabel/annotation-context': patch
+'@osdlabel/decoration': patch
+'@osdlabel/fabric-annotations': patch
+'@osdlabel/fabric-osd': patch
+'@osdlabel/geometry': patch
+'@osdlabel/react': patch
+'@osdlabel/solid': patch
+'@osdlabel/viewer-api': patch
+---
+
+Bring every README up to date with the features shipped since they were last written, and republish so the new content reaches npm.
+
+- Add the missing README for `@osdlabel/geometry`, the package the geometry math and `circleToBoundingRectangle` moved into. The root README's package layout lists it too.
+- Document what's new: polygon/polyline vertex editing (`PolyVertexEditor`), circle→rectangle conversion, per-cell `contrast` alongside `exposure`/`inverted`, the `customControl` overlay mode with its `createDragValueControl` / `createDragVectorControl` factories, `ViewerControlId` / `VIEWER_CONTROL_SPECS`, and `.` / `,` context cycling.
+- Drop `initFabricModule()` from every quick start — `FabricOverlay` now calls it on construction. The call stays documented as the escape hatch for building Fabric objects before an overlay exists.
+- Fix inaccuracies: `composeProviders` takes an array (not varargs) and `createMeasurementProvider` requires an options object, so the decoration examples did not compile; the geometry union member is `polygon`, not `path`; and the `@osdlabel/solid` / `@osdlabel/react` install commands no longer list `valibot`, which is not a peer dependency of either.
+- Replace the root README's keyboard table with the actual `DEFAULT_KEYBOARD_SHORTCUTS`, which had drifted — the polyline tool is `d` and freehand is `f`, and the `Shift`-modified view/tone bindings were missing entirely.

--- a/README.md
+++ b/README.md
@@ -9,9 +9,12 @@ Powered by [OpenSeaDragon](https://openseadragon.github.io/) for deep zoom tiled
 - **Deep Zoom support** — annotate gigapixel images served as DZI tiles, or plain image files
 - **Multi-image grid** — view and annotate up to 16 images simultaneously in a configurable grid layout
 - **Annotation tools** — rectangle, circle, line, point, polyline/polygon, and freehand path drawing
+- **Vertex editing** — long-press a polygon or polyline to move, insert, and delete individual vertices
+- **Geometry conversion** — convert a selected circle to its bounding rectangle
 - **Context system** — define multiple annotation contexts with per-tool constraints (max count, count scope)
 - **Decorations & measurements** — derived text labels, calibrated area/length/perimeter measurements, and connector lines via composable `DecorationProvider` functions, recomputed at render time (never serialized)
-- **View controls** — rotate and flip the viewport horizontally/vertically with overlay annotations following in lockstep
+- **View controls** — per-cell rotate, flip, and tonal adjustment (exposure, contrast, invert) with overlay annotations following in lockstep
+- **Drag-driven controls** — a `customControl` overlay mode that routes raw pointer input to your own handler, used by the built-in two-axis exposure/contrast gesture
 - **Serialization** — export and import annotations as JSON with a versioned document format
 - **Keyboard shortcuts** — fully configurable hotkeys for tools, grid navigation, and drawing actions
 - **Framework-agnostic core** — annotation model, serialization, and constraint logic have zero UI framework dependencies
@@ -38,15 +41,8 @@ npm install @osdlabel/react
 
 ```tsx
 import { render } from 'solid-js/web';
-import {
-  Annotator,
-  createImageId,
-  createAnnotationContextId,
-  initFabricModule,
-} from '@osdlabel/solid';
+import { Annotator, createImageId, createAnnotationContextId } from '@osdlabel/solid';
 import type { ImageSource, AnnotationContext } from '@osdlabel/solid';
-
-initFabricModule();
 
 const images: ImageSource[] = [
   {
@@ -90,15 +86,8 @@ render(() => <App />, document.getElementById('app')!);
 
 ```tsx
 import { createRoot } from 'react-dom/client';
-import {
-  Annotator,
-  createImageId,
-  createAnnotationContextId,
-  initFabricModule,
-} from '@osdlabel/react';
+import { Annotator, createImageId, createAnnotationContextId } from '@osdlabel/react';
 import type { ImageSource, AnnotationContext } from '@osdlabel/react';
-
-initFabricModule();
 
 // images and contexts defined the same way as above
 
@@ -120,12 +109,17 @@ function App() {
 createRoot(document.getElementById('app')!).render(<App />);
 ```
 
+The viewer registers the Fabric `id` custom property automatically when it
+mounts, so there is no setup call to remember. `initFabricModule()` is still
+exported and idempotent for advanced setups that build Fabric objects before any
+viewer exists.
+
 ## Composable API
 
 For more control, use the individual components and provider directly:
 
 ```tsx
-// SolidJS
+// SolidJS — the same names are exported from '@osdlabel/react'
 import {
   AnnotatorProvider,
   useAnnotator,
@@ -134,29 +128,25 @@ import {
   GridView,
   Filmstrip,
   GridControls,
+  ContextSwitcher,
+  ViewControls,
   serialize,
   deserialize,
 } from '@osdlabel/solid';
-
-// React
-import {
-  AnnotatorProvider,
-  useAnnotator,
-  Toolbar,
-  StatusBar,
-  GridView,
-  Filmstrip,
-  GridControls,
-  serialize,
-  deserialize,
-} from '@osdlabel/react';
 ```
 
-Wrap your UI in `<AnnotatorProvider>`, call `useAnnotator()` for access to state and actions, then compose `Toolbar`, `GridView`, `Filmstrip`, `StatusBar`, and `GridControls` however you like.
+Wrap your UI in `<AnnotatorProvider>`, call `useAnnotator()` for access to state and actions, then compose `Toolbar`, `GridView`, `Filmstrip`, `StatusBar`, `GridControls`, `ContextSwitcher`, and `ViewControls` however you like.
 
 ## Direct Package Imports
 
-For advanced usage or building a custom UI layer, import from the granular packages:
+**Import everything from the single umbrella package you already depend on**
+(`@osdlabel/solid`, `@osdlabel/react`, or `osdlabel`). Types such as `ImageId`,
+`AnnotationId`, and `ImageSource` physically live in lower-level subpackages, so
+importing them from those paths only resolves when the subpackage is a _direct_
+dependency of your app. The umbrella re-exports them all.
+
+Reach for the granular packages only when building a custom UI layer, and add
+them as explicit dependencies:
 
 ```ts
 import type { Annotation, Geometry } from '@osdlabel/annotation';
@@ -186,24 +176,57 @@ const context: AnnotationContext = {
 
 Default shortcuts (configurable via `keyboardShortcuts` prop):
 
-| Action                | Key                    |
-| --------------------- | ---------------------- |
-| Select tool           | `v`                    |
-| Rectangle tool        | `r`                    |
-| Circle tool           | `c`                    |
-| Line tool             | `l`                    |
-| Point tool            | `p`                    |
-| Path tool             | `d`                    |
-| Delete annotation     | `Delete` / `Backspace` |
-| Cancel / Deselect     | `Escape`               |
-| Grid cell 1-9         | `1`-`9`                |
-| Increase grid columns | `=` / `+`              |
-| Decrease grid columns | `-`                    |
-| Increase grid rows    | `]`                    |
-| Decrease grid rows    | `[`                    |
-| Finish path           | `Enter`                |
-| Close path            | `c`                    |
-| Cancel path           | `Escape`               |
+### Tools
+
+| Action             | Key                    |
+| ------------------ | ---------------------- |
+| Select tool        | `v`                    |
+| Rectangle tool     | `r`                    |
+| Circle tool        | `c`                    |
+| Line tool          | `l`                    |
+| Point tool         | `p`                    |
+| Polyline tool      | `d`                    |
+| Freehand path tool | `f`                    |
+| Delete annotation  | `Delete` / `Backspace` |
+| Cancel / Deselect  | `Escape`               |
+
+### Grid & contexts
+
+| Action                      | Key       |
+| --------------------------- | --------- |
+| Grid cell 1-9               | `1`-`9`   |
+| Increase grid columns       | `=` / `+` |
+| Decrease grid columns       | `-`       |
+| Increase grid rows          | `]`       |
+| Decrease grid rows          | `[`       |
+| Next annotation context     | `.`       |
+| Previous annotation context | `,`       |
+
+Context cycling steps through the `contexts` array in configured order, wrapping
+at both ends and skipping contexts scoped to other images.
+
+### View & tone (active cell, `Shift` + key)
+
+| Action            | Key         |
+| ----------------- | ----------- |
+| Rotate clockwise  | `Shift`+`R` |
+| Rotate counter-CW | `Shift`+`L` |
+| Flip horizontally | `Shift`+`H` |
+| Flip vertically   | `Shift`+`V` |
+| Toggle negative   | `Shift`+`N` |
+| Increase exposure | `Shift`+`E` |
+| Decrease exposure | `Shift`+`D` |
+| Increase contrast | `Shift`+`C` |
+| Decrease contrast | `Shift`+`X` |
+| Reset view        | `Shift`+`0` |
+
+### Polyline drawing
+
+| Action      | Key      |
+| ----------- | -------- |
+| Finish path | `Enter`  |
+| Close path  | `c`      |
+| Cancel path | `Escape` |
 
 ## Decorations & Measurements
 
@@ -217,12 +240,47 @@ calibrated physical measurements:
 ```ts
 import { createMeasurementProvider, createLabelProvider, composeProviders } from '@osdlabel/solid'; // or '@osdlabel/react'
 
-const providers = composeProviders(
+// composeProviders takes an array; createMeasurementProvider needs an options
+// object saying which measurements to render (all flags default to false).
+const providers = composeProviders([
   createLabelProvider(),
-  createMeasurementProvider(), // area / perimeter / length / radius
-);
+  createMeasurementProvider({ area: true, perimeter: true, length: true, radius: true }),
+]);
 
 // <Annotator decorationProviders={providers} defaultPixelSpacing={{ x: 0.25, y: 0.25, unit: 'um' }} ... />
+```
+
+## View & Tone Controls
+
+Each grid cell carries its own `CellTransform` — rotation, horizontal/vertical
+flip, and the tonal adjustments `exposure`, `contrast`, and `inverted`. Rotation
+and flip are composed into the Fabric `viewportTransform` so annotations track
+the image exactly; the tonal fields are rendered as a CSS `filter` on the viewer
+element and never touch annotation geometry.
+
+The built-in `ViewControls` component exposes all of these (shown by default in
+`Annotator`; disable with `showViewControls={false}`), and the `Shift`+key
+shortcuts above drive the same actions.
+
+Exposure and contrast also have a **drag** gesture: arming the `tone` control puts
+the overlay into `customControl` mode, where a horizontal drag adjusts exposure
+(left = brighter) and a vertical drag adjusts contrast (up = more). The same
+mechanism is available for your own controls:
+
+```ts
+import { createDragValueControl, createDragVectorControl } from '@osdlabel/solid';
+
+const handler = createDragValueControl({
+  getValue: () => currentValue, // read at pointer-down
+  setValue: (v) => setValue(v), // called continuously during the drag
+  sensitivity: 0.01,
+  step: 0.025,
+  min: -1,
+  max: 1,
+});
+
+overlay.setCustomControlHandler(handler);
+overlay.setMode('customControl');
 ```
 
 ## Serialization
@@ -248,8 +306,9 @@ focused packages with strict dependency boundaries:
 ```
 packages/annotation/          # @osdlabel/annotation — pure data model (zero deps)
 packages/viewer-api/          # @osdlabel/viewer-api — viewer state types, PixelSpacing
+packages/geometry/            # @osdlabel/geometry — geometry math & conversions
 packages/annotation-context/  # @osdlabel/annotation-context — contexts, constraints, scoping
-packages/decoration/          # @osdlabel/decoration — decorations, geometry math, providers
+packages/decoration/          # @osdlabel/decoration — decorations & providers (re-exports geometry math)
 packages/validation/          # @osdlabel/validation — Valibot schemas (Standard Schema)
 packages/osd-helper/          # @osdlabel/osd-helper — OpenSeaDragon utilities
 packages/fabric-annotations/  # @osdlabel/fabric-annotations — Fabric.js tools & serialization
@@ -285,16 +344,17 @@ pnpm format           # format with Prettier
 
 ## Tech Stack
 
-| Layer         | Technology               |
-| ------------- | ------------------------ |
-| UI Frameworks | SolidJS 1.9, React 18/19 |
-| State (React) | Immer                    |
-| Canvas        | Fabric.js 7              |
-| Tile Viewer   | OpenSeaDragon 5          |
-| Language      | TypeScript 5             |
-| Bundler       | Vite 6                   |
-| Tests         | Vitest + Playwright      |
-| Monorepo      | pnpm + Turborepo         |
+| Layer         | Technology                |
+| ------------- | ------------------------- |
+| UI Frameworks | SolidJS 1.9, React 18/19  |
+| State (React) | Immer 10                  |
+| Canvas        | Fabric.js 7.4             |
+| Tile Viewer   | OpenSeaDragon 5           |
+| Validation    | Valibot (Standard Schema) |
+| Language      | TypeScript 5.9            |
+| Bundler       | Vite 8                    |
+| Tests         | Vitest 4 + Playwright     |
+| Monorepo      | pnpm + Turborepo          |
 
 ## License
 

--- a/apps/docs/public/llms.txt
+++ b/apps/docs/public/llms.txt
@@ -1099,6 +1099,34 @@ osdlabel is designed for high-throughput annotation tasks with a comprehensive s
 | `-`                    | Remove a grid column                      |
 | `]`                    | Add a grid row                            |
 | `[`                    | Remove a grid row                         |
+| `.` / `>`              | Activate the next annotation context      |
+| `,` / `<`              | Activate the previous annotation context  |
+
+### Annotation context cycling
+
+`.` and `,` step through the `contexts` array in the order you configured it,
+wrapping around at both ends. This is the keyboard equivalent of picking an
+entry in the [`ContextSwitcher`](/osdlabel/api/components/) — nothing else about
+the session changes.
+
+Contexts scoped to other images (via `AnnotationContext.imageIds`) are skipped,
+so cycling only ever lands on a context that is usable on the image in the
+active cell. If the currently active context is itself scoped out of that image,
+`.` enters the ring at the first usable context and `,` at the last.
+
+The active tool is deliberately left selected across a switch. If the new
+context disallows it, the toolbar shows it disabled and the draw is rejected —
+the same enforcement that applies when you pick a context from the UI.
+
+```tsx
+const contexts = [
+  { id: createAnnotationContextId('lesions'), label: 'Lesions', tools: [{ type: 'rectangle' }] },
+  { id: createAnnotationContextId('landmarks'), label: 'Landmarks', tools: [{ type: 'point' }] },
+];
+
+// Pressing `.` with 'lesions' active makes 'landmarks' the active context.
+<Annotator images={images} contexts={contexts} />;
+```
 
 ### Polyline tool shortcuts
 

--- a/apps/docs/src/content/docs/llm.md
+++ b/apps/docs/src/content/docs/llm.md
@@ -1093,6 +1093,34 @@ osdlabel is designed for high-throughput annotation tasks with a comprehensive s
 | `-`                    | Remove a grid column                      |
 | `]`                    | Add a grid row                            |
 | `[`                    | Remove a grid row                         |
+| `.` / `>`              | Activate the next annotation context      |
+| `,` / `<`              | Activate the previous annotation context  |
+
+### Annotation context cycling
+
+`.` and `,` step through the `contexts` array in the order you configured it,
+wrapping around at both ends. This is the keyboard equivalent of picking an
+entry in the [`ContextSwitcher`](/osdlabel/api/components/) — nothing else about
+the session changes.
+
+Contexts scoped to other images (via `AnnotationContext.imageIds`) are skipped,
+so cycling only ever lands on a context that is usable on the image in the
+active cell. If the currently active context is itself scoped out of that image,
+`.` enters the ring at the first usable context and `,` at the last.
+
+The active tool is deliberately left selected across a switch. If the new
+context disallows it, the toolbar shows it disabled and the draw is rejected —
+the same enforcement that applies when you pick a context from the UI.
+
+```tsx
+const contexts = [
+  { id: createAnnotationContextId('lesions'), label: 'Lesions', tools: [{ type: 'rectangle' }] },
+  { id: createAnnotationContextId('landmarks'), label: 'Landmarks', tools: [{ type: 'point' }] },
+];
+
+// Pressing `.` with 'lesions' active makes 'landmarks' the active context.
+<Annotator images={images} contexts={contexts} />;
+```
 
 ### Polyline tool shortcuts
 

--- a/packages/annotation-context/README.md
+++ b/packages/annotation-context/README.md
@@ -18,8 +18,10 @@ npm install @osdlabel/annotation-context
 
 ## What's inside
 
-- `AnnotationContext`, `AnnotationContextId` (branded id)
-- `ToolConstraint`, `ConstraintStatus`, `ContextState`, `ContextFields`
+- `AnnotationContext`, `AnnotationContextId` (branded id), and its
+  `createAnnotationContextId` factory
+- `ToolConstraint`, `CountScope` (`'per-image' | 'global'`), `ConstraintStatus`,
+  `ContextState`, `ContextFields`
 - Scoping helpers: `isContextScopedToImage`, `getCountableImageIds`
 
 ## Usage

--- a/packages/annotation/README.md
+++ b/packages/annotation/README.md
@@ -19,8 +19,11 @@ npm install @osdlabel/annotation
   via intersection by feature packages
 - `BaseAnnotation`, `AnnotationStyle`, `AnnotationId` (branded id)
 - `Geometry` — discriminated union of geometry types (rectangle, circle, line,
-  point, polyline, path)
-- `ToolType` and `toolTypeToGeometryType`
+  point, polyline, polygon)
+- `ToolType` (`rectangle`, `circle`, `line`, `point`, `polyline`,
+  `freeHandPath`) and `toolTypeToGeometryType` — several tools can produce the
+  same geometry, so the two unions are deliberately distinct
+- `DEFAULT_ANNOTATION_STYLE`
 - `RawAnnotationData<TFormat, TData>` — generic raw-data container
 - `createAnnotationId` and other id/util helpers
 

--- a/packages/decoration/README.md
+++ b/packages/decoration/README.md
@@ -8,7 +8,8 @@ library for gigapixel/DZI images.
 Decorations are a **pure derivation** of annotation state — they are never
 serialized, and they are recomputed whenever the underlying annotations change.
 This package defines the data model and provider contract; the rendering happens
-in `@osdlabel/fabric-osd`. Zero framework dependencies.
+in `@osdlabel/fabric-osd`. Zero framework dependencies. Depends on
+`@osdlabel/annotation`, `@osdlabel/geometry`, and `@osdlabel/viewer-api`.
 
 ## Installation
 
@@ -18,17 +19,19 @@ npm install @osdlabel/decoration
 
 ## What's inside
 
-- `Decoration` discriminated union — `TextDecoration` (supports `zIndex`) and
-  `LineDecoration`
+- `Decoration` discriminated union — `TextDecoration` (supports `zIndex`),
+  `LineDecoration`, and `DomDecoration`
 - `DecorationProvider` contract + `composeProviders`, `DecorationContext`
 - Built-in providers: `createMeasurementProvider`, `createLabelProvider`,
   `createDistanceProvider`
 - `withSelectionEmphasis` — opt-in style/z-index elevation for the selected
   annotation's decorations
-- Geometry math: `area`, `perimeter`, `length`, `radius`, `distance`,
-  `centroid`, `midpoint`, `boundingBox`
 - Measurements: `Measurement`, `toPhysicalLength`, `toPhysicalArea`,
   `formatMeasurement`
+- Geometry math — `area`, `perimeter`, `length`, `radius`, `distance`,
+  `centroid`, `midpoint`, `boundingBox`, `circleToBoundingRectangle` — now lives
+  in [`@osdlabel/geometry`](https://github.com/osdlabel/osdlabel/tree/main/packages/geometry)
+  and is re-exported here unchanged
 
 ## Usage
 
@@ -39,10 +42,12 @@ import {
   composeProviders,
 } from '@osdlabel/decoration';
 
-const providers = composeProviders(
+// composeProviders takes an array; createMeasurementProvider needs an options
+// object saying which measurements to render (all flags default to false).
+const providers = composeProviders([
   createLabelProvider(),
-  createMeasurementProvider(), // area / perimeter / length / radius
-);
+  createMeasurementProvider({ area: true, perimeter: true, length: true, radius: true }),
+]);
 ```
 
 ## License

--- a/packages/fabric-annotations/README.md
+++ b/packages/fabric-annotations/README.md
@@ -20,18 +20,42 @@ npm install @osdlabel/fabric-annotations fabric
 - Drawing tools: `RectangleTool`, `CircleTool`, `LineTool`, `PointTool`,
   `PolylineTool`, `FreeHandPathTool`, `SelectTool` (plus `BaseTool` / `ShapeTool`
   base classes) and the `ToolOverlay` interface
+- `PolyVertexEditor` — interactive vertex editing for polygon / polyline
+  annotations, plus `DEFAULT_VERTEX_EDIT_LONG_PRESS_MS` and
+  `DEFAULT_VERTEX_EDIT_MOVE_TOLERANCE_PX`
 - `initFabricModule` — registers custom serialized properties on Fabric objects
 - Serialization helpers: `serializeFabricObject`, `deserializeFabricObject`,
   `createFabricObjectFromRawData`, `getGeometryFromFabricObject`,
   `getFabricOptions`
+- `buildFabricObjectFromGeometry` — rebuilds a Fabric object from annotation
+  geometry (used when an annotation's geometry changes type, e.g. circle →
+  rectangle)
 - `FabricRawAnnotationData` and the `FabricFields` extension interface
+
+## Vertex editing
+
+`PolyVertexEditor` builds on Fabric v7's native poly controls
+(`controlsUtils.createPolyControls`) and adds three things on top: a configurable
+**long-press** to enter a sticky edit mode (tablet-friendly), **edge-insertion**
+handles at edge midpoints that splice in a new vertex and continue the same
+drag, and **vertex deletion** via `Delete`/`Backspace`, honoring per-shape
+minimums (3 points for a polygon, 2 for a polyline).
+
+It is owned by the Select, Polyline, and free-draw tools, so it is active
+automatically — vertex moves commit through the same `object:modified` →
+`getGeometryFromFabricObject` path as any other edit. Tune the gesture through
+`SelectTool`'s constructor, or through the `vertexEditLongPressMs` /
+`vertexEditMoveTolerancePx` props on the framework `Annotator`.
 
 ## Usage
 
 ```ts
 import { initFabricModule } from '@osdlabel/fabric-annotations';
 
-// Call once before creating any annotations so custom properties serialize.
+// Optional: `FabricOverlay` calls this on construction, so most consumers never
+// need it. It stays exported (and idempotent) for setups that build Fabric
+// objects before any overlay exists. The `id` entry is merged into existing
+// `customProperties`, so consumer-registered properties are preserved.
 initFabricModule();
 ```
 

--- a/packages/fabric-osd/README.md
+++ b/packages/fabric-osd/README.md
@@ -19,16 +19,50 @@ npm install @osdlabel/fabric-osd fabric openseadragon
 ## What's inside
 
 - `FabricOverlay` — canvas overlay + viewport transform; exposes `onSync`,
-  `overlayElement`, and flip-aware `imageToScreen` / `screenToImage`
+  `overlayElement`, and flip-aware `imageToScreen` / `screenToImage`. Calls
+  `initFabricModule()` on construction, so consumers don't have to.
 - `DecorationLayer` — renders text decorations as positioned DOM elements and
   connector lines as non-interactive Fabric objects
+- `composeImageFilterCss` / `ImageFilters` — composes a cell's tonal adjustments
+  (`exposure`, `contrast`, `inverted`) into a CSS `filter` value
+- Drag-driven control factories: `createDragValueControl` (one value),
+  `createDragVectorControl` (one value per axis), and the shared
+  `DragAxisBehavior` config
 - Pure helpers: `computeViewportTransform`, `imageToScreenFlipAware`,
   `screenToImageFlipAware`
+
+## Overlay modes
+
+`FabricOverlay` routes pointer input through an OSD `MouseTracker`, and its
+`OverlayMode` decides who owns the mouse:
+
+| Mode            | OSD navigation | Fabric annotation | Pointer events go to                   |
+| --------------- | -------------- | ----------------- | -------------------------------------- |
+| `navigation`    | enabled        | display-only      | OSD (pan / zoom)                       |
+| `annotation`    | disabled\*     | active            | Fabric (select / move / draw)          |
+| `customControl` | disabled       | inert             | your registered `CustomControlHandler` |
+
+\* In `annotation` mode, `Ctrl`/`Cmd`+drag still passes through to OSD for
+panning. In `customControl` mode `Ctrl`/`Cmd`+scroll still zooms, so users don't
+lose zoom while a control is engaged.
 
 ## Usage
 
 ```ts
-import { FabricOverlay, DecorationLayer } from '@osdlabel/fabric-osd';
+import { FabricOverlay, DecorationLayer, createDragValueControl } from '@osdlabel/fabric-osd';
+
+// Route pointer drags to your own handler instead of OSD or Fabric.
+overlay.setCustomControlHandler(
+  createDragValueControl({
+    getValue: () => exposure, // read at pointer-down
+    setValue: (v) => setExposure(v), // called continuously during the drag
+    sensitivity: 0.01,
+    step: 0.025,
+    min: -1,
+    max: 1,
+  }),
+);
+overlay.setMode('customControl');
 ```
 
 See the [main repository](https://github.com/osdlabel/osdlabel) for full overlay

--- a/packages/geometry/README.md
+++ b/packages/geometry/README.md
@@ -1,0 +1,58 @@
+# @osdlabel/geometry
+
+Pure geometry math and geometry-type conversions for
+[osdlabel](https://github.com/osdlabel/osdlabel), a web-based image annotation
+library for gigapixel/DZI images.
+
+Everything here operates on the `Geometry` discriminated union from
+`@osdlabel/annotation` in **image-space pixels** — no calibration, no rendering,
+no framework dependencies. Physical-unit conversion (`toPhysicalLength`,
+`toPhysicalArea`) lives in `@osdlabel/decoration`.
+
+## Installation
+
+```bash
+npm install @osdlabel/geometry
+```
+
+`@osdlabel/decoration` re-exports this package's entire surface, so if you
+already depend on `@osdlabel/decoration`, `osdlabel`, `@osdlabel/solid`, or
+`@osdlabel/react` you can import these functions from there instead of adding a
+dependency.
+
+## What's inside
+
+- Measurements: `area`, `perimeter`, `length`, `radius`
+- Point math: `distance`, `centroid`, `midpoint`
+- `boundingBox` — axis-aligned bounds of any geometry
+- `circleToBoundingRectangle` — converts a circle geometry to the rectangle that
+  bounds it (backs the "convert to rectangle" annotation action)
+
+Every function accepts any `Geometry`, so callers never branch on
+`geometry.type` themselves:
+
+- `area` returns image-px² for rectangles, circles, and polygons, and `0` for
+  zero-area geometries (points, lines, polylines). Polygon area uses the
+  absolute shoelace area, so winding direction doesn't matter.
+- `perimeter` is the closed-perimeter of rectangles, circles, and polygons, and
+  `0` for open shapes — use `length` for those.
+- `length` is the open-curve length of lines and polylines; for closed shapes it
+  equals `perimeter`.
+- `radius` returns `number | undefined` — it is the only geometry-specific
+  accessor, defined for circles alone.
+
+## Usage
+
+```ts
+import { area, boundingBox, circleToBoundingRectangle } from '@osdlabel/geometry';
+
+const px = area(annotation.geometry); // square image pixels
+
+if (annotation.geometry.type === 'circle') {
+  const rect = circleToBoundingRectangle(annotation.geometry);
+}
+```
+
+## License
+
+BSD-3-Clause. Part of the [osdlabel](https://github.com/osdlabel/osdlabel) monorepo.

--- a/packages/osdlabel/README.md
+++ b/packages/osdlabel/README.md
@@ -23,14 +23,25 @@ npm install osdlabel fabric openseadragon valibot
 - `serialize` / `deserialize` (versioned JSON document format),
   `SerializationError`, `DeserializeResult`
 - Pure reducers — `applyAnnotationAction`, `applyUIAction`, `applyContextAction`
-  — that work with both SolidJS `produce()` and Immer `produce()`
-- Initial-state factories and `computeConstraintStatus`
-- Keyboard mapping: `mapKeyEventToActions`, `DEFAULT_KEYBOARD_SHORTCUTS`
+  — that work with both SolidJS `produce()` and Immer `produce()`, plus
+  `validateAddAnnotation`
+- Initial-state factories, `computeConstraintStatus`, and
+  `countAnnotationsForContextAndType`
+- Keyboard mapping: `mapKeyEventToActions`, `DEFAULT_KEYBOARD_SHORTCUTS`,
+  `MAX_GRID_SIZE`
 - Context cycling: `getCycledContextId`, `getSelectableContexts`
-- Tool factory: `createAnnotationTool`, `buildToolCallbacks`
+- `createAnnotationFromGeometry` — builds a complete annotation (id, style, raw
+  Fabric data) from a geometry
+- Tool factory: `createAnnotationTool`, `buildToolCallbacks`, and the pure
+  processors `processObjectModified`, `processToolAddAnnotation`,
+  `processToolUpdateAnnotation`, `processConvertCircleToRectangle`
+- `VIEWER_CONTROL_SPECS` / `getToneValue` — the framework-agnostic registry of
+  drag-driven viewer controls, so the Solid and React hooks configure the
+  exposure/contrast gesture identically
 - `enableLiveDecorationUpdates` — rAF-throttled live label-follows-shape updates
   during Fabric drags
-- Re-exports the full `@osdlabel/decoration` API
+- Re-exports the full `@osdlabel/decoration`, `@osdlabel/fabric-annotations`,
+  `@osdlabel/fabric-osd`, and `@osdlabel/validation` public APIs
 
 ## Usage
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -15,32 +15,30 @@ management. Works with React 18 and 19.
 - Deep zoom annotation of gigapixel DZI images or plain image files
 - Multi-image grid (up to 16 images) with one active annotation cell at a time
 - Rectangle, circle, line, point, polyline/polygon, and freehand path tools
-- Annotation contexts with per-tool constraints (max count, count scope)
+- Vertex editing on polygons and polylines (long-press to move, insert, delete)
+- Convert a selected circle to its bounding rectangle
+- Annotation contexts with per-tool constraints (max count, count scope), with
+  `.` / `,` to cycle between them
 - Derived text labels, calibrated measurements, and connector lines via
   decoration providers
-- View controls (rotate / flip) with overlay annotations following in lockstep
+- Per-cell view controls — rotate, flip, and tonal adjustment (exposure,
+  contrast, invert) — with overlay annotations following in lockstep
+- Drag-driven custom controls via the `customControl` overlay mode
 - Configurable keyboard shortcuts
 - Versioned JSON serialization
 
 ## Installation
 
 ```bash
-npm install @osdlabel/react react react-dom fabric openseadragon valibot
+npm install @osdlabel/react react react-dom fabric openseadragon
 ```
 
 ## Quick Start
 
 ```tsx
 import { createRoot } from 'react-dom/client';
-import {
-  Annotator,
-  createImageId,
-  createAnnotationContextId,
-  initFabricModule,
-} from '@osdlabel/react';
+import { Annotator, createImageId, createAnnotationContextId } from '@osdlabel/react';
 import type { ImageSource, AnnotationContext } from '@osdlabel/react';
-
-initFabricModule();
 
 const images: ImageSource[] = [
   {
@@ -77,11 +75,16 @@ function App() {
 createRoot(document.getElementById('app')!).render(<App />);
 ```
 
+The `Annotator` registers the Fabric `id` custom property automatically when its
+viewer mounts, so there is no setup call to remember. `initFabricModule()` is
+still exported and idempotent if you build Fabric objects yourself before any
+viewer exists.
+
 ## Composable API
 
 Prefer to assemble the UI yourself? Wrap your tree in `<AnnotatorProvider>`, call
 `useAnnotator()` for state and actions, then compose `Toolbar`, `GridView`,
-`Filmstrip`, `StatusBar`, `GridControls`, and `ViewControls`:
+`Filmstrip`, `StatusBar`, `GridControls`, `ContextSwitcher`, and `ViewControls`:
 
 ```tsx
 import {
@@ -92,10 +95,16 @@ import {
   Filmstrip,
   StatusBar,
   GridControls,
+  ContextSwitcher,
+  ViewControls,
   serialize,
   deserialize,
 } from '@osdlabel/react';
 ```
+
+`ViewControls` exposes the per-cell rotate / flip / exposure / contrast / invert
+actions. It is shown by default inside `Annotator` — pass
+`showViewControls={false}` to hide it.
 
 Sub-path barrels are also available: `@osdlabel/react/components`,
 `@osdlabel/react/state`, `@osdlabel/react/hooks`.

--- a/packages/solid/README.md
+++ b/packages/solid/README.md
@@ -14,32 +14,30 @@ components, hooks, and state stores.
 - Deep zoom annotation of gigapixel DZI images or plain image files
 - Multi-image grid (up to 16 images) with one active annotation cell at a time
 - Rectangle, circle, line, point, polyline/polygon, and freehand path tools
-- Annotation contexts with per-tool constraints (max count, count scope)
+- Vertex editing on polygons and polylines (long-press to move, insert, delete)
+- Convert a selected circle to its bounding rectangle
+- Annotation contexts with per-tool constraints (max count, count scope), with
+  `.` / `,` to cycle between them
 - Derived text labels, calibrated measurements, and connector lines via
   decoration providers
-- View controls (rotate / flip) with overlay annotations following in lockstep
+- Per-cell view controls — rotate, flip, and tonal adjustment (exposure,
+  contrast, invert) — with overlay annotations following in lockstep
+- Drag-driven custom controls via the `customControl` overlay mode
 - Configurable keyboard shortcuts
 - Versioned JSON serialization
 
 ## Installation
 
 ```bash
-npm install @osdlabel/solid solid-js fabric openseadragon valibot
+npm install @osdlabel/solid solid-js fabric openseadragon
 ```
 
 ## Quick Start
 
 ```tsx
 import { render } from 'solid-js/web';
-import {
-  Annotator,
-  createImageId,
-  createAnnotationContextId,
-  initFabricModule,
-} from '@osdlabel/solid';
+import { Annotator, createImageId, createAnnotationContextId } from '@osdlabel/solid';
 import type { ImageSource, AnnotationContext } from '@osdlabel/solid';
-
-initFabricModule();
 
 const images: ImageSource[] = [
   {
@@ -76,11 +74,16 @@ function App() {
 render(() => <App />, document.getElementById('app')!);
 ```
 
+The `Annotator` registers the Fabric `id` custom property automatically when its
+viewer mounts, so there is no setup call to remember. `initFabricModule()` is
+still exported and idempotent if you build Fabric objects yourself before any
+viewer exists.
+
 ## Composable API
 
 Prefer to assemble the UI yourself? Wrap your tree in `<AnnotatorProvider>`, call
 `useAnnotator()` for state and actions, then compose `Toolbar`, `GridView`,
-`Filmstrip`, `StatusBar`, `GridControls`, and `ViewControls`:
+`Filmstrip`, `StatusBar`, `GridControls`, `ContextSwitcher`, and `ViewControls`:
 
 ```tsx
 import {
@@ -91,10 +94,16 @@ import {
   Filmstrip,
   StatusBar,
   GridControls,
+  ContextSwitcher,
+  ViewControls,
   serialize,
   deserialize,
 } from '@osdlabel/solid';
 ```
+
+`ViewControls` exposes the per-cell rotate / flip / exposure / contrast / invert
+actions. It is shown by default inside `Annotator` — pass
+`showViewControls={false}` to hide it.
 
 Sub-path barrels are also available: `@osdlabel/solid/components`,
 `@osdlabel/solid/state`, `@osdlabel/solid/hooks`.

--- a/packages/viewer-api/README.md
+++ b/packages/viewer-api/README.md
@@ -17,7 +17,11 @@ npm install @osdlabel/viewer-api
 - `ImageSource` — describes a tile source / image to annotate
 - `PixelSpacing` — physical calibration for measurements
 - `AnnotationState<E>` and `getAllAnnotationsFlat`
-- `CellTransform`, `DEFAULT_CELL_TRANSFORM` — per-cell pan/zoom/rotate/flip state
+- `CellTransform`, `DEFAULT_CELL_TRANSFORM` — per-cell view state: `rotation`,
+  `flippedH` / `flippedV`, and the tonal fields `exposure`, `contrast` (both
+  `-1`–`1`, `0` = unchanged) and `inverted`
+- `ViewerControlId` — identifies a drag-driven viewer control (currently `tone`,
+  the two-axis exposure/contrast gesture)
 - `UIState`, `KeyboardShortcutMap`
 
 ## Usage


### PR DESCRIPTION
Most READMEs were last written on 2026-06-05; a lot has landed since. Refresh
every one against the current source, and add the missing README for
@osdlabel/geometry (the package the geometry math moved into).

Newly documented: polygon/polyline vertex editing (PolyVertexEditor), circle to
rectangle conversion, per-cell `contrast` alongside `exposure`/`inverted`, the
`customControl` overlay mode with its createDragValueControl /
createDragVectorControl factories, ViewerControlId / VIEWER_CONTROL_SPECS, and
`.` / `,` annotation-context cycling.

`initFabricModule()` is gone from every quick start — FabricOverlay calls it on
construction now. It stays documented as the escape hatch for building Fabric
objects before an overlay exists.

Corrections to things that were simply wrong:

- `composeProviders` takes an array, not varargs, and
  `createMeasurementProvider` requires an options object — the decoration
  examples did not compile as written.
- The geometry union member is `polygon`, not `path`.
- The @osdlabel/solid and @osdlabel/react install commands listed `valibot`,
  which is not a peer dependency of either.
- The root keyboard table had drifted: the polyline tool is `d` and freehand is
  `f`, and the Shift-modified view/tone bindings were missing entirely.

Verified by compiling every documented symbol and call signature against the
built packages. The docs site's llm.md / llms.txt are regenerated artifacts that
were stale since the context-cycling commit; the build refreshes them here.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014YUSUmKi4EVXTyBz5AJX3M