### PR TITLE
fix(viewer): keep the fitted view reachable and stop click-to-zoom

### DIFF
--- a/.changeset/wild-mugs-shave.md
+++ b/.changeset/wild-mugs-shave.md
@@ -1,0 +1,20 @@
+---
+'@osdlabel/osd-helper': patch
+'@osdlabel/solid': patch
+'@osdlabel/react': patch
+---
+
+Fix viewer zoom: the fitted view is reachable again, and a click no longer zooms
+
+The viewer cells configured OpenSeadragon with an absolute `minZoomLevel: 0.5`.
+Home zoom (the "fit the image" zoom) is `imageAspect / containerAspect` whenever
+the image is taller than its cell, which is often well below `0.5`, so OSD's
+`applyConstraints()` — which runs on every mouse-up — snapped the view in and
+then refused to zoom back out far enough to fit the image again. The floor is now
+`minZoomImageRatio: 0.5`, which is relative to home zoom.
+
+Plain clicks also zoomed in 2x via OSD's default `clickToZoom`. Clicking a cell
+now leaves the view where it is; double-click and the scroll wheel still zoom.
+
+Both defaults now live in the new `DEFAULT_VIEWER_OPTIONS` export from
+`@osdlabel/osd-helper`, shared by the SolidJS and React viewer cells.

--- a/apps/dev/tests/e2e/viewer-zoom.spec.ts
+++ b/apps/dev/tests/e2e/viewer-zoom.spec.ts
@@ -1,0 +1,107 @@
+import { test, expect } from '@playwright/test';
+
+interface ZoomState {
+  readonly zoom: number;
+  readonly home: number;
+  readonly min: number;
+}
+
+/**
+ * Reads OSD's viewport zoom state through the `testMode` hook that
+ * `FabricOverlay` installs on the OSD canvas container.
+ */
+const readZoom = (page: import('@playwright/test').Page): Promise<ZoomState | null> =>
+  page.evaluate(() => {
+    const el = document.querySelector('.openseadragon-canvas') as
+      | (Element & {
+          __osdViewer?: {
+            viewport?: {
+              getZoom: (current?: boolean) => number;
+              getHomeZoom: () => number;
+              getMinZoom: () => number;
+            };
+          };
+        })
+      | null;
+    const viewport = el?.__osdViewer?.viewport;
+    if (!viewport) return null;
+    return {
+      zoom: viewport.getZoom(false),
+      home: viewport.getHomeZoom(),
+      min: viewport.getMinZoom(),
+    };
+  });
+
+test.describe('Viewer zoom', () => {
+  test.beforeEach(async ({ page }) => {
+    // A short, wide window makes the cell much wider than the 800x600 sample
+    // image, so the image fits by HEIGHT and home zoom drops well below 1 —
+    // the configuration that used to trip the absolute `minZoomLevel` floor.
+    await page.setViewportSize({ width: 1500, height: 520 });
+    await page.goto('/');
+    await page.waitForSelector('.openseadragon-canvas');
+
+    // Local JPG — no tile server needed.
+    await page.getByTestId('filmstrip-item-jpg').click();
+    await page.waitForFunction(() => {
+      const el = document.querySelector('.openseadragon-canvas') as
+        | (Element & { __osdViewer?: { isOpen?: () => boolean } })
+        | null;
+      return el?.__osdViewer?.isOpen?.() === true;
+    });
+  });
+
+  test('the fit-the-image zoom stays reachable', async ({ page }) => {
+    const state = await readZoom(page);
+    expect(state).not.toBeNull();
+    // Guard the premise: the cell is wide enough that the image fits by height.
+    expect(state!.home).toBeLessThan(1);
+    // The zoom-out floor must sit below home zoom, otherwise the user can
+    // never fit the image again once OSD applies its constraints.
+    expect(state!.min).toBeLessThan(state!.home);
+  });
+
+  test('a click in navigate mode does not zoom the image', async ({ page }) => {
+    const before = await readZoom(page);
+    expect(before).not.toBeNull();
+
+    const box = await page.locator('.openseadragon-canvas').first().boundingBox();
+    if (!box) throw new Error('viewer canvas not found');
+    await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+    await page.mouse.down();
+    await page.mouse.up();
+    // Longer than OSD's animationTime (0.3s) so any zoom animation settles.
+    await page.waitForTimeout(600);
+
+    const after = await readZoom(page);
+    expect(after!.zoom).toBeCloseTo(before!.zoom, 6);
+  });
+
+  test('zooming out after a click restores the fitted view', async ({ page }) => {
+    const box = await page.locator('.openseadragon-canvas').first().boundingBox();
+    if (!box) throw new Error('viewer canvas not found');
+    await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+    await page.mouse.down();
+    await page.mouse.up();
+    await page.waitForTimeout(600);
+
+    // Zoom all the way out, then let OSD clamp to its own limits.
+    await page.evaluate(() => {
+      const el = document.querySelector('.openseadragon-canvas') as Element & {
+        __osdViewer?: {
+          viewport: {
+            zoomTo: (zoom: number, ref: null, immediately: boolean) => void;
+            applyConstraints: (immediately: boolean) => void;
+          };
+        };
+      };
+      el.__osdViewer?.viewport.zoomTo(0.0001, null, true);
+      el.__osdViewer?.viewport.applyConstraints(true);
+    });
+    await page.waitForTimeout(600);
+
+    const after = await readZoom(page);
+    // The whole image fits again (zoomed out at least to home zoom).
+    expect(after!.zoom).toBeLessThanOrEqual(after!.home);
+  });
+});

--- a/packages/osd-helper/src/index.ts
+++ b/packages/osd-helper/src/index.ts
@@ -1,1 +1,2 @@
 export { openImage } from './open-image.js';
+export { DEFAULT_VIEWER_OPTIONS } from './viewer-options.js';

--- a/packages/osd-helper/src/viewer-options.ts
+++ b/packages/osd-helper/src/viewer-options.ts
@@ -1,0 +1,49 @@
+import type OpenSeadragon from 'openseadragon';
+
+/**
+ * How far below the home zoom (the "fit the whole image in the cell" zoom)
+ * the user is allowed to zoom out. `0.5` means the image can be shrunk to
+ * half its fitted size.
+ *
+ * This MUST stay relative — OSD's absolute `minZoomLevel` is expressed in
+ * viewport zoom units, where `1` means "image width fills the viewport
+ * width". Home zoom is only `1` when the image is the limiting dimension
+ * horizontally; for an image whose aspect ratio is taller than the cell's,
+ * home zoom is `imageAspect / containerAspect`, which can be far below any
+ * fixed floor. With an absolute floor above home zoom, OSD's
+ * `applyConstraints()` (which runs on every mouse-up) snaps the viewer to
+ * the floor and then refuses to zoom back out — the image can never be
+ * fitted again.
+ */
+const MIN_ZOOM_IMAGE_RATIO = 0.5;
+
+/**
+ * Default OpenSeadragon options used by the viewer cells.
+ *
+ * Callers spread these and add the per-cell `element`:
+ *
+ * ```ts
+ * const viewer = OpenSeadragon({ ...DEFAULT_VIEWER_OPTIONS, element });
+ * ```
+ *
+ * Note `minZoomLevel` is deliberately absent: zoom-out is bounded relative
+ * to home zoom via `minZoomImageRatio` so that "fit the image" is always
+ * reachable regardless of the image/cell aspect ratios.
+ */
+export const DEFAULT_VIEWER_OPTIONS = {
+  prefixUrl: '',
+  showNavigationControl: false,
+  animationTime: 0.3,
+  minZoomImageRatio: MIN_ZOOM_IMAGE_RATIO,
+  maxZoomLevel: 40,
+  visibilityRatio: 0.5,
+  constrainDuringPan: true,
+  gestureSettingsMouse: {
+    // OSD zooms in by `zoomPerClick` (2x) on a plain click by default. In an
+    // annotator a click on a cell means "activate this cell" / "interact with
+    // the image", not "zoom" — a stray click must not move the view. Zooming
+    // in stays available deliberately via double-click and the scroll wheel.
+    clickToZoom: false,
+    dblClickToZoom: true,
+  },
+} as const satisfies OpenSeadragon.Options;

--- a/packages/osd-helper/tests/unit/viewer-options.test.ts
+++ b/packages/osd-helper/tests/unit/viewer-options.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { DEFAULT_VIEWER_OPTIONS } from '../../src/viewer-options.js';
+
+/**
+ * Mirrors `OpenSeadragon.Viewport#getMinZoom` (v5.0.1):
+ *
+ * ```js
+ * var homeZoom = this.getHomeZoom(),
+ *     zoom = this.minZoomLevel ? this.minZoomLevel : this.minZoomImageRatio * homeZoom;
+ * ```
+ */
+const osdMinZoom = (
+  options: { readonly minZoomLevel?: number; readonly minZoomImageRatio?: number },
+  homeZoom: number,
+): number =>
+  options.minZoomLevel ? options.minZoomLevel : (options.minZoomImageRatio ?? 1) * homeZoom;
+
+/**
+ * `getHomeZoom` for a non-`homeFillsViewer` viewer with a unit-width content
+ * bounds: fit by width when the image is wider than the cell, else by height.
+ */
+const osdHomeZoom = (imageAspect: number, containerAspect: number): number => {
+  const aspectFactor = imageAspect / containerAspect;
+  return aspectFactor >= 1 ? 1 : aspectFactor;
+};
+
+describe('DEFAULT_VIEWER_OPTIONS', () => {
+  it('bounds zoom-out relative to home zoom, not by an absolute floor', () => {
+    expect(DEFAULT_VIEWER_OPTIONS).not.toHaveProperty('minZoomLevel');
+    expect(DEFAULT_VIEWER_OPTIONS.minZoomImageRatio).toBeLessThanOrEqual(1);
+    expect(DEFAULT_VIEWER_OPTIONS.minZoomImageRatio).toBeGreaterThan(0);
+  });
+
+  // Regression: an absolute `minZoomLevel: 0.5` sits above the home zoom of any
+  // image taller than its cell, so OSD's `applyConstraints()` (which runs on
+  // every mouse-up) zoomed in and then refused to zoom back out to fit.
+  it.each([
+    ['portrait image, wide cell', 0.5, 2],
+    ['very tall image, wide cell', 0.25, 1.6],
+    ['square image, wide cell', 1, 1.78],
+    ['landscape image, narrow cell', 1.78, 1],
+    ['landscape image, wide cell', 2, 2],
+  ])('keeps the fit-the-image zoom reachable (%s)', (_label, imageAspect, containerAspect) => {
+    const homeZoom = osdHomeZoom(imageAspect, containerAspect);
+    const minZoom = osdMinZoom(DEFAULT_VIEWER_OPTIONS, homeZoom);
+
+    expect(minZoom).toBeLessThanOrEqual(homeZoom);
+  });
+
+  // Regression: OSD's default `clickToZoom` zoomed the view by `zoomPerClick`
+  // (2x) on every plain click in navigate mode.
+  it('does not zoom on a plain click', () => {
+    expect(DEFAULT_VIEWER_OPTIONS.gestureSettingsMouse.clickToZoom).toBe(false);
+    expect(DEFAULT_VIEWER_OPTIONS.gestureSettingsMouse.dblClickToZoom).toBe(true);
+  });
+
+  it('still allows zooming out past the fitted image', () => {
+    const homeZoom = osdHomeZoom(0.5, 2);
+
+    expect(osdMinZoom(DEFAULT_VIEWER_OPTIONS, homeZoom)).toBeLessThan(homeZoom);
+  });
+});

--- a/packages/react/src/components/ViewerCell.tsx
+++ b/packages/react/src/components/ViewerCell.tsx
@@ -8,7 +8,7 @@ import type { OverlayMode } from '@osdlabel/fabric-osd';
 import type { AnnotationContextId } from '@osdlabel/annotation-context';
 import { DEFAULT_CELL_TRANSFORM } from '@osdlabel/viewer-api';
 import type { ImageSource } from '@osdlabel/viewer-api';
-import { openImage } from '@osdlabel/osd-helper';
+import { DEFAULT_VIEWER_OPTIONS, openImage } from '@osdlabel/osd-helper';
 import { useAnnotationTool } from '../hooks/useAnnotationTool.js';
 import { useAnnotator } from '../state/annotator-context.js';
 import type { Annotation } from '@osdlabel/annotation';
@@ -52,14 +52,8 @@ export default function ViewerCell({
     if (!containerRef.current) return;
 
     const viewer = OpenSeadragon({
+      ...DEFAULT_VIEWER_OPTIONS,
       element: containerRef.current,
-      prefixUrl: '',
-      showNavigationControl: false,
-      animationTime: 0.3,
-      minZoomLevel: 0.5,
-      maxZoomLevel: 40,
-      visibilityRatio: 0.5,
-      constrainDuringPan: true,
     });
     viewerRef.current = viewer;
 

--- a/packages/solid/src/components/ViewerCell.tsx
+++ b/packages/solid/src/components/ViewerCell.tsx
@@ -9,7 +9,7 @@ import type { OverlayMode } from '@osdlabel/fabric-osd';
 import type { AnnotationContextId } from '@osdlabel/annotation-context';
 import { DEFAULT_CELL_TRANSFORM } from '@osdlabel/viewer-api';
 import type { ImageSource } from '@osdlabel/viewer-api';
-import { openImage } from '@osdlabel/osd-helper';
+import { DEFAULT_VIEWER_OPTIONS, openImage } from '@osdlabel/osd-helper';
 import { useAnnotationTool } from '../hooks/useAnnotationTool.js';
 import { useAnnotator } from '../state/annotator-context.js';
 import type { Annotation } from '@osdlabel/annotation';
@@ -44,14 +44,8 @@ const ViewerCell: Component<ViewerCellProps> = (props) => {
     if (!containerRef) return;
 
     viewer = OpenSeadragon({
+      ...DEFAULT_VIEWER_OPTIONS,
       element: containerRef,
-      prefixUrl: '',
-      showNavigationControl: false,
-      animationTime: 0.3,
-      minZoomLevel: 0.5,
-      maxZoomLevel: 40,
-      visibilityRatio: 0.5,
-      constrainDuringPan: true,
     });
 
     viewer.addHandler('open', () => {

--- a/references/openseadragon-api.md
+++ b/references/openseadragon-api.md
@@ -11,12 +11,31 @@ const viewer = OpenSeadragon({
   prefixUrl: '', // disable default button images
   showNavigationControl: false, // disable default zoom buttons
   animationTime: 0.3, // pan/zoom animation duration (seconds)
-  minZoomLevel: 0.5,
+  minZoomImageRatio: 0.5, // zoom-out floor, relative to home zoom
   maxZoomLevel: 40,
   visibilityRatio: 0.5,
   constrainDuringPan: true,
+  gestureSettingsMouse: { clickToZoom: false, dblClickToZoom: true },
 });
+```
 
+`@osdlabel/osd-helper` exports these as `DEFAULT_VIEWER_OPTIONS`; the viewer
+cells spread it and add their own `element`.
+
+Two of those options are load-bearing:
+
+- **`minZoomImageRatio`, never `minZoomLevel`.** `minZoomLevel` is an absolute
+  zoom (`1` = image width fills the viewport width), but home zoom — the
+  "fit the image" zoom — is `imageAspect / containerAspect` whenever the image
+  is taller than its container, which can be far below any fixed floor. An
+  absolute floor above home zoom makes `applyConstraints()` (called on every
+  mouse-up) snap the view in and then refuse to zoom back out to fit.
+  `minZoomImageRatio` is relative to home zoom, so fitting always stays
+  reachable.
+- **`clickToZoom: false`.** OSD zooms in by `zoomPerClick` (2x) on a plain
+  click by default, so clicking a cell to activate it would move the view.
+
+```typescript
 // Open a DZI tile source
 viewer.open({
   Image: {


### PR DESCRIPTION
Both viewer cells configured OSD with an absolute `minZoomLevel: 0.5`. Home
zoom — the "fit the image" zoom — is `imageAspect / containerAspect` whenever
the image is taller than its cell, which is routinely below 0.5, so OSD's
`applyConstraints()` (run on every mouse-up) snapped the view in and then
refused to zoom back out far enough to fit the image again.

Bound zoom-out with `minZoomImageRatio: 0.5` instead, which is relative to
home zoom, so fitting stays reachable for any image/cell aspect ratio.

Plain clicks also zoomed in 2x via OSD's default `clickToZoom`; a click on a
cell means "activate this cell", not "zoom". Disable it and enable
`dblClickToZoom` so zooming in stays a deliberate gesture.

Both defaults now live in `DEFAULT_VIEWER_OPTIONS` in `@osdlabel/osd-helper`,
shared by the SolidJS and React viewer cells, with unit tests on the config
invariants and E2E coverage of the click / zoom-out behaviour.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RL38wMp2AowykxzEqDBHKX